### PR TITLE
Enable third-party auth and prefill plugins without core patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@ __pycache__
 local.py
 /env/
 /venv/
+.venv/
 /media/
 /private_media/
 /static/
@@ -62,3 +63,4 @@ src/token_exchange
 # docker volumes
 setup_configuration/*
 !setup_configuration/.gitkeep
+docker-compose.override.yml

--- a/docs/developers/plugins/authentication_plugins.rst
+++ b/docs/developers/plugins/authentication_plugins.rst
@@ -29,3 +29,45 @@ base :class:`openforms.contrib.auth_oidc.plugin.OIDCAuthentication`.
 
 .. autoclass:: openforms.contrib.auth_oidc.plugin.OIDCAuthentication
    :members:
+
+Custom auth context for third-party plugins
+===========================================
+
+The built-in authentication plugins (DigiD, eHerkenning, Yivi, etc.) each have a
+dedicated ``TypedDict`` in :mod:`openforms.authentication.types` that describes
+the shape of their auth context. These types are collected in the ``AnyAuthContext``
+union.
+
+Third-party plugins that manage their own auth context do not need to add a
+plugin-specific type to this union. Instead, set ``manage_auth_context = True``
+on the plugin class and implement
+:meth:`~openforms.authentication.base.BasePlugin.auth_info_to_auth_context`
+to return a dict matching :class:`~openforms.authentication.types.PluginAuthContext`:
+
+.. code-block:: python
+
+    from openforms.authentication.base import BasePlugin
+    from openforms.authentication.types import PluginAuthContext
+
+    class MyPlugin(BasePlugin):
+        manage_auth_context = True
+
+        def auth_info_to_auth_context(self, auth_info) -> PluginAuthContext:
+            return {
+                "source": "my-provider",
+                "levelOfAssurance": auth_info.loa,
+                "authorizee": {
+                    "legalSubject": {
+                        "identifierType": "bsn",
+                        "identifier": auth_info.value,
+                    }
+                },
+            }
+
+``PluginAuthContext`` uses ``str`` for ``source`` and ``levelOfAssurance`` and
+``dict`` for ``authorizee``, so the plugin is free to structure the authorizee
+payload however it needs.
+
+**Reference**
+
+.. autoclass:: openforms.authentication.types.PluginAuthContext

--- a/docs/developers/plugins/prefill_plugins.rst
+++ b/docs/developers/plugins/prefill_plugins.rst
@@ -40,6 +40,46 @@ There are two relevant public methods:
     the actual implementation of the prefill functionality. This is invoked inside the
     request-response cycle of certain API endpoints.
 
+Context-aware prefill attributes
+--------------------------------
+
+Some prefill plugins have attributes that depend on form-level configuration
+(e.g. which authentication flow is selected). Instead of returning a static list
+from ``get_available_attributes``, these plugins can declare a custom API
+endpoint that the form builder calls at design time.
+
+Override :meth:`~openforms.prefill.base.BasePlugin.get_custom_attributes_url` to
+return an absolute API path:
+
+.. code-block:: python
+
+    @register("my-plugin")
+    class MyPrefill(BasePlugin):
+        requires_auth_plugin = ("my-auth",)
+
+        @classmethod
+        def get_custom_attributes_url(cls) -> str:
+            return "/api/v2/my-plugin/available-claims"
+
+        @staticmethod
+        def get_available_attributes():
+            # Static fallback (used by non-JS callers and tests)
+            return (("claim_a", "Claim A"), ("claim_b", "Claim B"))
+
+The endpoint must return a JSON array of ``{"id": "...", "label": "..."}``
+objects.
+
+When ``customAttributesUrl`` is set (exposed in the prefill plugin list API
+response), the form builder will ``GET`` this URL instead of the default
+``/api/v2/prefill/plugins/<id>/attributes`` endpoint. The options from the
+matching authentication backend are forwarded as query parameters, so the
+endpoint can scope the attribute list to the selected authentication flow.
+
+For example, if the form has an authentication backend with
+``options: {"clientId": "abc-123"}``, the form builder will request::
+
+    GET /api/v2/my-plugin/available-claims?clientId=abc-123
+
 Public Python API
 =================
 

--- a/src/openforms/authentication/models.py
+++ b/src/openforms/authentication/models.py
@@ -27,6 +27,7 @@ from .types import (
     EIDASCompanyContext,
     EIDASContext,
     EmployeeContext,
+    PluginAuthContext,
     YiviContext,
 )
 
@@ -291,6 +292,7 @@ class AuthInfo(BaseAuthInfo):
         | EIDASCompanyContext
         | EmployeeContext
         | YiviContext
+        | PluginAuthContext
     ):
         if self.attribute_hashed:
             logger.debug("detected_hashed_authentication_attributes", auth_info=self.pk)

--- a/src/openforms/authentication/types.py
+++ b/src/openforms/authentication/types.py
@@ -141,6 +141,19 @@ class YiviContext(TypedDict):
     authorizee: YiviAuthorizee
 
 
+class PluginAuthContext(TypedDict):
+    """Generic auth context for third-party plugins that set manage_auth_context = True.
+
+    Plugins that manage their own auth context return a dict matching this shape
+    from their ``auth_info_to_auth_context`` method.  Adding this to AnyAuthContext
+    means new wallet/disclosure plugins no longer need to patch this module.
+    """
+
+    source: str
+    levelOfAssurance: str
+    authorizee: dict
+
+
 class EIDASNaturalPersonSubject(TypedDict):
     identifierType: Literal["bsn", "opaque"]
     identifier: str
@@ -210,4 +223,5 @@ type AnyAuthContext = (
     | EIDASCompanyContext
     | EmployeeContext
     | YiviContext
+    | PluginAuthContext
 )

--- a/src/openforms/js/components/formio_builder/plugins.js
+++ b/src/openforms/js/components/formio_builder/plugins.js
@@ -33,6 +33,22 @@ export const getPrefillAttributes = async (plugin, context = {}) => {
     return attributes.map(([attribute, label]) => ({id: attribute, label}));
   }
 
+  // If the plugin declares a custom attributes endpoint, use it instead of the
+  // default static list. This lets third-party plugins supply context-aware
+  // attributes without requiring changes to this file.  The matching auth
+  // backend's options are forwarded as query parameters so the endpoint can
+  // scope the attribute list to the selected authentication flow.
+  const {availablePrefillPlugins = [], authBackends = []} = context;
+  const pluginMeta = availablePrefillPlugins.find(p => p.id === plugin);
+  if (pluginMeta?.customAttributesUrl) {
+    const requiredPlugins = pluginMeta.requiresAuthPlugin || [];
+    const authBackend = authBackends.find(b => requiredPlugins.includes(b.backend));
+    const queryParams = authBackend?.options || {};
+    const resp = await get(pluginMeta.customAttributesUrl, queryParams);
+    if (!resp.ok) return [];
+    return (resp.data || []).map(item => ({id: item.id, label: item.label || item.id}));
+  }
+
   const resp = await get(`/api/v2/prefill/plugins/${plugin}/attributes`);
   return resp.data;
 };

--- a/src/openforms/prefill/api/serializers.py
+++ b/src/openforms/prefill/api/serializers.py
@@ -29,6 +29,15 @@ class PrefillPluginSerializer(PluginBaseSerializer):
             ),
         ),
     )
+    custom_attributes_url = serializers.CharField(
+        source="get_custom_attributes_url",
+        label=_("Custom attributes URL"),
+        help_text=_(
+            "When set, the form builder fetches available prefill attributes "
+            "from this URL instead of the default attributes endpoint."
+        ),
+        allow_null=True,
+    )
     configuration_context = serializers.JSONField(
         label=_("Extra configuration context"),
         help_text=_(

--- a/src/openforms/prefill/base.py
+++ b/src/openforms/prefill/base.py
@@ -186,5 +186,18 @@ class BasePlugin[OptionsT: Options](AbstractBasePlugin):
         return submission.auth_info.plugin in cls.requires_auth_plugin
 
     @classmethod
+    def get_custom_attributes_url(cls) -> str | None:
+        """Return an absolute API path for fetching context-aware attributes.
+
+        When not ``None``, the form builder will ``GET`` this URL instead of the
+        default ``/api/v2/prefill/plugins/<id>/attributes`` endpoint.  The
+        response must be a JSON array of ``{id, label}`` objects.
+
+        Override this in plugins whose available attributes depend on form-level
+        configuration (e.g. the selected authentication flow).
+        """
+        return None
+
+    @classmethod
     def configuration_context(cls) -> JSONObject | None:
         return None


### PR DESCRIPTION
## Summary

Third-party authentication and prefill plugins currently require patching
core files to work:

- Auth plugins that set `manage_auth_context = True` work at runtime but
  the closed `AnyAuthContext` type union rejects their context dicts
- Prefill plugins whose available attributes depend on form-level context
  (e.g. the selected auth flow) must add hardcoded branches in `plugins.js`

This PR adds two small extension points that remove those barriers:

1. **`PluginAuthContext`** — a generic TypedDict (`source: str`,
   `levelOfAssurance: str`, `authorizee: dict`) added to `AnyAuthContext`.
   Plugins return their own dict from `auth_info_to_auth_context()` without
   editing `types.py`.

2. **`get_custom_attributes_url()`** on prefill `BasePlugin` — when not
   `None`, the form builder GETs this URL instead of the static
   `/api/v2/prefill/plugins/<id>/attributes` endpoint. The matching auth
   backend's options are forwarded as query parameters so the endpoint can
   scope attributes to the selected authentication flow. Exposed as
   `customAttributesUrl` in the prefill plugin list API response.

Also adds `.venv/` and `docker-compose.override.yml` to `.gitignore`.

## Checklist

- Impact on features

  - [x] Checked copying a form — no impact, purely additive type and API changes
  - [x] Checked import/export of a form — no impact, no model or serialization changes
  - [x] Config checks in the configuration overview admin page — n/a, no new config
  - [x] Checked new model fields are usable in the admin — n/a, no new models
  - [x] Problem detection in the admin email digest is handled — n/a

- Dockerfile/scripts

  - [x] Updated the Dockerfile — n/a, no new scripts or dependencies

- Commit hygiene

  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added developer documentation for `PluginAuthContext` in `docs/developers/plugins/authentication_plugins.rst` with code example
  - [x] Added developer documentation for `get_custom_attributes_url()` in `docs/developers/plugins/prefill_plugins.rst` with code example and query parameter forwarding explanation