### PR TITLE
Use stricter test data setup in tests

### DIFF
--- a/src/openforms/formio/components/translations.py
+++ b/src/openforms/formio/components/translations.py
@@ -7,10 +7,10 @@ def translate_options(
     enabled: bool,
 ) -> None:
     for option in options:
-        if "openForms" not in option:
+        if (open_forms := option.get("openForms")) is None:
             continue
 
-        if not (translations := option["openForms"].get("translations")):
+        if not (translations := open_forms.get("translations")):
             continue
 
         if enabled and (_translations := translations.get(language_code)):
@@ -21,4 +21,5 @@ def translate_options(
                 option["description"] = translated_description
 
         # always clean up
+        assert "openForms" in option
         del option["openForms"]["translations"]

--- a/src/openforms/formio/dynamic_config/tests/test_date_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_date_component.py
@@ -155,7 +155,6 @@ class DynamicDateConfigurationTests(TestCase):
                 "minDate": {
                     "mode": "relativeToVariable",
                     "variable": "now",
-                    "operator": "",
                     "delta": {
                         "days": None,
                         "months": None,
@@ -181,7 +180,6 @@ class DynamicDateConfigurationTests(TestCase):
                 "minDate": {
                     "mode": "relativeToVariable",
                     "variable": "now",
-                    "operator": "",
                     "delta": {
                         "days": None,
                         "months": None,
@@ -305,6 +303,7 @@ class DynamicDateConfigurationTests(TestCase):
         component = {
             "type": "date",
             "key": "aDate",
+            "label": "aDate",
             "openForms": {
                 "maxDate": {
                     "mode": "relativeToVariable",

--- a/src/openforms/formio/dynamic_config/tests/test_datetime_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_datetime_component.py
@@ -126,7 +126,6 @@ class DynamicDatetimeConfigurationTests(TestCase):
                 "minDate": {
                     "mode": "relativeToVariable",
                     "variable": "now",
-                    "operator": "",
                     "delta": {
                         "days": None,
                         "months": None,
@@ -152,7 +151,6 @@ class DynamicDatetimeConfigurationTests(TestCase):
                 "minDate": {
                     "mode": "relativeToVariable",
                     "variable": "now",
-                    "operator": "",
                     "delta": {
                         "days": None,
                         "months": None,

--- a/src/openforms/formio/dynamic_config/tests/test_dynamic_options.py
+++ b/src/openforms/formio/dynamic_config/tests/test_dynamic_options.py
@@ -96,9 +96,13 @@ class TestDynamicConfigAddingOptions(TestCase):
         configuration = {
             "components": [
                 {
+                    "label": "repeatingGroup",
                     "key": "repeatingGroup",
                     "type": "editgrid",
-                    "components": [{"type": "textfield", "key": "name"}],
+                    "groupLabel": "Item",
+                    "components": [
+                        {"type": "textfield", "key": "name", "label": "name"}
+                    ],
                 },
                 {
                     "label": "Select Boxes",
@@ -181,9 +185,13 @@ class TestDynamicConfigAddingOptions(TestCase):
         configuration = {
             "components": [
                 {
+                    "label": "repeatingGroup",
                     "key": "repeatingGroup",
                     "type": "editgrid",
-                    "components": [{"type": "textfield", "key": "name"}],
+                    "groupLabel": "Item",
+                    "components": [
+                        {"type": "textfield", "key": "name", "label": "name"}
+                    ],
                 },
                 {
                     "label": "Select Boxes",
@@ -255,9 +263,11 @@ class TestDynamicConfigAddingOptions(TestCase):
         configuration = {
             "components": [
                 {
+                    "label": "textField",
                     "key": "textField",
                     "type": "textfield",
                     "multiple": True,
+                    "defaultValue": [],
                 },
                 {
                     "label": "Select Boxes",
@@ -334,9 +344,11 @@ class TestDynamicConfigAddingOptions(TestCase):
         configuration = {
             "components": [
                 {
+                    "label": "textField",
                     "key": "textField",
                     "type": "textfield",
                     "multiple": True,
+                    "defaultValue": [],
                 },
                 {
                     "label": "Select Boxes",
@@ -402,9 +414,13 @@ class TestDynamicConfigAddingOptions(TestCase):
         configuration = {
             "components": [
                 {
+                    "label": "repeatingGroup",
                     "key": "repeatingGroup",
                     "type": "editgrid",
-                    "components": [{"type": "textfield", "key": "name"}],
+                    "groupLabel": "Item",
+                    "components": [
+                        {"type": "textfield", "key": "name", "label": "name"}
+                    ],
                 },
                 {
                     "label": "Select Boxes",
@@ -497,9 +513,11 @@ class TestDynamicConfigAddingOptions(TestCase):
         configuration = {
             "components": [
                 {
+                    "label": "textField",
                     "key": "textField",
                     "type": "textfield",
                     "multiple": True,
+                    "defaultValue": [],
                 },
                 {
                     "label": "Radio",
@@ -538,6 +556,7 @@ class TestDynamicConfigAddingOptions(TestCase):
         configuration = {
             "components": [
                 {
+                    "label": "textField",
                     "key": "textField",
                     "type": "textfield",
                     "multiple": False,  # Not an array!
@@ -584,9 +603,11 @@ class TestDynamicConfigAddingOptions(TestCase):
         configuration = {
             "components": [
                 {
+                    "label": "textField",
                     "key": "textField",
                     "type": "textfield",
                     "multiple": True,
+                    "defaultValue": [],
                 },
                 {
                     "label": "Radio",
@@ -619,9 +640,13 @@ class TestDynamicConfigAddingOptions(TestCase):
         configuration = {
             "components": [
                 {
+                    "label": "repeatingGroup",
                     "key": "repeatingGroup",
                     "type": "editgrid",
-                    "components": [{"type": "textfield", "key": "name"}],
+                    "groupLabel": "Item",
+                    "components": [
+                        {"type": "textfield", "key": "name", "label": "name"}
+                    ],
                 },
                 {
                     "label": "Radio",
@@ -714,8 +739,10 @@ class TestDynamicConfigAddingOptions(TestCase):
         configuration = {
             "components": [
                 {
+                    "label": "repeatingGroup",
                     "key": "repeatingGroup",
                     "type": "editgrid",
+                    "groupLabel": "Item",
                     "components": [
                         {"type": "textfield", "key": "name"},
                         {"type": "textfield", "key": "bsn"},

--- a/src/openforms/formio/dynamic_config/tests/test_file_component.py
+++ b/src/openforms/formio/dynamic_config/tests/test_file_component.py
@@ -29,10 +29,11 @@ class FileComponentTests(TestCase):
         component = {
             "type": "file",
             "key": "fileTest",
+            "label": "fileTest",
             "url": "",
             "useConfigFiletypes": True,
             "filePattern": "*",
-            "file": {},
+            "file": {"type": []},
         }
 
         wrapper = _get_dynamic_config(component)
@@ -53,10 +54,11 @@ class FileComponentTests(TestCase):
         component = {
             "type": "file",
             "key": "fileTest",
+            "label": "fileTest",
             "url": "",
             "useConfigFiletypes": True,
             "filePattern": "*",
-            "file": {},
+            "file": {"type": []},
         }
 
         wrapper = _get_dynamic_config(component)

--- a/src/openforms/formio/rendering/tests/test_utils.py
+++ b/src/openforms/formio/rendering/tests/test_utils.py
@@ -21,10 +21,12 @@ class TestReshapeSubmissionDataForJsonSummary(TestCase):
                     {
                         "key": "input1",
                         "type": "textfield",
+                        "label": "input1",
                     },
                     {
                         "key": "input2",
                         "type": "textfield",
+                        "label": "input2",
                     },
                 ]
             },
@@ -37,10 +39,12 @@ class TestReshapeSubmissionDataForJsonSummary(TestCase):
                     {
                         "key": "input3",
                         "type": "textfield",
+                        "label": "input3",
                     },
                     {
                         "key": "input4",
                         "type": "textfield",
+                        "label": "input4",
                     },
                 ]
             },
@@ -89,26 +93,32 @@ class TestReshapeSubmissionDataForJsonSummary(TestCase):
                 "components": [
                     {
                         "key": "fieldset1",
+                        "label": "fieldset1",
                         "type": "fieldset",
                         "components": [
                             {
                                 "key": "input1",
+                                "label": "input1",
                                 "type": "textfield",
                             },
                             {
                                 "key": "input2",
+                                "label": "input2",
                                 "type": "textfield",
                             },
                             {
                                 "key": "fieldset2",
+                                "label": "fieldset2",
                                 "type": "fieldset",
                                 "components": [
                                     {
                                         "key": "input3",
+                                        "label": "input3",
                                         "type": "textfield",
                                     },
                                     {
                                         "key": "input4",
+                                        "label": "input4",
                                         "type": "textfield",
                                     },
                                 ],
@@ -117,6 +127,7 @@ class TestReshapeSubmissionDataForJsonSummary(TestCase):
                     },
                     {
                         "key": "input5",
+                        "label": "input5",
                         "type": "textfield",
                     },
                 ]
@@ -164,6 +175,7 @@ class TestReshapeSubmissionDataForJsonSummary(TestCase):
                 "components": [
                     {
                         "key": "column1",
+                        "label": "column1",
                         "type": "columns",
                         "columns": [
                             {
@@ -171,6 +183,7 @@ class TestReshapeSubmissionDataForJsonSummary(TestCase):
                                 "components": [
                                     {
                                         "key": "input1",
+                                        "label": "input1",
                                         "type": "textfield",
                                     }
                                 ],
@@ -180,16 +193,19 @@ class TestReshapeSubmissionDataForJsonSummary(TestCase):
                                 "components": [
                                     {
                                         "key": "fieldset1",
+                                        "label": "fieldset1",
                                         "type": "fieldset",
                                         "components": [
                                             {
                                                 "key": "input2",
+                                                "label": "input2",
                                                 "type": "textfield",
                                             },
                                         ],
                                     },
                                     {
                                         "key": "input3",
+                                        "label": "input3",
                                         "type": "textfield",
                                     },
                                 ],
@@ -240,10 +256,13 @@ class TestReshapeSubmissionDataForJsonSummary(TestCase):
                     {
                         "type": "editgrid",
                         "key": "editgrid1",
+                        "label": "editgrid1",
+                        "groupLabel": "item",
                         "components": [
                             {
                                 "type": "textfield",
                                 "key": "input1",
+                                "label": "input1",
                             }
                         ],
                     },

--- a/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
+++ b/src/openforms/formio/rendering/tests/test_vanilla_formio_components.py
@@ -1317,6 +1317,7 @@ class FormNodeTests(TestCase):
                     {
                         "type": "fieldset",
                         "key": "fieldSet1",
+                        "label": "Fieldset",
                         "conditional": {
                             "show": True,
                             "when": "selectBoxes1",
@@ -1326,12 +1327,14 @@ class FormNodeTests(TestCase):
                             {
                                 "key": "textField1",
                                 "type": "textfield",
+                                "label": "textField1",
                             }
                         ],
                     },
                     {
                         "key": "selectBoxes1",
                         "type": "selectboxes",
+                        "label": "selectBoxes1",
                         "values": [
                             {"value": "a", "label": "A"},
                             {"value": "b", "label": "B"},

--- a/src/openforms/formio/tests/test_component_json_schemas.py
+++ b/src/openforms/formio/tests/test_component_json_schemas.py
@@ -306,7 +306,7 @@ class RadioTests(SimpleTestCase):
         component: RadioComponent = {
             "label": "Radio label",
             "key": "radio",
-            "values": [{"label": "", "value": ""}],
+            "values": [{"value": "", "label": ""}],
             "openForms": {
                 "dataSrc": DataSrcOptions.variable,
                 "itemsExpression": {"var": "foo"},

--- a/src/openforms/formio/tests/test_component_translations.py
+++ b/src/openforms/formio/tests/test_component_translations.py
@@ -82,6 +82,8 @@ TEST_CONFIGURATION = {
         {
             "type": "editgrid",
             "key": "editgrid",
+            "label": "Repeating group",
+            "groupLabel": "Item",
             "components": [
                 {
                     "type": "content",

--- a/src/openforms/formio/tests/test_dynamic_config.py
+++ b/src/openforms/formio/tests/test_dynamic_config.py
@@ -30,6 +30,7 @@ class DynamicConfigTests(TestCase):
                 {
                     "type": "map",
                     "key": "map",
+                    "label": "map",
                     "defaultZoom": 3,
                     "initialCenter": {
                         "lat": 43.23,
@@ -49,6 +50,7 @@ class DynamicConfigTests(TestCase):
         expected = {
             "type": "map",
             "key": "map",
+            "label": "map",
             "defaultZoom": 3,
             "initialCenter": {
                 "lat": 43.23,
@@ -71,6 +73,7 @@ class DynamicConfigTests(TestCase):
                 {
                     "type": "map",
                     "key": "map",
+                    "label": "map",
                     "defaultZoom": 3,
                     "initialCenter": {
                         "lat": 43.23,
@@ -90,6 +93,7 @@ class DynamicConfigTests(TestCase):
         expected = {
             "type": "map",
             "key": "map",
+            "label": "map",
             "defaultZoom": 8,
             "initialCenter": {
                 "lat": 55.123,
@@ -105,6 +109,7 @@ class DynamicConfigTests(TestCase):
                 {
                     "type": "map",
                     "key": "map",
+                    "label": "map",
                     "defaultZoom": 3,
                     "initialCenter": {
                         "lat": 43.23,
@@ -125,6 +130,7 @@ class DynamicConfigTests(TestCase):
         expected = {
             "type": "map",
             "key": "map",
+            "label": "map",
             "defaultZoom": 3,
             "initialCenter": {
                 "lat": 43.23,
@@ -141,6 +147,7 @@ class DynamicConfigTests(TestCase):
                 {
                     "type": "map",
                     "key": "map",
+                    "label": "map",
                     "defaultZoom": 3,
                     "initialCenter": {
                         "lat": 43.23,
@@ -161,6 +168,7 @@ class DynamicConfigTests(TestCase):
         expected = {
             "type": "map",
             "key": "map",
+            "label": "map",
             "defaultZoom": 3,
             "initialCenter": {
                 "lat": 43.23,
@@ -177,6 +185,7 @@ class DynamicConfigTests(TestCase):
                 {
                     "type": "map",
                     "key": "map",
+                    "label": "map",
                     "defaultZoom": 3,
                     "initialCenter": {
                         "lat": 43.23,
@@ -197,6 +206,7 @@ class DynamicConfigTests(TestCase):
         expected = {
             "type": "map",
             "key": "map",
+            "label": "map",
             "defaultZoom": 3,
             "initialCenter": {
                 "lat": 43.23,
@@ -214,6 +224,7 @@ class DynamicConfigTests(TestCase):
                 {
                     "type": "map",
                     "key": "map",
+                    "label": "map",
                     "defaultZoom": 3,
                     "initialCenter": {
                         "lat": 43.23,
@@ -234,6 +245,7 @@ class DynamicConfigTests(TestCase):
         expected = {
             "type": "map",
             "key": "map",
+            "label": "map",
             "defaultZoom": 3,
             "initialCenter": {
                 "lat": 43.23,
@@ -260,6 +272,7 @@ class DynamicConfigTests(TestCase):
                 {
                     "type": "map",
                     "key": "map",
+                    "label": "map",
                     "defaultZoom": 3,
                     "initialCenter": {
                         "lat": 43.23,
@@ -280,6 +293,7 @@ class DynamicConfigTests(TestCase):
         expected = {
             "type": "map",
             "key": "map",
+            "label": "map",
             "defaultZoom": 8,
             "initialCenter": {
                 "lat": 55.123,
@@ -300,6 +314,7 @@ class DynamicConfigTests(TestCase):
                 {
                     "type": "map",
                     "key": "map",
+                    "label": "map",
                     "defaultZoom": 3,
                     "initialCenter": {
                         "lat": 43.23,
@@ -309,7 +324,7 @@ class DynamicConfigTests(TestCase):
                         {
                             "type": "wms",
                             "uuid": "1266c027-9a18-4ecb-8a9e-6acddf7e74f3",
-                            "name": "My first overlay",
+                            "label": "My first overlay",
                             "layers": ["layer1", "layer2"],
                         }
                     ],
@@ -329,6 +344,7 @@ class DynamicConfigTests(TestCase):
         expected = {
             "type": "map",
             "key": "map",
+            "label": "map",
             "defaultZoom": 3,
             "initialCenter": {
                 "lat": 43.23,
@@ -338,7 +354,7 @@ class DynamicConfigTests(TestCase):
                 {
                     "type": "wms",
                     "uuid": "1266c027-9a18-4ecb-8a9e-6acddf7e74f3",
-                    "name": "My first overlay",
+                    "label": "My first overlay",
                     "layers": ["layer1", "layer2"],
                     "url": "https://example.wms.com",
                 }
@@ -352,6 +368,7 @@ class DynamicConfigTests(TestCase):
                 {
                     "type": "map",
                     "key": "map",
+                    "label": "map",
                     "defaultZoom": 3,
                     "initialCenter": {
                         "lat": 43.23,
@@ -362,7 +379,7 @@ class DynamicConfigTests(TestCase):
                             "type": "wms",
                             # Some unknown uuid
                             "uuid": "44c9ee90-96a3-4ac2-bb55-f2f42b547b15",
-                            "name": "My first overlay",
+                            "label": "My first overlay",
                             "layers": ["layer1", "layer2"],
                         }
                     ],
@@ -381,6 +398,7 @@ class DynamicConfigTests(TestCase):
         expected = {
             "type": "map",
             "key": "map",
+            "label": "map",
             "defaultZoom": 3,
             "initialCenter": {
                 "lat": 43.23,

--- a/src/openforms/formio/tests/test_service.py
+++ b/src/openforms/formio/tests/test_service.py
@@ -20,12 +20,16 @@ class ServiceTestCase(TestCase):
                 {
                     "id": "e1a2cv9",
                     "key": "my_file",
+                    "label": "my_file",
                     "type": "file",
                     "url": "bad",
+                    "file": {"type": []},
+                    "filePattern": "",
                 },
                 {
                     "id": "e2a2cv9",
                     "key": "my_content",
+                    "label": "my_content",
                     "type": "content",
                     "html": '<img style="width: 90%; border: 5000px solid red;">',
                 },

--- a/src/openforms/formio/tests/test_validation.py
+++ b/src/openforms/formio/tests/test_validation.py
@@ -55,6 +55,7 @@ class GenericValidationTests(SimpleTestCase):
                 "required": True,
                 "maxLength": 3,
             },
+            "defaultValue": [],
         }
         data: JSONObject = {
             "textMultiple": [

--- a/src/openforms/formio/tests/validation/test_datetime.py
+++ b/src/openforms/formio/tests/validation/test_datetime.py
@@ -136,6 +136,7 @@ class DatetimeFieldValidationTests(SimpleTestCase):
             "key": "datetimes",
             "label": "Multiple datetimes",
             "multiple": True,
+            "defaultValue": [],
         }
         data: JSONValue = {"datetimes": ["2024-01-01T00:00:00+00:00", "notdatetime"]}
 

--- a/src/openforms/formio/tests/validation/test_editgrid.py
+++ b/src/openforms/formio/tests/validation/test_editgrid.py
@@ -25,6 +25,7 @@ class EditGridValidationTests(SimpleTestCase):
             "type": "editgrid",
             "key": "parent",
             "label": "Repeating group",
+            "groupLabel": "item",
             "components": [
                 {
                     "type": "textfield",
@@ -81,6 +82,7 @@ class EditGridValidationTests(SimpleTestCase):
             "type": "editgrid",
             "key": "parent",
             "label": "Repeating group",
+            "groupLabel": "item",
             "components": [
                 {
                     "type": "textfield",
@@ -141,6 +143,7 @@ class EditGridValidationTests(SimpleTestCase):
             "type": "editgrid",
             "key": "toplevel",
             "label": "Repeating group",
+            "groupLabel": "item",
             "components": [
                 {
                     "type": "textfield",
@@ -182,6 +185,7 @@ class EditGridValidationTests(SimpleTestCase):
             "type": "editgrid",
             "key": "optionalRepeatingGroup",
             "label": "Optional repeating group",
+            "groupLabel": "item",
             "validate": {"required": False},
             "components": [
                 {
@@ -205,6 +209,7 @@ class EditGridValidationTests(SimpleTestCase):
             "type": "editgrid",
             "key": "requiredRepeatingGroup",
             "label": "Required repeating group",
+            "groupLabel": "item",
             "validate": {"required": True},
             "components": [
                 {
@@ -219,6 +224,7 @@ class EditGridValidationTests(SimpleTestCase):
             "type": "fieldset",
             "key": "fieldset",
             "label": "Hidden fieldset",
+            "groupLabel": "item",
             "hidden": True,
             "components": [editgrid],
         }
@@ -314,6 +320,7 @@ class EditGridValidationTests(SimpleTestCase):
             "type": "editgrid",
             "key": "editgrid",
             "label": "Edit grid with nested conditional",
+            "groupLabel": "item",
             "components": [
                 {
                     "type": "textfield",
@@ -359,6 +366,7 @@ class EditGridValidationTests(SimpleTestCase):
             "type": "editgrid",
             "key": "editgrid",
             "label": "Edit grid with nested conditional",
+            "groupLabel": "item",
             "components": [
                 {
                     "type": "textfield",
@@ -377,6 +385,7 @@ class EditGridValidationTests(SimpleTestCase):
             "type": "fieldset",
             "key": "fieldset",
             "label": "Container",
+            "groupLabel": "item",
             "components": [
                 {
                     "type": "textfield",

--- a/src/openforms/formio/tests/validation/test_file.py
+++ b/src/openforms/formio/tests/validation/test_file.py
@@ -30,7 +30,7 @@ DEFAULT_FILE_COMPONENT: FileComponent = {
     "url": "",
     "useConfigFiletypes": False,
     "filePattern": "",
-    "file": {"allowedTypesLabels": []},
+    "file": {"type": [], "allowedTypesLabels": []},
 }
 
 
@@ -47,7 +47,7 @@ class FileValidationMaxFilesAndRequiredTests(TestCase):
             "url": "",
             "useConfigFiletypes": False,
             "filePattern": "",
-            "file": {"allowedTypesLabels": []},
+            "file": {"type": [], "allowedTypesLabels": []},
         }
 
         with self.subTest("without any provided value"):
@@ -69,7 +69,7 @@ class FileValidationMaxFilesAndRequiredTests(TestCase):
             "url": "",
             "useConfigFiletypes": False,
             "filePattern": "",
-            "file": {"allowedTypesLabels": []},
+            "file": {"type": [], "allowedTypesLabels": []},
             "validate": {"required": True},
         }
 
@@ -98,7 +98,7 @@ class FileValidationMaxFilesAndRequiredTests(TestCase):
             "url": "",
             "useConfigFiletypes": False,
             "filePattern": "",
-            "file": {"allowedTypesLabels": []},
+            "file": {"type": [], "allowedTypesLabels": []},
             "multiple": True,
             "maxNumberOfFiles": 2,
         }
@@ -130,7 +130,7 @@ class FileValidationMaxFilesAndRequiredTests(TestCase):
             "url": "",
             "useConfigFiletypes": False,
             "filePattern": "",
-            "file": {"allowedTypesLabels": []},
+            "file": {"type": [], "allowedTypesLabels": []},
             "multiple": False,
         }
 
@@ -164,7 +164,7 @@ class FileValidationMaxFilesAndRequiredTests(TestCase):
             "url": "",
             "useConfigFiletypes": False,
             "filePattern": "",
-            "file": {"allowedTypesLabels": []},
+            "file": {"type": [], "allowedTypesLabels": []},
             "maxNumberOfFiles": 1,
         }
 
@@ -199,6 +199,7 @@ class FileValidationMaxFilesAndRequiredTests(TestCase):
             "type": "editgrid",
             "key": "parent",
             "label": "Repeating group",
+            "groupLabel": "item",
             "components": [
                 {
                     "type": "file",
@@ -208,7 +209,7 @@ class FileValidationMaxFilesAndRequiredTests(TestCase):
                     "url": "",
                     "useConfigFiletypes": False,
                     "filePattern": "",
-                    "file": {"allowedTypesLabels": []},
+                    "file": {"type": [], "allowedTypesLabels": []},
                     "multiple": True,
                     "maxNumberOfFiles": 2,
                 }
@@ -493,7 +494,7 @@ class FileValidationMimeTypeTests(TestCase):
             "url": "",
             "useConfigFiletypes": False,
             "filePattern": "",
-            "file": {"allowedTypesLabels": []},
+            "file": {"type": [], "allowedTypesLabels": []},
         }
 
         is_valid, _ = validate_formio_data(component, data, submission=submission)

--- a/src/openforms/formio/tests/validation/test_iban.py
+++ b/src/openforms/formio/tests/validation/test_iban.py
@@ -63,6 +63,7 @@ class IbanFieldValidationTests(SimpleTestCase):
             "key": "foo",
             "label": "Test",
             "multiple": True,
+            "defaultValue": [],
         }
 
         data: JSONValue = {"foo": ["NL02ABNA0123456789", "NL14 ABNA 1238 8878 00"]}

--- a/src/openforms/formio/tests/validation/test_licenseplate.py
+++ b/src/openforms/formio/tests/validation/test_licenseplate.py
@@ -136,6 +136,7 @@ class LicenseplateFieldValidationTests(SimpleTestCase):
             "validate": {
                 "pattern": r"^[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}$",
             },
+            "defaultValue": [],
         }
 
         data: JSONValue = {"foo": ["1-AAA-222", "33-A-AF6"]}

--- a/src/openforms/formio/tests/validation/test_map.py
+++ b/src/openforms/formio/tests/validation/test_map.py
@@ -9,6 +9,9 @@ class MapValidationTests(SimpleTestCase):
         component: MapComponent = {
             "type": "map",
             "key": "foo",
+            "label": "foo",
+            "interactions": {"marker": True, "polyline": False, "polygon": False},
+            "useConfigDefaultMapSettings": False,
             "validate": {"required": True},
         }
 
@@ -35,6 +38,9 @@ class MapValidationTests(SimpleTestCase):
         component: MapComponent = {
             "type": "map",
             "key": "foo",
+            "label": "foo",
+            "interactions": {"marker": True, "polyline": False, "polygon": False},
+            "useConfigDefaultMapSettings": False,
         }
 
         invalid_value = {
@@ -55,6 +61,9 @@ class MapValidationTests(SimpleTestCase):
         component: MapComponent = {
             "type": "map",
             "key": "foo",
+            "label": "foo",
+            "interactions": {"marker": True, "polyline": False, "polygon": False},
+            "useConfigDefaultMapSettings": False,
         }
 
         invalid_value = {
@@ -75,6 +84,9 @@ class MapValidationTests(SimpleTestCase):
         component: MapComponent = {
             "type": "map",
             "key": "foo",
+            "label": "foo",
+            "interactions": {"marker": True, "polyline": False, "polygon": False},
+            "useConfigDefaultMapSettings": False,
         }
 
         with self.subTest(case="Using non-array values for coordinates"):
@@ -135,6 +147,9 @@ class MapValidationTests(SimpleTestCase):
         component: MapComponent = {
             "type": "map",
             "key": "foo",
+            "label": "foo",
+            "interactions": {"marker": True, "polyline": False, "polygon": False},
+            "useConfigDefaultMapSettings": False,
         }
 
         with self.subTest(case="Less than 2 values in coordinates"):
@@ -178,6 +193,9 @@ class MapValidationTests(SimpleTestCase):
         component: MapComponent = {
             "type": "map",
             "key": "foo",
+            "label": "foo",
+            "interactions": {"marker": True, "polyline": False, "polygon": False},
+            "useConfigDefaultMapSettings": False,
         }
 
         valid_value = {
@@ -192,6 +210,9 @@ class MapValidationTests(SimpleTestCase):
         component: MapComponent = {
             "type": "map",
             "key": "foo",
+            "label": "foo",
+            "interactions": {"marker": True, "polyline": False, "polygon": False},
+            "useConfigDefaultMapSettings": False,
         }
 
         invalid_value = {
@@ -212,6 +233,9 @@ class MapValidationTests(SimpleTestCase):
         component: MapComponent = {
             "type": "map",
             "key": "foo",
+            "label": "foo",
+            "interactions": {"marker": True, "polyline": False, "polygon": False},
+            "useConfigDefaultMapSettings": False,
         }
 
         with self.subTest(case="Using non-array values for coordinates"):
@@ -290,6 +314,9 @@ class MapValidationTests(SimpleTestCase):
         component: MapComponent = {
             "type": "map",
             "key": "foo",
+            "label": "foo",
+            "interactions": {"marker": True, "polyline": False, "polygon": False},
+            "useConfigDefaultMapSettings": False,
         }
 
         with self.subTest(case="Less than 2 values in coordinates"):
@@ -337,6 +364,9 @@ class MapValidationTests(SimpleTestCase):
         component: MapComponent = {
             "type": "map",
             "key": "foo",
+            "label": "foo",
+            "interactions": {"marker": True, "polyline": False, "polygon": False},
+            "useConfigDefaultMapSettings": False,
         }
 
         valid_value = {
@@ -351,6 +381,9 @@ class MapValidationTests(SimpleTestCase):
         component: MapComponent = {
             "type": "map",
             "key": "foo",
+            "label": "foo",
+            "interactions": {"marker": True, "polyline": False, "polygon": False},
+            "useConfigDefaultMapSettings": False,
         }
 
         invalid_value = {
@@ -371,6 +404,9 @@ class MapValidationTests(SimpleTestCase):
         component: MapComponent = {
             "type": "map",
             "key": "foo",
+            "label": "foo",
+            "interactions": {"marker": True, "polyline": False, "polygon": False},
+            "useConfigDefaultMapSettings": False,
         }
 
         with self.subTest(case="Using non-array values for coordinates"):
@@ -470,6 +506,9 @@ class MapValidationTests(SimpleTestCase):
         component: MapComponent = {
             "type": "map",
             "key": "foo",
+            "label": "foo",
+            "interactions": {"marker": True, "polyline": False, "polygon": False},
+            "useConfigDefaultMapSettings": False,
         }
 
         with self.subTest(case="Using less than 2 values for coordinates"):
@@ -518,6 +557,9 @@ class MapValidationTests(SimpleTestCase):
         component: MapComponent = {
             "type": "map",
             "key": "foo",
+            "label": "foo",
+            "interactions": {"marker": True, "polyline": False, "polygon": False},
+            "useConfigDefaultMapSettings": False,
         }
 
         data = {

--- a/src/openforms/formio/tests/validation/test_phonenumber.py
+++ b/src/openforms/formio/tests/validation/test_phonenumber.py
@@ -107,17 +107,15 @@ class PhoneNumberValidationTests(SimpleTestCase):
 
     @tag("gh-4068")
     def test_multiple_with_form_builder_empty_defaults(self):
-        # Our own form builder does funky stuff here by setting the defaultValue to
-        # a list with `null` item.
-        # XXX null is really not a correct value, but we need to rework the rest of our
-        # builder (in the backend) for this first.
+        # Our own form builder did funky stuff here by setting the defaultValue to
+        # a list with `null` item. This is simulated in the submitted value.
         component: Component = {
             "type": "phoneNumber",
             "key": "manyPhonenumber",
             "label": "Optional Phone numbers",
             "validate": {"required": False},
             "multiple": True,
-            "defaultValue": [None],  # FIXME: should really be [""] or []
+            "defaultValue": [""],
         }
 
         is_valid, _ = validate_formio_data(component, {"manyPhonenumber": [None]})

--- a/src/openforms/formio/tests/validation/test_select.py
+++ b/src/openforms/formio/tests/validation/test_select.py
@@ -85,6 +85,7 @@ class SelectValidationTests(SimpleTestCase):
                 ],
             },
             "validate": {"required": True},
+            "defaultValue": [],
         }
 
         invalid_values = [

--- a/src/openforms/formio/tests/validation/test_textarea.py
+++ b/src/openforms/formio/tests/validation/test_textarea.py
@@ -63,17 +63,15 @@ class TextAreaValidationTests(SimpleTestCase):
 
     @tag("gh-4068")
     def test_multiple_with_form_builder_empty_defaults(self):
-        # Our own form builder does funky stuff here by setting the defaultValue to
-        # a list with `null` item.
-        # XXX null is really not a correct value, but we need to rework the rest of our
-        # builder (in the backend) for this first.
+        # Our own form builder did funky stuff here by setting the defaultValue to
+        # a list with `null` item. This is simulated in the submitted value.
         component: Component = {
             "type": "textarea",
             "key": "manyTextarea",
             "label": "Optional textareas",
             "validate": {"required": False},
             "multiple": True,
-            "defaultValue": [None],  # FIXME: should really be [""] or []
+            "defaultValue": [""],
         }
 
         is_valid, _ = validate_formio_data(component, {"manyTextarea": [None]})

--- a/src/openforms/formio/tests/validation/test_textfield.py
+++ b/src/openforms/formio/tests/validation/test_textfield.py
@@ -99,6 +99,7 @@ class TextFieldValidationTests(SimpleTestCase):
             "label": "House number",
             "multiple": True,
             "validate": {"pattern": r"\d+"},
+            "defaultValue": [],
         }
         data: JSONValue = {"numbers": ["42", "notnumber"]}
 
@@ -113,17 +114,15 @@ class TextFieldValidationTests(SimpleTestCase):
 
     @tag("gh-4068")
     def test_multiple_with_form_builder_empty_defaults(self):
-        # Our own form builder does funky stuff here by setting the defaultValue to
-        # a list with `null` item.
-        # XXX null is really not a correct value, but we need to rework the rest of our
-        # builder (in the backend) for this first.
+        # Our own form builder did funky stuff here by setting the defaultValue to
+        # a list with `null` item. This is simulated in the submitted value.
         component: TextFieldComponent = {
             "type": "textfield",
             "key": "manyTextfield",
             "label": "Optional Text fields",
             "validate": {"required": False},
             "multiple": True,
-            "defaultValue": [None],  # FIXME: should really be [""] or []
+            "defaultValue": [""],
         }
 
         is_valid, _ = validate_formio_data(component, {"manyTextfield": [None]})

--- a/src/openforms/forms/tests/test_api_formdefinition.py
+++ b/src/openforms/forms/tests/test_api_formdefinition.py
@@ -405,6 +405,7 @@ class FormDefinitionsAPITests(APITestCase):
                         {
                             "someCamelCase": "field",
                             "key": "somekey",
+                            "label": "somekey",
                             "type": "textfield",
                         }
                     ],
@@ -429,6 +430,7 @@ class FormDefinitionsAPITests(APITestCase):
                 "components": [
                     {
                         "key": "somekey",
+                        "label": "somekey",
                         "type": "textfield",
                         "widget": {"time_24hr": True},
                     }
@@ -632,6 +634,7 @@ class FormDefinitionsAPITests(APITestCase):
                     {
                         "type": "textfield",
                         "key": "text1",
+                        "label": "text1",
                         "description": "Simple {{ missingVariable }} print",
                         "placeholder": 'Placeholder with date filter {{ now|date:"d-m-Y" }}',
                     },
@@ -665,6 +668,7 @@ class FormDefinitionsAPITests(APITestCase):
                     {
                         "type": "textfield",
                         "key": "text1",
+                        "label": "text1",
                         "description": "Broken {{ var {{ brokenNestedVar }} }}",
                     },
                     {

--- a/src/openforms/forms/tests/test_json_schema.py
+++ b/src/openforms/forms/tests/test_json_schema.py
@@ -74,16 +74,19 @@ class GenerateJsonSchemaTests(TestCase):
                         "type": "editgrid",
                         "key": "editgrid",
                         "label": "Editgrid",
+                        "groupLabel": "item",
                         "components": [
                             {
                                 "type": "coSign",
                                 "key": "coSign",
                                 "label": "Cosign",
+                                "authPlugin": "bsn",
                             },
                             {
                                 "type": "softRequiredErrors",
                                 "key": "softRequiredErrors",
                                 "label": "Errors",
+                                "html": "<p>BOO</p>",
                             },
                         ],
                     },

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -2,7 +2,7 @@ from concurrent.futures import Future, ThreadPoolExecutor, as_completed
 from datetime import timedelta
 from uuid import UUID, uuid4
 
-from django.db.models.base import connections
+from django.db import connections
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.text import get_text_list
@@ -83,6 +83,7 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -171,12 +172,14 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
                                 {
                                     "type": "textfield",
                                     "key": "component2",
+                                    "label": "component2",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -318,12 +321,14 @@ class FormEndpointTests(APITestCase):
                     {
                         "type": "textfield",
                         "key": "component1",
+                        "label": "component1",
                         "hidden": False,
                         "clear_on_hide": True,
                     },
                     {
                         "type": "textfield",
                         "key": "component2",
+                        "label": "component2",
                         "hidden": False,
                         "clear_on_hide": True,
                     },
@@ -503,12 +508,14 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
                                 {
                                     "type": "textfield",
                                     "key": "component2",
+                                    "label": "component2",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -552,12 +559,14 @@ class FormEndpointTests(APITestCase):
                     {
                         "type": "textfield",
                         "key": "component1",
+                        "label": "component1",
                         "hidden": False,
                         "clear_on_hide": True,
                     },
                     {
                         "type": "textfield",
                         "key": "component2",
+                        "label": "component2",
                         "hidden": False,
                         "clear_on_hide": True,
                     },
@@ -588,6 +597,7 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -657,6 +667,7 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -703,6 +714,7 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -833,6 +845,7 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -966,6 +979,7 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -1023,6 +1037,7 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -1077,6 +1092,7 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -1131,6 +1147,7 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -1159,12 +1176,14 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component2",
+                                    "label": "component2",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
                                 {
                                     "type": "textfield",
                                     "key": "component3",
+                                    "label": "component3",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -1209,6 +1228,7 @@ class FormEndpointTests(APITestCase):
                     {
                         "type": "textfield",
                         "key": "component1",
+                        "label": "component1",
                         "hidden": False,
                         "clear_on_hide": True,
                     },
@@ -1227,12 +1247,14 @@ class FormEndpointTests(APITestCase):
                     {
                         "type": "textfield",
                         "key": "component2",
+                        "label": "component2",
                         "hidden": False,
                         "clear_on_hide": True,
                     },
                     {
                         "type": "textfield",
                         "key": "component3",
+                        "label": "component3",
                         "hidden": False,
                         "clear_on_hide": True,
                     },
@@ -1245,7 +1267,9 @@ class FormEndpointTests(APITestCase):
         existing_form_definition_uuid = uuid4()
         unrelated_form_step = FormStepFactory.create(
             form_definition__configuration={
-                "components": [{"key": "textfield", "type": "textfield"}]
+                "components": [
+                    {"key": "textfield", "type": "textfield", "label": "textfield"}
+                ]
             },
             form_definition__is_reusable=True,
             form_definition__uuid=existing_form_definition_uuid,
@@ -1271,12 +1295,14 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
                                 {
                                     "type": "textfield",
                                     "key": "component2",
+                                    "label": "component2",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -1314,12 +1340,14 @@ class FormEndpointTests(APITestCase):
                     {
                         "type": "textfield",
                         "key": "component1",
+                        "label": "component1",
                         "hidden": False,
                         "clear_on_hide": True,
                     },
                     {
                         "type": "textfield",
                         "key": "component2",
+                        "label": "component2",
                         "hidden": False,
                         "clear_on_hide": True,
                     },
@@ -1353,12 +1381,14 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
                                 {
                                     "type": "textfield",
                                     "key": "component2",
+                                    "label": "component2",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -1388,12 +1418,14 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
                                 {
                                     "type": "textfield",
                                     "key": "component2",
+                                    "label": "component2",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -1451,6 +1483,7 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -1480,12 +1513,14 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
                                 {
                                     "type": "textfield",
                                     "key": "component2",
+                                    "label": "component2",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -1553,18 +1588,21 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
                                 {
                                     "type": "textfield",
                                     "key": "component2",
+                                    "label": "component2",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -1622,14 +1660,18 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "key": "repeatingGroup",
                                     "type": "editgrid",
+                                    "label": "repeatingGroup",
+                                    "groupLabel": "Item",
                                     "components": [
                                         {
                                             "type": "file",
                                             "key": "fileInRepeatingGroup1",
+                                            "label": "fileInRepeatingGroup1",
                                         },
                                         {
                                             "type": "file",
                                             "key": "fileInRepeatingGroup1",
+                                            "label": "fileInRepeatingGroup1",
                                         },
                                     ],
                                 },
@@ -1688,6 +1730,7 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -1756,6 +1799,7 @@ class FormEndpointTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -1855,6 +1899,7 @@ class FormEndpointVariableTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -1924,7 +1969,7 @@ class FormEndpointVariableTests(APITestCase):
                                 {
                                     "type": "customerProfile",
                                     "key": "profile",
-                                    "name": "Profile",
+                                    "label": "Profile",
                                     "digitalAddressTypes": ["email"],
                                     "shouldUpdateCustomerData": True,
                                 }
@@ -1968,7 +2013,7 @@ class FormEndpointVariableTests(APITestCase):
         variables = form.formvariable_set.order_by("name")
 
         # component variable, generated for the form step (based on the form defintion)
-        self.assertEqual(variables[0].name, "profile")
+        self.assertEqual(variables[0].name, "Profile")
         self.assertEqual(variables[0].key, "profile")
         self.assertEqual(variables[0].source, FormVariableSources.component)
         self.assertEqual(variables[0].form_definition.uuid, form_definition_uuid)
@@ -2003,6 +2048,7 @@ class FormEndpointVariableTests(APITestCase):
                                     {
                                         "type": "textfield",
                                         "key": "component1",
+                                        "label": "component1",
                                         "hidden": False,
                                         "clearOnHide": True,
                                     },
@@ -2088,6 +2134,7 @@ class FormEndpointVariableTests(APITestCase):
                                     {
                                         "type": "textfield",
                                         "key": "component1",
+                                        "label": "component1",
                                         "hidden": False,
                                         "clearOnHide": True,
                                     },
@@ -2184,6 +2231,7 @@ class FormEndpointVariableTests(APITestCase):
                                     {
                                         "type": "textfield",
                                         "key": "component1",
+                                        "label": "component1",
                                         "hidden": False,
                                         "clearOnHide": True,
                                     },
@@ -2260,6 +2308,7 @@ class FormEndpointVariableTests(APITestCase):
                                     {
                                         "type": "textfield",
                                         "key": "component1",
+                                        "label": "component1",
                                         "hidden": False,
                                         "clearOnHide": True,
                                     },
@@ -2333,10 +2382,12 @@ class FormEndpointVariableTests(APITestCase):
                     {
                         "type": "textfield",
                         "key": "name",
+                        "label": "name",
                     },
                     {
                         "type": "number",
                         "key": "age",
+                        "label": "age",
                     },
                 ]
             },
@@ -2350,10 +2401,12 @@ class FormEndpointVariableTests(APITestCase):
                     {
                         "type": "number",
                         "key": "nLargeBoxes",
+                        "label": "nLargeBoxes",
                     },
                     {
                         "type": "number",
                         "key": "nGiganticBoxes",
+                        "label": "nGiganticBoxes",
                     },
                 ]
             },
@@ -2380,10 +2433,12 @@ class FormEndpointVariableTests(APITestCase):
                                 {
                                     "type": "number",
                                     "key": "age",
+                                    "label": "age",
                                 },
                                 {
                                     "type": "textfield",
                                     "key": "email",
+                                    "label": "email",
                                 },
                             ],
                         },
@@ -2410,6 +2465,7 @@ class FormEndpointVariableTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "city",
+                                    "label": "city",
                                 },
                             ],
                         },
@@ -2436,6 +2492,7 @@ class FormEndpointVariableTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "streetname",
+                                    "label": "streetname",
                                 },
                             ],
                         },
@@ -2521,6 +2578,7 @@ class FormEndpointVariableTests(APITestCase):
                                     {
                                         "type": "textfield",
                                         "key": "component1",
+                                        "label": "component1",
                                         "hidden": False,
                                         "clearOnHide": True,
                                     },
@@ -2586,6 +2644,7 @@ class FormEndpointVariableTests(APITestCase):
                                     {
                                         "type": "textfield",
                                         "key": "component1",
+                                        "label": "component1",
                                         "hidden": False,
                                         "clearOnHide": True,
                                     },
@@ -2656,6 +2715,7 @@ class FormEndpointVariableTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -2721,6 +2781,7 @@ class FormEndpointVariableTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "component1",
+                                    "label": "component1",
                                     "hidden": False,
                                     "clearOnHide": True,
                                 },
@@ -2787,7 +2848,7 @@ class FormEndpointVariableTests(APITestCase):
                                 {
                                     "type": "customerProfile",
                                     "key": "profile",
-                                    "name": "Profile",
+                                    "label": "Profile",
                                     "digitalAddressTypes": ["email"],
                                     "shouldUpdateCustomerData": True,
                                 }
@@ -2861,7 +2922,7 @@ class FormEndpointVariableTests(APITestCase):
                                     {
                                         "type": "customerProfile",
                                         "key": "profile",
-                                        "name": "Profile",
+                                        "label": "Profile",
                                         "digitalAddressTypes": ["email"],
                                         "shouldUpdateCustomerData": True,
                                     }
@@ -2923,7 +2984,7 @@ class FormEndpointVariableTests(APITestCase):
                                     {
                                         "type": "customerProfile",
                                         "key": "profile",
-                                        "name": "Profile",
+                                        "label": "Profile",
                                         "digitalAddressTypes": ["email"],
                                         "shouldUpdateCustomerData": True,
                                     }
@@ -2995,7 +3056,7 @@ class FormEndpointVariableTests(APITestCase):
                                 {
                                     "type": "customerProfile",
                                     "key": "profile",
-                                    "name": "Profile",
+                                    "label": "Profile",
                                     "digitalAddressTypes": ["email"],
                                     "shouldUpdateCustomerData": True,
                                 },
@@ -3075,7 +3136,7 @@ class FormEndpointVariableTests(APITestCase):
                                 {
                                     "type": "customerProfile",
                                     "key": "profile",
-                                    "name": "Profile",
+                                    "label": "Profile",
                                     "digitalAddressTypes": ["email"],
                                     "shouldUpdateCustomerData": True,
                                 }
@@ -3162,7 +3223,7 @@ class FormEndpointVariableTests(APITestCase):
                                 {
                                     "type": "customerProfile",
                                     "key": "profile",
-                                    "name": "Profile",
+                                    "label": "Profile",
                                     "digitalAddressTypes": ["email"],
                                     "shouldUpdateCustomerData": True,
                                 }
@@ -3317,6 +3378,7 @@ class FormEndpointConcurrentTests(APITransactionTestCase):
                                         {
                                             "type": "textfield",
                                             "key": "component1",
+                                            "label": "component1",
                                             "hidden": False,
                                             "clearOnHide": True,
                                         },
@@ -3355,6 +3417,7 @@ class FormEndpointConcurrentTests(APITransactionTestCase):
                                         {
                                             "type": "textfield",
                                             "key": "component2",
+                                            "label": "component2",
                                             "hidden": False,
                                             "clearOnHide": True,
                                         },
@@ -3456,6 +3519,7 @@ class FormEndpointConcurrentTests(APITransactionTestCase):
                                         {
                                             "type": "textfield",
                                             "key": "component1",
+                                            "label": "component1",
                                             "hidden": False,
                                             "clearOnHide": True,
                                         },
@@ -3494,6 +3558,7 @@ class FormEndpointConcurrentTests(APITransactionTestCase):
                                         {
                                             "type": "textfield",
                                             "key": "component2",
+                                            "label": "component2",
                                             "hidden": False,
                                             "clearOnHide": True,
                                         },

--- a/src/openforms/registrations/contrib/email/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/email/tests/test_backend.py
@@ -102,8 +102,20 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
                     "label": "some_list",
                     "defaultValue": [],
                 },
-                {"key": "file1", "type": "file", "label": "file1"},
-                {"key": "file2", "type": "file", "label": "file2"},
+                {
+                    "key": "file1",
+                    "type": "file",
+                    "label": "file1",
+                    "file": {"type": []},
+                    "filePattern": "",
+                },
+                {
+                    "key": "file2",
+                    "type": "file",
+                    "label": "file2",
+                    "file": {"type": []},
+                    "filePattern": "",
+                },
             ],
             submitted_data={
                 "foo": "bar",
@@ -505,7 +517,12 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
             completed_on=timezone.make_aware(datetime(2021, 1, 1, 12, 0, 0)),
             components_list=[
                 {"key": "voornaam", "type": "textfield"},
-                {"key": "someFile", "type": "file"},
+                {
+                    "key": "someFile",
+                    "type": "file",
+                    "file": {"type": []},
+                    "filePattern": "",
+                },
             ],
             submitted_data={
                 "voornaam": "Foo",
@@ -930,6 +947,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
                         {
                             "columns": [
                                 {
+                                    "size": 6,
                                     "components": [
                                         {
                                             "key": "dev1Naam",
@@ -940,6 +958,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
                                     ],
                                 },
                                 {
+                                    "size": 6,
                                     "components": [
                                         {
                                             "key": "dev1taken",
@@ -989,6 +1008,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
                         {
                             "columns": [
                                 {
+                                    "size": 6,
                                     "components": [
                                         {
                                             "key": "dev2Naam",
@@ -999,6 +1019,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
                                     ],
                                 },
                                 {
+                                    "size": 6,
                                     "components": [
                                         {
                                             "key": "dev2taken",
@@ -1076,8 +1097,20 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
                     "defaultValue": [],
                     "label": "some_list",
                 },
-                {"key": "file1", "type": "file", "label": "file1"},
-                {"key": "file2", "type": "file", "label": "file2"},
+                {
+                    "key": "file1",
+                    "type": "file",
+                    "label": "file1",
+                    "file": {"type": []},
+                    "filePattern": "",
+                },
+                {
+                    "key": "file2",
+                    "type": "file",
+                    "label": "file2",
+                    "file": {"type": []},
+                    "filePattern": "",
+                },
             ],
             submitted_data={
                 "foo": "bar",
@@ -1226,18 +1259,41 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
             submission=submission,
             form_step__form_definition__configuration={
                 "components": [
-                    {"key": "normalAttachment", "type": "file"},
+                    {
+                        "key": "normalAttachment",
+                        "type": "file",
+                        "label": "file",
+                        "file": {"type": []},
+                        "filePattern": "",
+                    },
                     {
                         "key": "repeatingGroup",
                         "type": "editgrid",
+                        "label": "repeatingGroup",
+                        "groupLabel": "item",
                         "components": [
-                            {"key": "attachmentInRepeatingGroup", "type": "file"}
+                            {
+                                "key": "attachmentInRepeatingGroup",
+                                "label": "attachmentInRepeatingGroup",
+                                "type": "file",
+                                "file": {"type": []},
+                                "filePattern": "",
+                            }
                         ],
                     },
                     {
                         "key": "fieldset",
                         "type": "fieldset",
-                        "components": [{"key": "attachmentInFieldset", "type": "file"}],
+                        "label": "fieldset",
+                        "components": [
+                            {
+                                "key": "attachmentInFieldset",
+                                "label": "attachmentInFieldset",
+                                "type": "file",
+                                "file": {"type": []},
+                                "filePattern": "",
+                            }
+                        ],
                     },
                 ]
             },

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend.py
@@ -474,6 +474,9 @@ class ObjectsAPIBackendVCRTests(OFVCRMixin, TestCase):
                 {
                     "key": "attachment",
                     "type": "file",
+                    "label": "attachment",
+                    "file": {"type": []},
+                    "filePattern": "",
                 }
             ],
             submitted_data={

--- a/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_backend_v1.py
@@ -611,6 +611,8 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                         # `omschrijving` "Attachment Informatieobjecttype other catalog":
                         "informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/cd6aeaf2-ca37-416f-b78c-1cc302f81a81",
                     },
+                    "file": {"type": []},
+                    "filePattern": "",
                 },
                 {
                     "key": "field2",
@@ -618,6 +620,8 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                     "registration": {
                         "informatieobjecttype": "",
                     },
+                    "file": {"type": []},
+                    "filePattern": "",
                 },
             ],
             language_code="en",
@@ -695,6 +699,8 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                 {
                     "key": "fileUpload",
                     "type": "file",
+                    "file": {"type": []},
+                    "filePattern": "",
                     "registration": {
                         # `omschrijving` "Attachment Informatieobjecttype other catalog":
                         "informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/cd6aeaf2-ca37-416f-b78c-1cc302f81a81",
@@ -777,7 +783,10 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                     "components": [
                         {
                             "key": "fileUpload",
+                            "label": "fileUpload",
                             "type": "file",
+                            "file": {"type": []},
+                            "filePattern": "",
                             "registration": {
                                 # `omschrijving` "Attachment Informatieobjecttype other catalog":
                                 "informatieobjecttype": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/cd6aeaf2-ca37-416f-b78c-1cc302f81a81",
@@ -1161,6 +1170,8 @@ class ObjectsAPIBackendV1Tests(OFVCRMixin, TestCase):
                     "type": "file",
                     "key": "file",
                     "label": "File",
+                    "file": {"type": []},
+                    "filePattern": "",
                     "registration": {
                         "documentType": {
                             "catalogue": {

--- a/src/openforms/registrations/contrib/objects_api/tests/test_templatetags.py
+++ b/src/openforms/registrations/contrib/objects_api/tests/test_templatetags.py
@@ -24,6 +24,7 @@ class JsonSummaryTests(TestCase):
                     {
                         "key": "voornaam",
                         "type": "textfield",
+                        "label": "voornaam",
                         "registration": {
                             "attribute": RegistrationAttribute.initiator_voornamen,
                         },
@@ -31,6 +32,7 @@ class JsonSummaryTests(TestCase):
                     {
                         "key": "achternaam",
                         "type": "textfield",
+                        "label": "achternaam",
                         "registration": {
                             "attribute": RegistrationAttribute.initiator_geslachtsnaam,
                         },
@@ -38,6 +40,7 @@ class JsonSummaryTests(TestCase):
                     {
                         "key": "tussenvoegsel",
                         "type": "textfield",
+                        "label": "tussenvoegsel",
                         "registration": {
                             "attribute": RegistrationAttribute.initiator_tussenvoegsel,
                         },
@@ -65,7 +68,13 @@ class JsonSummaryTests(TestCase):
     @override_settings(ESCAPE_REGISTRATION_OUTPUT=False)
     def test_render_json_summary_doesnt_escape_html_when_disabled(self):
         submission = SubmissionFactory.from_components(
-            components_list=[{"key": "voornaam", "type": "textfield"}],
+            components_list=[
+                {
+                    "key": "voornaam",
+                    "type": "textfield",
+                    "label": "voornaam",
+                }
+            ],
             submitted_data={
                 "voornaam": '<script>alert();</script>""',
             },
@@ -90,7 +99,9 @@ class JsonSummaryTests(TestCase):
     @override_settings(ESCAPE_REGISTRATION_OUTPUT=True)
     def test_render_json_summary_escapes_html_when_enabled(self):
         submission = SubmissionFactory.from_components(
-            components_list=[{"key": "voornaam", "type": "textfield"}],
+            components_list=[
+                {"key": "voornaam", "type": "textfield", "label": "voornaam"}
+            ],
             submitted_data={"voornaam": "<script>alert();</script>"},
             form_definition_kwargs={"slug": "formstep-slug"},
             completed=True,
@@ -135,29 +146,38 @@ class JsonSummaryTests(TestCase):
                     {
                         "key": "date",
                         "type": "date",
+                        "label": "date",
                     },
                     {
                         "key": "dateMultiple",
                         "type": "date",
+                        "label": "dateMultiple",
                         "multiple": True,
+                        "defaultValue": [],
                     },
                     {
                         "key": "datetime",
                         "type": "datetime",
+                        "label": "datetime",
                     },
                     {
                         "key": "datetimeMultiple",
                         "type": "datetime",
+                        "label": "datetimeMultiple",
                         "multiple": True,
+                        "defaultValue": [],
                     },
                     {
                         "key": "time",
                         "type": "time",
+                        "label": "time",
                     },
                     {
                         "key": "timeMultiple",
                         "type": "time",
+                        "label": "timeMultiple",
                         "multiple": True,
+                        "defaultValue": [],
                     },
                 ],
             },

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
@@ -46,6 +46,7 @@ NP_INITIATOR_FIELDS = [
     {
         "key": "achternaam",
         "type": "textfield",
+        "label": "achternaam",
         "registration": {
             "attribute": RegistrationAttribute.initiator_geslachtsnaam,
         },
@@ -53,6 +54,7 @@ NP_INITIATOR_FIELDS = [
     {
         "key": "postcode",
         "type": "textfield",
+        "label": "postcode",
         "registration": {
             "attribute": RegistrationAttribute.initiator_postcode,
         },
@@ -60,11 +62,13 @@ NP_INITIATOR_FIELDS = [
     {
         "key": "woonplaats",
         "type": "textfield",
+        "label": "woonplaats",
         "registration": {"attribute": RegistrationAttribute.initiator_woonplaats},
     },
     {
         "key": "straat",
         "type": "textfield",
+        "label": "straat",
         "registration": {
             "attribute": RegistrationAttribute.initiator_straat,
         },
@@ -72,6 +76,7 @@ NP_INITIATOR_FIELDS = [
     {
         "key": "huisnummer",
         "type": "number",
+        "label": "huisnummer",
         "registration": {
             "attribute": RegistrationAttribute.initiator_huisnummer,
         },
@@ -696,6 +701,7 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
             [
                 {
                     "key": "handelsnaam",
+                    "label": "handelsnaam",
                     "type": "textfield",
                     "registration": {
                         "attribute": RegistrationAttribute.initiator_handelsnaam,
@@ -703,6 +709,7 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
                 },
                 {
                     "key": "postcode",
+                    "label": "postcode",
                     "type": "textfield",
                     "registration": {
                         "attribute": RegistrationAttribute.initiator_postcode,
@@ -710,6 +717,7 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
                 },
                 {
                     "key": "woonplaats",
+                    "label": "woonplaats",
                     "type": "textfield",
                     "registration": {
                         "attribute": RegistrationAttribute.initiator_woonplaats
@@ -717,6 +725,7 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
                 },
                 {
                     "key": "straat",
+                    "label": "straat",
                     "type": "textfield",
                     "registration": {
                         "attribute": RegistrationAttribute.initiator_straat,
@@ -724,6 +733,7 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
                 },
                 {
                     "key": "huisnummer",
+                    "label": "huisnummer",
                     "type": "number",
                     "registration": {
                         "attribute": RegistrationAttribute.initiator_huisnummer,
@@ -1566,6 +1576,7 @@ class ZGWBackendVCRTests(OFVCRMixin, TestCase):
                     "key": "editgrid",
                     "type": "editgrid",
                     "label": "Editgrid",
+                    "groupLabel": "item",
                     "components": [
                         {
                             "type": "time",

--- a/src/openforms/submissions/cosigning.py
+++ b/src/openforms/submissions/cosigning.py
@@ -143,7 +143,8 @@ class CosignState:
 
         # if the component itself is marked as required, we know for sure cosigning is
         # required
-        required = cosign_component.get("validate", {}).get("required", False)
+        validate = cosign_component.get("validate") or {}
+        required = validate.get("required", False)
         if required:
             return True
 

--- a/src/openforms/submissions/tests/form_logic/test_cache_dmn_requests.py
+++ b/src/openforms/submissions/tests/form_logic/test_cache_dmn_requests.py
@@ -17,9 +17,9 @@ class TestCacheDMNRequests(SubmissionsMixin, APITestCase):
     def test_requests_not_made_multiple_times(self, m):
         submission = SubmissionFactory.from_components(
             [
-                {"type": "textfield", "key": "fieldA"},
-                {"type": "textfield", "key": "fieldB"},
-                {"type": "textfield", "key": "fieldC"},
+                {"type": "textfield", "key": "fieldA", "label": "fieldA"},
+                {"type": "textfield", "key": "fieldB", "label": "fieldB"},
+                {"type": "textfield", "key": "fieldC", "label": "fieldC"},
             ]
         )
 
@@ -122,9 +122,22 @@ class TestCacheDMNRequests(SubmissionsMixin, APITestCase):
     def test_requests_not_made_multiple_times_with_non_serialiseable_vars(self, m):
         submission = SubmissionFactory.from_components(
             [
-                {"type": "date", "key": "fieldA", "multiple": True},
-                {"type": "datetime", "key": "fieldB"},
-                {"type": "textfield", "key": "fieldC"},
+                {
+                    "type": "date",
+                    "key": "fieldA",
+                    "multiple": True,
+                    "defaultValue": [],
+                },
+                {
+                    "type": "datetime",
+                    "key": "fieldB",
+                    "label": "fieldB",
+                },
+                {
+                    "type": "textfield",
+                    "key": "fieldC",
+                    "label": "fieldC",
+                },
             ]
         )
 

--- a/src/openforms/submissions/tests/form_logic/test_conditional_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_conditional_logic.py
@@ -96,6 +96,8 @@ class ConditionalLogicTests(TestCase):
                         "eq": "hide",
                     },
                     "clearOnHide": True,
+                    "file": {"type": []},
+                    "filePattern": "",
                 },
                 {
                     "type": "textfield",
@@ -302,6 +304,7 @@ class ConditionalLogicTests(TestCase):
                     "type": "editgrid",
                     "key": "editgrid",
                     "label": "Edit grid",
+                    "groupLabel": "item",
                     "components": [
                         {
                             "type": "textfield",
@@ -368,6 +371,7 @@ class ConditionalLogicTests(TestCase):
                     "type": "editgrid",
                     "key": "editgrid",
                     "label": "Edit grid",
+                    "groupLabel": "item",
                     "components": [
                         {
                             "type": "textfield",
@@ -378,6 +382,7 @@ class ConditionalLogicTests(TestCase):
                             "type": "editgrid",
                             "key": "editgrid2",
                             "label": "editgrid2",
+                            "groupLabel": "nested item",
                             "components": [
                                 {
                                     "type": "textfield",
@@ -553,6 +558,7 @@ class ConditionalLogicTests(TestCase):
                     "label": "Textfield visible",
                     "multiple": True,
                     "hidden": False,
+                    "defaultValue": [],
                 },
                 {
                     "type": "textfield",
@@ -675,6 +681,8 @@ class ConditionalLogicTests(TestCase):
                     "type": "file",
                     "key": "file",
                     "label": "file visible",
+                    "file": {"type": []},
+                    "filePattern": "",
                 },
                 {
                     "type": "textfield",
@@ -735,6 +743,7 @@ class ConditionalLogicTests(TestCase):
                 {
                     "key": "radio",
                     "type": "radio",
+                    "label": "radio",
                     "values": [
                         {"label": "yes", "value": "yes"},
                         {"label": "no", "value": "no"},
@@ -743,9 +752,12 @@ class ConditionalLogicTests(TestCase):
                 {
                     "type": "file",
                     "key": "file",
+                    "label": "file",
                     "hidden": False,
                     "conditional": {"eq": "yes", "show": True, "when": "radio"},
                     "clearOnHide": True,
+                    "file": {"type": []},
+                    "filePattern": "",
                 },
             ],
         )
@@ -822,6 +834,7 @@ class ConditionalLogicTests(TestCase):
                     "type": "editgrid",
                     "key": "editgrid",
                     "label": "Edit grid",
+                    "groupLabel": "item",
                     "components": [
                         {
                             "type": "fieldset",

--- a/src/openforms/submissions/tests/form_logic/test_endpoint.py
+++ b/src/openforms/submissions/tests/form_logic/test_endpoint.py
@@ -34,6 +34,7 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "select",
                         "key": "pet",
+                        "label": "pet",
                         "data": {
                             "values": [
                                 {"label": "Cat", "value": "cat"},
@@ -51,6 +52,7 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "step2",
+                        "label": "step2",
                     }
                 ]
             },
@@ -62,6 +64,7 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "step3",
+                        "label": "step3",
                     }
                 ]
             },
@@ -157,6 +160,7 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "radio",
                         "key": "radio",
+                        "label": "radio",
                         "values": [
                             {"label": "A", "value": "a"},
                             {"label": "B", "value": "b"},
@@ -339,6 +343,7 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "someComponent",
+                        "label": "someComponent",
                     }
                 ]
             },
@@ -544,6 +549,7 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
                     "label": "Editgrid",
                     "clearOnHide": True,
                     "hidden": False,
+                    "groupLabel": "item",
                     "components": [
                         {
                             "type": "textfield",
@@ -559,6 +565,7 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
                     "label": "Editgrid inverted",
                     "clearOnHide": True,
                     "hidden": True,
+                    "groupLabel": "item",
                     "components": [
                         {
                             "type": "textfield",
@@ -685,6 +692,7 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "textfieldStep1",
+                        "label": "Text field step 1",
                         "hidden": True,
                         "clearOnHide": True,
                     },
@@ -698,6 +706,7 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "textfieldStep2",
+                        "label": "Text field step 2",
                         "hidden": True,
                         "clearOnHide": True,
                     }
@@ -1020,6 +1029,7 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
                         "key": "date_multiple",
                         "label": "Date multiple",
                         "multiple": True,
+                        "defaultValue": [],
                     },
                     {
                         "type": "date",
@@ -1191,6 +1201,7 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
                         "type": "editgrid",
                         "key": "editgrid",
                         "label": "Editgrid",
+                        "groupLabel": "item",
                         "clearOnHide": True,
                         "components": [
                             {

--- a/src/openforms/submissions/tests/form_logic/test_evaluation_determinism.py
+++ b/src/openforms/submissions/tests/form_logic/test_evaluation_determinism.py
@@ -89,10 +89,12 @@ class DeterministicEvaluationTests(TestCase):
                     {
                         "type": "number",
                         "key": "a",
+                        "label": "a",
                     },
                     {
                         "type": "number",
                         "key": "b",
+                        "label": "b",
                     },
                 ]
             },
@@ -104,6 +106,7 @@ class DeterministicEvaluationTests(TestCase):
                     {
                         "type": "number",
                         "key": "c",
+                        "label": "c",
                     }
                 ]
             },
@@ -115,6 +118,7 @@ class DeterministicEvaluationTests(TestCase):
                     {
                         "type": "number",
                         "key": "d",
+                        "label": "d",
                     }
                 ]
             },

--- a/src/openforms/submissions/tests/form_logic/test_modify_components.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_components.py
@@ -24,6 +24,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "step1_textfield1",
+                        "label": "step1_textfield1",
                     }
                 ]
             },
@@ -35,6 +36,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "step2_textfield1",
+                        "label": "step2_textfield1",
                         "hidden": False,
                     }
                 ]
@@ -83,6 +85,7 @@ class ComponentModificationTests(TestCase):
                 {
                     "type": "textfield",
                     "key": "step2_textfield1",
+                    "label": "step2_textfield1",
                     "hidden": True,
                 }
             ]
@@ -99,12 +102,14 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "component1",
+                        "label": "component1",
                         "hidden": False,
                         "clearOnHide": True,
                     },
                     {
                         "type": "textfield",
                         "key": "component2",
+                        "label": "component2",
                         "hidden": False,
                         "clearOnHide": True,
                     },
@@ -157,12 +162,14 @@ class ComponentModificationTests(TestCase):
                 {
                     "type": "textfield",
                     "key": "component1",
+                    "label": "component1",
                     "hidden": False,
                     "clearOnHide": True,
                 },
                 {
                     "type": "textfield",
                     "key": "component2",
+                    "label": "component2",
                     "hidden": True,
                     "clearOnHide": True,
                 },
@@ -180,6 +187,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "name",
+                        "label": "name",
                     }
                 ]
             },
@@ -191,6 +199,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "surname",
+                        "label": "surname",
                         "validate": {"required": False},
                     }
                 ]
@@ -239,6 +248,7 @@ class ComponentModificationTests(TestCase):
                 {
                     "type": "textfield",
                     "key": "surname",
+                    "label": "surname",
                     "validate": {"required": True},
                 }
             ]
@@ -254,6 +264,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "fooBarBaz",
+                        "label": "fooBarBaz",
                     }
                 ]
             },
@@ -265,6 +276,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "test",
+                        "label": "test",
                         "hidden": True,
                     }
                 ]
@@ -313,6 +325,7 @@ class ComponentModificationTests(TestCase):
                 {
                     "type": "textfield",
                     "key": "test",
+                    "label": "test",
                     "hidden": False,
                 }
             ]
@@ -328,6 +341,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "email",
                         "key": "userEmail",
+                        "label": "userEmail",
                     }
                 ]
             },
@@ -339,6 +353,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "test",
+                        "label": "test",
                         "hidden": True,
                     }
                 ]
@@ -387,6 +402,7 @@ class ComponentModificationTests(TestCase):
                 {
                     "type": "textfield",
                     "key": "test",
+                    "label": "test",
                     "hidden": False,
                 }
             ]
@@ -402,6 +418,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "fooBarBaz",
+                        "label": "fooBarBaz",
                     }
                 ]
             },
@@ -413,6 +430,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "test",
+                        "label": "test",
                         "hidden": True,
                     }
                 ]
@@ -461,6 +479,7 @@ class ComponentModificationTests(TestCase):
                 {
                     "type": "textfield",
                     "key": "test",
+                    "label": "test",
                     "hidden": True,
                 }
             ]
@@ -476,6 +495,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "email",
                         "key": "userEmail",
+                        "label": "userEmail",
                     }
                 ]
             },
@@ -487,6 +507,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "test",
+                        "label": "test",
                         "hidden": True,
                     }
                 ]
@@ -535,6 +556,7 @@ class ComponentModificationTests(TestCase):
                 {
                     "type": "textfield",
                     "key": "test",
+                    "label": "test",
                     "hidden": True,
                 }
             ]
@@ -550,6 +572,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "step1_textfield1",
+                        "label": "step1_textfield1",
                     }
                 ]
             },
@@ -561,6 +584,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "step2_textfield1",
+                        "label": "step2_textfield1",
                         "hidden": False,
                     }
                 ]
@@ -600,6 +624,7 @@ class ComponentModificationTests(TestCase):
                 {
                     "type": "textfield",
                     "key": "step2_textfield1",
+                    "label": "step2_textfield1",
                     "hidden": False,
                 }
             ]
@@ -623,6 +648,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "name",
+                        "label": "name",
                     }
                 ]
             },
@@ -634,6 +660,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "surname",
+                        "label": "surname",
                         "validate": {"required": False},
                     }
                 ]
@@ -684,6 +711,7 @@ class ComponentModificationTests(TestCase):
                     "type": "textfield",
                     "key": "surname",
                     "validate": {"required": False},
+                    "label": "surname",
                 }
             ]
         }
@@ -704,12 +732,14 @@ class ComponentModificationTests(TestCase):
                         "components": [
                             {
                                 "key": "CatBirthDate",
+                                "label": "CatBirthDate",
                                 "type": "date",
                                 "format": "dd-MM-yyyy",
                                 "hidden": False,
                             },
                             {
                                 "key": "addAnotherCat",
+                                "label": "addAnotherCat",
                                 "type": "radio",
                                 "hidden": False,
                                 "values": [
@@ -728,6 +758,7 @@ class ComponentModificationTests(TestCase):
                         "components": [
                             {
                                 "key": "CatBirthDate2",
+                                "label": "CatBirthDate2",
                                 "type": "date",
                                 "format": "dd-MM-yyyy",
                                 "hidden": False,
@@ -774,6 +805,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "step1_textfield",
+                        "label": "step1_textfield",
                     }
                 ]
             },
@@ -785,6 +817,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "step2_textfield",
+                        "label": "step2_textfield",
                         "hidden": False,
                     }
                 ]
@@ -829,6 +862,7 @@ class ComponentModificationTests(TestCase):
                 {
                     "type": "textfield",
                     "key": "step1_textfield",
+                    "label": "step1_textfield",
                 }
             ]
         }
@@ -842,6 +876,7 @@ class ComponentModificationTests(TestCase):
                 "components": [
                     {
                         "key": "radio",
+                        "label": "radio",
                         "type": "radio",
                         "values": [
                             {"label": "yes", "value": "yes"},
@@ -851,6 +886,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "textField",
+                        "label": "textField",
                         "hidden": True,
                         "conditional": {"eq": "yes", "show": True, "when": "radio"},
                         "clearOnHide": True,
@@ -888,11 +924,13 @@ class ComponentModificationTests(TestCase):
                 "components": [
                     {
                         "key": "date",
+                        "label": "date",
                         "type": "date",
                     },
                     {
                         "type": "textfield",
                         "key": "textField",
+                        "label": "textField",
                         "conditional": {
                             "eq": "2025-01-01",
                             "show": True,
@@ -935,6 +973,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "textFieldA",
+                        "label": "textFieldA",
                         "hidden": True,
                         "conditional": {
                             "eq": "",
@@ -946,6 +985,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "textFieldB",
+                        "label": "textFieldB",
                         "hidden": True,
                         "conditional": {
                             "eq": "yes",
@@ -976,11 +1016,13 @@ class ComponentModificationTests(TestCase):
                 "components": [
                     {
                         "key": "nested.component",
+                        "label": "nested.component",
                         "type": "textfield",
                         "clearOnHide": True,
                     },
                     {
                         "key": "radio",
+                        "label": "radio",
                         "type": "radio",
                         "values": [
                             {"label": "A", "value": "a"},
@@ -1041,6 +1083,7 @@ class ComponentModificationTests(TestCase):
                 "components": [
                     {
                         "key": "selectboxes",
+                        "label": "selectboxes",
                         "type": "selectboxes",
                         "hidden": True,
                         "values": [
@@ -1077,6 +1120,7 @@ class ComponentModificationTests(TestCase):
                     {
                         "type": "postcode",
                         "key": "nicePostcode",
+                        "label": "nicePostcode",
                         "validate": {
                             "custom": "",
                             "unique": False,
@@ -1128,6 +1172,7 @@ class ComponentModificationTests(TestCase):
                 {
                     "type": "postcode",
                     "key": "nicePostcode",
+                    "label": "nicePostcode",
                     "validate": {
                         "custom": "",
                         "unique": False,
@@ -1166,6 +1211,7 @@ class ComponentModificationTests(TestCase):
                     },
                     {
                         "key": "container",
+                        "label": "container",
                         "type": "fieldset",
                         "hidden": False,
                         "components": [
@@ -1179,11 +1225,13 @@ class ComponentModificationTests(TestCase):
                                 "type": "coSign",
                                 "key": "coSign",
                                 "label": "Cosign",
+                                "authPlugin": "digid",
                             },
                             {
                                 "type": "softRequiredErrors",
                                 "key": "softRequiredErrors",
                                 "label": "Errors",
+                                "html": "<p>Errors</p>",
                             },
                         ],
                     },
@@ -1242,8 +1290,10 @@ class ComponentModificationTests(TestCase):
                     },
                     {
                         "key": "editgridHiddenByDefault",
+                        "label": "editgridHiddenByDefault",
                         "type": "editgrid",
                         "hidden": True,
+                        "groupLabel": "item",
                         "components": [
                             {
                                 "type": "textfield",
@@ -1261,8 +1311,10 @@ class ComponentModificationTests(TestCase):
                     },
                     {
                         "key": "editgridShownByDefault",
+                        "label": "editgridShownByDefault",
                         "type": "editgrid",
                         "hidden": False,
+                        "groupLabel": "item",
                         "components": [
                             {
                                 "type": "number",

--- a/src/openforms/submissions/tests/form_logic/test_modify_step.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_step.py
@@ -22,6 +22,7 @@ class StepModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "step1_textfield1",
+                        "label": "step1_textfield1",
                     }
                 ]
             },
@@ -33,6 +34,7 @@ class StepModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "step2_textfield1",
+                        "label": "step2_textfield1",
                     }
                 ]
             },
@@ -83,6 +85,7 @@ class StepModificationTests(TestCase):
                     {
                         "type": "number",
                         "key": "age",
+                        "label": "age",
                     }
                 ]
             },
@@ -94,6 +97,7 @@ class StepModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "driverId",
+                        "label": "driverId",
                     }
                 ]
             },
@@ -148,6 +152,7 @@ class StepModificationTests(TestCase):
                     {
                         "type": "number",
                         "key": "age",
+                        "label": "age",
                     }
                 ]
             },
@@ -159,6 +164,7 @@ class StepModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "driverId",
+                        "label": "driverId",
                     }
                 ]
             },
@@ -217,6 +223,7 @@ class StepModificationTests(TestCase):
                     {
                         "type": "date",
                         "key": "dateOfBirth",
+                        "label": "dateOfBirth",
                     }
                 ]
             },
@@ -261,6 +268,7 @@ class StepModificationTests(TestCase):
                     {
                         "type": "date",
                         "key": "dateOfBirth",
+                        "label": "dateOfBirth",
                     }
                 ]
             },
@@ -307,6 +315,7 @@ class StepModificationTests(TestCase):
                     {
                         "type": "selectboxes",
                         "key": "currentPets",
+                        "label": "currentPets",
                         "values": [
                             {"label": "Cat", "value": "cat"},
                             {"label": "Dog", "value": "dog"},
@@ -357,6 +366,7 @@ class StepModificationTests(TestCase):
                     {
                         "type": "selectboxes",
                         "key": "current.pets",
+                        "label": "current.pets",
                         "values": [
                             {"label": "Cat", "value": "cat"},
                             {"label": "Dog", "value": "dog"},
@@ -403,7 +413,13 @@ class StepModificationTests(TestCase):
         step = FormStepFactory.create(
             form=form,
             form_definition__configuration={
-                "components": [{"key": "normal.component", "type": "textfield"}]
+                "components": [
+                    {
+                        "key": "normal.component",
+                        "label": "normal.component",
+                        "type": "textfield",
+                    }
+                ]
             },
         )
         FormLogicFactory.create(
@@ -448,6 +464,7 @@ class StepModificationTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "name",
+                        "label": "name",
                     },
                 ]
             },
@@ -475,6 +492,7 @@ class StepModificationTests(TestCase):
                     {
                         "type": "datetime",
                         "key": "startOfConstructionWorks",
+                        "label": "startOfConstructionWorks",
                     }
                 ]
             },

--- a/src/openforms/submissions/tests/form_logic/test_modify_variables.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_variables.py
@@ -29,10 +29,12 @@ class VariableModificationTests(TestCase):
                     {
                         "type": "number",
                         "key": "nLargeBoxes",
+                        "label": "nLargeBoxes",
                     },
                     {
                         "type": "number",
                         "key": "nGiganticBoxes",
+                        "label": "nGiganticBoxes",
                     },
                 ]
             },
@@ -103,9 +105,11 @@ class VariableModificationTests(TestCase):
                     {
                         "type": "editgrid",
                         "key": "cars",
+                        "label": "cars",
+                        "groupLabel": "item",
                         "components": [
-                            {"type": "textfield", "key": "colour"},
-                            {"type": "number", "key": "price"},
+                            {"type": "textfield", "key": "colour", "label": "colour"},
+                            {"type": "number", "key": "price", "label": "price"},
                         ],
                     },
                 ]
@@ -208,6 +212,7 @@ class VariableModificationTests(TestCase):
                     {
                         "type": "date",
                         "key": "datum",
+                        "label": "datum",
                     },
                 ]
             },
@@ -281,14 +286,17 @@ class VariableModificationTests(TestCase):
                     {
                         "type": "number",
                         "key": "age",
+                        "label": "age",
                     },
                     {
                         "type": "number",
                         "key": "income",
+                        "label": "income",
                     },
                     {
                         "type": "checkbox",
                         "key": "canApply",
+                        "label": "canApply",
                     },
                 ]
             },
@@ -379,29 +387,35 @@ class VariableModificationTests(TestCase):
                     {
                         "key": "container1",
                         "type": "fieldset",
+                        "label": "fieldset",
                         "components": [
                             {
                                 "type": "number",
+                                "label": "number",
                                 "key": "age",
                             }
                         ],
                     },
                     {
                         "type": "columns",
+                        "label": "columns",
                         "key": "container2",
                         "columns": [
                             {
+                                "size": 12,
                                 "components": [
                                     {
                                         "type": "number",
+                                        "label": "number",
                                         "key": "income",
                                     }
-                                ]
+                                ],
                             }
                         ],
                     },
                     {
                         "type": "checkbox",
+                        "label": "checkbox",
                         "key": "yo.im.nested.canApply",
                     },
                 ]
@@ -492,10 +506,12 @@ class VariableModificationTests(TestCase):
                     {
                         "type": "number",
                         "key": "age",
+                        "label": "age",
                     },
                     {
                         "type": "number",
                         "key": "income",
+                        "label": "income",
                     },
                 ]
             },
@@ -618,6 +634,7 @@ class VariableModificationTests(TestCase):
                     {
                         "type": "children",
                         "key": "children",
+                        "label": "children",
                         "enableSelection": False,
                     },
                 ]
@@ -630,10 +647,16 @@ class VariableModificationTests(TestCase):
                     {
                         "type": "editgrid",
                         "key": "editgrid",
+                        "label": "editgrid",
+                        "groupLabel": "item",
                         "components": [
-                            {"type": "bsn", "key": "bsn"},
-                            {"type": "textfield", "key": "childName"},
-                            {"type": "textfield", "key": "affixes"},
+                            {"type": "bsn", "key": "bsn", "label": "bsn"},
+                            {
+                                "type": "textfield",
+                                "key": "childName",
+                                "label": "childName",
+                            },
+                            {"type": "textfield", "key": "affixes", "label": "affixes"},
                         ],
                     }
                 ]
@@ -755,6 +778,7 @@ class VariableModificationTests(TestCase):
                     {
                         "type": "children",
                         "key": "children",
+                        "label": "children",
                         "enableSelection": True,
                     },
                 ]
@@ -767,9 +791,15 @@ class VariableModificationTests(TestCase):
                     {
                         "type": "editgrid",
                         "key": "editgrid",
+                        "label": "editgrid",
+                        "groupLabel": "item",
                         "components": [
-                            {"type": "bsn", "key": "bsn"},
-                            {"type": "textfield", "key": "childName"},
+                            {"type": "bsn", "key": "bsn", "label": "bsn"},
+                            {
+                                "type": "textfield",
+                                "key": "childName",
+                                "label": "childName",
+                            },
                         ],
                     }
                 ]
@@ -886,6 +916,7 @@ class VariableModificationTests(TestCase):
                     {
                         "type": "children",
                         "key": "children",
+                        "label": "children",
                         "enableSelection": True,
                     },
                 ]
@@ -898,9 +929,19 @@ class VariableModificationTests(TestCase):
                     {
                         "type": "editgrid",
                         "key": "editgrid",
+                        "label": "editgrid",
+                        "groupLabel": "item",
                         "components": [
-                            {"type": "bsn", "key": "bsn"},
-                            {"type": "textfield", "key": "childName"},
+                            {
+                                "type": "bsn",
+                                "key": "bsn",
+                                "label": "bsn",
+                            },
+                            {
+                                "type": "textfield",
+                                "key": "childName",
+                                "label": "childName",
+                            },
                         ],
                     }
                 ]
@@ -1029,6 +1070,7 @@ class VariableModificationTests(TestCase):
                     {
                         "type": "children",
                         "key": "children",
+                        "label": "children",
                         "enableSelection": True,
                     },
                 ]
@@ -1041,9 +1083,19 @@ class VariableModificationTests(TestCase):
                     {
                         "type": "editgrid",
                         "key": "editgrid",
+                        "label": "editgrid",
+                        "groupLabel": "item",
                         "components": [
-                            {"type": "bsn", "key": "bsn"},
-                            {"type": "textfield", "key": "childName"},
+                            {
+                                "type": "bsn",
+                                "key": "bsn",
+                                "label": "bsn",
+                            },
+                            {
+                                "type": "textfield",
+                                "key": "childName",
+                                "label": "childName",
+                            },
                         ],
                     }
                 ]

--- a/src/openforms/submissions/tests/form_logic/test_side_effects.py
+++ b/src/openforms/submissions/tests/form_logic/test_side_effects.py
@@ -27,6 +27,7 @@ class SideEffectTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "radio",
                         "key": "step1",
+                        "label": "step1",
                         "values": [
                             {"label": "A", "value": "a"},
                             {"label": "B", "value": "b"},
@@ -42,6 +43,7 @@ class SideEffectTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "step2",
+                        "label": "step2",
                     }
                 ]
             },
@@ -134,6 +136,7 @@ class SideEffectTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "fieldA",
+                        "label": "fieldA",
                     }
                 ]
             },
@@ -145,6 +148,7 @@ class SideEffectTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "fieldB",
+                        "label": "fieldB",
                     }
                 ]
             },

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -33,6 +33,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "number",
                         "key": "age",
+                        "label": "age",
                     }
                 ]
             },
@@ -44,6 +45,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "driverId",
+                        "label": "driverId",
                     }
                 ]
             },
@@ -105,6 +107,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "text1",
+                        "label": "text1",
                     }
                 ]
             },
@@ -242,6 +245,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "text1",
+                        "label": "text1",
                     }
                 ]
             },
@@ -253,6 +257,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "text2",
+                        "label": "text2",
                     }
                 ]
             },
@@ -349,6 +354,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "date",
                         "key": "dateOfBirth",
+                        "label": "dateOfBirth",
                     }
                 ]
             },
@@ -360,6 +366,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "driverId",
+                        "label": "driverId",
                     }
                 ]
             },
@@ -452,6 +459,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "date",
                         "key": "dateOfBirth",
+                        "label": "dateOfBirth",
                     }
                 ]
             },
@@ -463,6 +471,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "driving",
+                        "label": "driving",
                     }
                 ]
             },
@@ -515,16 +524,19 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "checkbox",
                         "key": "hide",
+                        "label": "hide",
                         "defaultValue": True,
                     },
                     {
                         "type": "textfield",
                         "key": "when-unchecked",
+                        "label": "when-unchecked",
                         "hidden": False,
                     },
                     {
                         "type": "textfield",
                         "key": "when-checked",
+                        "label": "when-checked",
                         "hidden": False,
                     },
                 ]
@@ -605,6 +617,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                 configuration["components"][1],
                 {
                     "key": "when-unchecked",
+                    "label": "when-unchecked",
                     "type": "textfield",
                     "hidden": True,
                 },
@@ -613,6 +626,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                 configuration["components"][2],
                 {
                     "key": "when-checked",
+                    "label": "when-checked",
                     "type": "textfield",
                     "hidden": False,
                 },
@@ -627,6 +641,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                 configuration["components"][1],
                 {
                     "key": "when-unchecked",
+                    "label": "when-unchecked",
                     "type": "textfield",
                     "hidden": False,
                 },
@@ -635,6 +650,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                 configuration["components"][2],
                 {
                     "key": "when-checked",
+                    "label": "when-checked",
                     "type": "textfield",
                     "hidden": True,
                 },
@@ -649,6 +665,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                 configuration["components"][1],
                 {
                     "key": "when-unchecked",
+                    "label": "when-unchecked",
                     "type": "textfield",
                     "hidden": True,
                 },
@@ -657,6 +674,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                 configuration["components"][2],
                 {
                     "key": "when-checked",
+                    "label": "when-checked",
                     "type": "textfield",
                     "hidden": False,
                 },
@@ -671,6 +689,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                 "components": [
                     {
                         "key": "radio",
+                        "label": "radio",
                         "type": "radio",
                         "values": [
                             {"label": "yes", "value": "yes"},
@@ -680,6 +699,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "testHidden",
+                        "label": "testHidden",
                         "hidden": True,
                         "clearOnHide": True,
                         "defaultValue": "",
@@ -715,6 +735,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                 "components": [
                     {
                         "key": "radio",
+                        "label": "radio",
                         "type": "radio",
                         "values": [
                             {"label": "show", "value": "show"},
@@ -723,16 +744,19 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     },
                     {
                         "key": "fieldset",
+                        "label": "fieldset",
                         "type": "fieldset",
                         "hidden": True,
                         "components": [
                             {
                                 "key": "textfield1",
+                                "label": "textfield1",
                                 "type": "textfield",
                                 "clearOnHide": True,
                             },
                             {
                                 "key": "textfield2",
+                                "label": "textfield2",
                                 "type": "textfield",
                                 "clearOnHide": False,
                             },
@@ -812,6 +836,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                 "components": [
                     {
                         "key": "radio",
+                        "label": "radio",
                         "type": "radio",
                         "values": [
                             {"label": "show", "value": "show"},
@@ -820,11 +845,13 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     },
                     {
                         "key": "fieldset",
+                        "label": "fieldset",
                         "type": "fieldset",
                         "hidden": True,
                         "components": [
                             {
                                 "key": "textfield",
+                                "label": "textfield",
                                 "type": "textfield",
                                 "clearOnHide": True,
                             },
@@ -832,7 +859,9 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     },
                     {
                         "key": "calculatedResult",
+                        "label": "calculatedResult",
                         "type": "fieldset",
+                        "components": [],
                     },
                 ]
             },
@@ -1015,6 +1044,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "date",
                         "key": "date",
+                        "label": "date",
                     },
                 ]
             },
@@ -1063,15 +1093,18 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "checkbox",
                         "key": "checkbox",
+                        "label": "checkbox",
                     },
                     {
                         "type": "fieldset",
                         "key": "fieldset",
+                        "label": "fieldset",
                         "hidden": False,
                         "components": [
                             {
                                 "type": "textfield",
                                 "key": "textfieldClientSide",
+                                "label": "textfieldClientSide",
                                 "hidden": True,
                                 "conditional": {
                                     "show": True,
@@ -1082,6 +1115,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                             {
                                 "type": "textfield",
                                 "key": "textfieldServerSide",
+                                "label": "textfieldServerSide",
                                 "hidden": True,
                             },
                         ],
@@ -1175,6 +1209,7 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
                         "type": "editgrid",
                         "key": "editgrid",
                         "label": "Edit grid",
+                        "groupLabel": "item",
                         "clearOnHide": False,
                         "components": [
                             {
@@ -1551,6 +1586,7 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
                     {
                         "type": "radio",
                         "key": "radio",
+                        "label": "radio",
                         "values": [
                             {"value": "a", "label": "A"},
                             {"value": "b", "label": "B"},
@@ -1559,6 +1595,7 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
                     {
                         "type": "textfield",
                         "key": "show-when-a",
+                        "label": "show-when-a",
                         "hidden": True,
                     },
                 ]
@@ -1622,6 +1659,7 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
                     {
                         "type": "radio",
                         "key": "radio",
+                        "label": "radio",
                         "values": [
                             {"value": "a", "label": "A"},
                             {"value": "b", "label": "B"},
@@ -1630,6 +1668,7 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
                     {
                         "type": "textfield",
                         "key": "show-when-a",
+                        "label": "show-when-a",
                         "hidden": True,
                     },
                 ]
@@ -1690,6 +1729,7 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
                     {
                         "type": "radio",
                         "key": "radio",
+                        "label": "radio",
                         "values": [
                             {"value": "a", "label": "A"},
                             {"value": "b", "label": "B"},
@@ -1698,20 +1738,24 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
                     {
                         "type": "checkbox",
                         "key": "checkbox",
+                        "label": "checkbox",
                     },
                     {
                         "type": "textfield",
                         "key": "hide-when-a-but-show-when-checkbox-checked",
+                        "label": "hide-when-a-but-show-when-checkbox-checked",
                         "hidden": False,
                     },
                     {
                         "type": "fieldset",
                         "key": "fieldset",
+                        "label": "fieldset",
                         "hidden": False,
                         "components": [
                             {
                                 "type": "textfield",
                                 "key": "nestedTextfield",
+                                "label": "nestedTextfield",
                                 "hidden": False,
                             }
                         ],
@@ -1719,6 +1763,7 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
                     {
                         "type": "textfield",
                         "key": "observer",
+                        "label": "observer",
                         "validate": {"required": False},
                     },
                 ]
@@ -1833,6 +1878,7 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
                     {
                         "type": "radio",
                         "key": "radio",
+                        "label": "radio",
                         "values": [
                             {"value": "a", "label": "A"},
                             {"value": "b", "label": "B"},
@@ -1841,20 +1887,24 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
                     {
                         "type": "checkbox",
                         "key": "checkbox",
+                        "label": "checkbox",
                     },
                     {
                         "type": "textfield",
                         "key": "hide-when-a-but-show-when-checkbox-checked",
+                        "label": "hide-when-a-but-show-when-checkbox-checked",
                         "hidden": True,
                     },
                     {
                         "type": "fieldset",
                         "key": "fieldset",
+                        "label": "fieldset",
                         "hidden": True,
                         "components": [
                             {
                                 "type": "textfield",
                                 "key": "nestedTextfield",
+                                "label": "nestedTextfield",
                                 "hidden": False,
                             }
                         ],
@@ -1862,6 +1912,7 @@ class MultipleRulesTargettingSameComponentVisibilityTests(
                     {
                         "type": "textfield",
                         "key": "observer",
+                        "label": "observer",
                         "validate": {"required": False},
                     },
                 ]
@@ -1994,11 +2045,13 @@ class EvaluateLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "name",
+                        "label": "name",
                         "defaultValue": "some-default",
                     },
                     {
                         "type": "textfield",
                         "key": "optional",
+                        "label": "optional",
                         "hidden": False,
                     },
                 ]
@@ -2039,6 +2092,7 @@ class EvaluateLogicSubmissionTest(SubmissionsMixin, APITestCase):
             configuration["components"][1],
             {
                 "key": "optional",
+                "label": "optional",
                 "type": "textfield",
                 "hidden": True,
             },
@@ -2052,6 +2106,7 @@ class EvaluateLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "number",
                         "key": "number1",
+                        "label": "number1",
                     },
                 ]
             },
@@ -2101,10 +2156,12 @@ class EvaluateLogicSubmissionTest(SubmissionsMixin, APITestCase):
                     {
                         "type": "number",
                         "key": "number1",
+                        "label": "number1",
                     },
                     {
                         "type": "number",
                         "key": "number2",
+                        "label": "number2",
                     },
                 ]
             },

--- a/src/openforms/submissions/tests/renderer/test_renderer.py
+++ b/src/openforms/submissions/tests/renderer/test_renderer.py
@@ -33,6 +33,7 @@ class FormNodeTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "input1",
+                        "label": "input1",
                     }
                 ]
             },
@@ -45,6 +46,7 @@ class FormNodeTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "input2",
+                        "label": "input2",
                     }
                 ]
             },

--- a/src/openforms/submissions/tests/renderer/test_submission_summary.py
+++ b/src/openforms/submissions/tests/renderer/test_submission_summary.py
@@ -154,6 +154,7 @@ class SubmissionSummaryRendererTests(TestCase):
                         "key": "repeatingGroup",
                         "type": "editgrid",
                         "label": "Repeating Group",
+                        "groupLabel": "item",
                         "components": [
                             {
                                 "key": "someText",
@@ -210,6 +211,7 @@ class SubmissionSummaryRendererTests(TestCase):
                         "key": "repeatingGroup",
                         "type": "editgrid",
                         "label": "Repeating Group",
+                        "groupLabel": "item",
                         "components": [
                             {
                                 "key": "radioCondition",
@@ -279,6 +281,7 @@ class SubmissionSummaryRendererTests(TestCase):
                         "key": "container.repeatingGroup",
                         "type": "editgrid",
                         "label": "Repeating Group",
+                        "groupLabel": "item",
                         "components": [
                             {
                                 "key": "radioCondition",
@@ -378,6 +381,7 @@ class SubmissionSummaryRendererTests(TestCase):
                         "key": "container.repeatingGroup",
                         "type": "editgrid",
                         "label": "Repeating Group",
+                        "groupLabel": "item",
                         "components": [
                             {
                                 "key": "selectboxesCondition",
@@ -467,6 +471,7 @@ class SubmissionSummaryRendererTests(TestCase):
                         "type": "content",
                         "label": "Content",
                         "html": "<p>Some data</p>",
+                        "showInSummary": True,
                     }
                 ]
             },

--- a/src/openforms/submissions/tests/test_admin.py
+++ b/src/openforms/submissions/tests/test_admin.py
@@ -309,6 +309,7 @@ class TestSubmissionAdmin(WebTest):
                     {
                         "type": "textfield",
                         "key": "text1",
+                        "label": "text1",
                     }
                 ]
             },

--- a/src/openforms/submissions/tests/test_admin_export.py
+++ b/src/openforms/submissions/tests/test_admin_export.py
@@ -23,13 +23,45 @@ class TestSubmissionExportAdmin(WebTest):
         form_definition = FormDefinitionFactory(
             configuration={
                 "components": [
-                    {"type": "textfield", "key": "adres"},
-                    {"type": "textfield", "key": "voornaam"},
-                    {"type": "textfield", "key": "familienaam"},
-                    {"type": "date", "key": "geboortedatum"},
-                    {"type": "signature", "key": "signature"},
-                    {"type": "textfield", "key": "multi_str", "multiple": True},
-                    {"type": "file", "key": "my_file"},
+                    {
+                        "type": "textfield",
+                        "key": "adres",
+                        "label": "adres",
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "voornaam",
+                        "label": "voornaam",
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "familienaam",
+                        "label": "familienaam",
+                    },
+                    {
+                        "type": "date",
+                        "key": "geboortedatum",
+                        "label": "geboortedatum",
+                    },
+                    {
+                        "type": "signature",
+                        "key": "signature",
+                        "label": "signature",
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "multi_str",
+                        "label": "multi_str",
+                        "multiple": True,
+                        "defaultValue": [],
+                    },
+                    {
+                        "type": "file",
+                        "key": "my_file",
+                        "label": "my_file",
+                        "file": {"type": []},
+                        "filePattern": "",
+                    },
                 ]
             }
         )

--- a/src/openforms/submissions/tests/test_authentication_requirements.py
+++ b/src/openforms/submissions/tests/test_authentication_requirements.py
@@ -44,6 +44,7 @@ class AuthOptionalTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "component1",
+                        "label": "component1",
                     }
                 ]
             },
@@ -125,6 +126,7 @@ class AuthRequiredTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "component1",
+                        "label": "component1",
                     }
                 ]
             },

--- a/src/openforms/submissions/tests/test_exports.py
+++ b/src/openforms/submissions/tests/test_exports.py
@@ -34,26 +34,31 @@ class ExportTests(TestCase):
                 {
                     "type": "textfield",
                     "key": "input1",
+                    "label": "input1",
                     "hidden": False,
                 },
                 {
                     "type": "textfield",
                     "key": "input2",
+                    "label": "input2",
                     "hidden": True,
                     "clearOnHide": False,
                 },
                 {
                     "type": "fieldset",
                     "key": "fieldset1",
+                    "label": "fieldset1",
                     "components": [
                         {
                             "type": "textfield",
                             "key": "input3",
+                            "label": "input3",
                             "hidden": False,
                         },
                         {
                             "type": "textfield",
                             "key": "input4",
+                            "label": "input4",
                             "hidden": True,
                             "clearOnHide": False,
                         },
@@ -62,6 +67,7 @@ class ExportTests(TestCase):
                 {
                     "type": "columns",
                     "key": "columns1",
+                    "label": "columns1",
                     "hidden": True,
                     "columns": [
                         {
@@ -70,6 +76,7 @@ class ExportTests(TestCase):
                                 {
                                     "type": "textfield",
                                     "key": "input5",
+                                    "label": "input5",
                                     "hidden": False,
                                     "clearOnHide": False,
                                 },
@@ -81,6 +88,7 @@ class ExportTests(TestCase):
                                 {
                                     "type": "textfield",
                                     "key": "input6",
+                                    "label": "input6",
                                     "hidden": True,
                                     "clearOnHide": False,
                                 },
@@ -91,6 +99,7 @@ class ExportTests(TestCase):
                 {
                     "type": "content",
                     "key": "content",
+                    "label": "content",
                     "html": "<p>Some wysigyg content</p>",
                 },
             ],
@@ -189,6 +198,7 @@ class ExportTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "input1",
+                        "label": "input1",
                     }
                 ]
             },
@@ -200,6 +210,7 @@ class ExportTests(TestCase):
                     {
                         "type": "textfield",
                         "key": "input2",
+                        "label": "input2",
                     }
                 ]
             },
@@ -281,6 +292,7 @@ class ExportTests(TestCase):
                         "type": "editgrid",
                         "key": "repeatingGroup",
                         "label": "Repeating group",
+                        "groupLabel": "item",
                         "components": [
                             {
                                 "type": "textfield",
@@ -328,6 +340,8 @@ class ExportTests(TestCase):
                         "key": "attachments",
                         "label": "Attachments",
                         "multiple": True,
+                        "file": {"type": []},
+                        "filePattern": "",
                     }
                 ]
             },

--- a/src/openforms/submissions/tests/test_submission_completion.py
+++ b/src/openforms/submissions/tests/test_submission_completion.py
@@ -168,6 +168,7 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "number",
                         "key": "age",
+                        "label": "age",
                     }
                 ]
             },
@@ -179,6 +180,7 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "driverId",
+                        "label": "driverId",
                     }
                 ]
             },
@@ -234,6 +236,7 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "number",
                         "key": "age",
+                        "label": "Age",
                     }
                 ]
             },
@@ -246,6 +249,7 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "number",
                         "key": "age",
+                        "label": "Age",
                     }
                 ]
             },
@@ -258,6 +262,7 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "radio",
                         "key": "questionInput",
+                        "label": "Question input",
                         "values": [
                             {"label": "Yes", "value": "yes"},
                             {
@@ -271,6 +276,7 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                         "type": "textfield",
                         "hidden": True,
                         "key": "driverId",
+                        "label": "Driver ID",
                         "validate": {
                             "required": True,
                         },
@@ -286,6 +292,7 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "driverId",
+                        "label": "Driver ID",
                     }
                 ]
             },
@@ -298,6 +305,7 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "driverId",
+                        "label": "Driver ID",
                     }
                 ]
             },
@@ -532,6 +540,7 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "testComponent",
+                        "label": "testComponent",
                     },
                 ]
             },
@@ -592,6 +601,7 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                     {
                         "key": "someCondition",
                         "type": "radio",
+                        "label": "someCondition",
                         "values": [
                             {"label": "A", "value": "a"},
                             {"label": "B", "value": "b"},
@@ -738,12 +748,14 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                     {
                         "key": "someCondition",
                         "type": "radio",
+                        "label": "someCondition",
                         "openForms": {
                             "dataSrc": DataSrcOptions.variable,
                             "itemsExpression": [
                                 ["a", "A"],
                             ],
                         },
+                        "values": [],
                     },
                 ]
             },

--- a/src/openforms/submissions/tests/test_submission_step_validate.py
+++ b/src/openforms/submissions/tests/test_submission_step_validate.py
@@ -44,11 +44,16 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
                 "components": [
                     {
                         "key": "test-key",
+                        "label": "test-key",
                         "type": "textfield",
                     },
                     {
                         "key": "my_file",
+                        "label": "my_file",
                         "type": "file",
+                        "filePattern": "",
+                        "file": {"type": []},
+                        "url": "",
                     },
                 ]
             },
@@ -310,6 +315,7 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
                     {
                         "key": "fieldset",
                         "type": "fieldset",
+                        "label": "fieldset",
                         "hidden": True,
                         "components": [
                             {
@@ -491,6 +497,7 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
                 "components": [
                     {
                         "key": "time",
+                        "label": "time",
                         "type": "time",
                         "errors": {"invalid_time": "Invalid time! Oh no!"},
                     }
@@ -541,6 +548,7 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
                         "type": "editgrid",
                         "key": "repeatingGroup",
                         "label": "Repeating group",
+                        "groupLabel": "item",
                         "components": [
                             {
                                 "type": "number",
@@ -704,6 +712,7 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
                                         },
                                         "type": "file",
                                         "label": "File Upload 1",
+                                        "filePattern": "",
                                     },
                                 ],
                             },
@@ -719,6 +728,7 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
                                         },
                                         "type": "file",
                                         "label": "File Upload 2",
+                                        "filePattern": "",
                                     },
                                 ],
                             },
@@ -751,18 +761,21 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
             form_definition__configuration={
                 "components": [
                     {
-                        "key": "fieldset",
                         "type": "fieldset",
+                        "key": "fieldset",
+                        "label": "fieldset",
+                        "hideHeader": False,
                         "components": [
                             {
+                                "type": "file",
                                 "key": "fileUpload1",
+                                "label": "File Upload 1",
                                 "file": {
                                     "name": "",
                                     "type": [],
                                     "allowedTypesLabels": [],
                                 },
-                                "type": "file",
-                                "label": "File Upload 1",
+                                "filePattern": "",
                             },
                         ],
                     },
@@ -1435,6 +1448,7 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
                         "key": "textfield",
                         "label": "Textfield",
                         "multiple": True,
+                        "defaultValue": [],
                     },
                     {
                         "type": "radio",
@@ -1481,6 +1495,7 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
                 "components": [
                     {
                         "key": "profile",
+                        "label": "profile",
                         "type": "customerProfile",
                         "digitalAddressTypes": ["email", "phoneNumber"],
                         "shouldUpdateCustomerData": True,

--- a/src/openforms/submissions/tests/test_tasks_pdf.py
+++ b/src/openforms/submissions/tests/test_tasks_pdf.py
@@ -585,6 +585,7 @@ class SubmissionReportGenerationTests(TestCase):
                     "key": "repeatingGroup",
                     "type": "editgrid",
                     "label": "Repeating Group",
+                    "groupLabel": "Item",
                     "components": [
                         {
                             "type": "textfield",

--- a/src/openforms/submissions/tests/test_variables/test_num_queries.py
+++ b/src/openforms/submissions/tests/test_variables/test_num_queries.py
@@ -27,8 +27,8 @@ class SubmissionVariablesPerformanceTests(APITestCase):
             form=form,
             form_definition__configuration={
                 "components": [
-                    {"key": "var1", "type": "textfield"},
-                    {"key": "var2", "type": "textfield"},
+                    {"key": "var1", "label": "var1", "type": "textfield"},
+                    {"key": "var2", "label": "var2", "type": "textfield"},
                 ]
             },
         )
@@ -36,8 +36,8 @@ class SubmissionVariablesPerformanceTests(APITestCase):
             form=form,
             form_definition__configuration={
                 "components": [
-                    {"key": "var3", "type": "textfield"},
-                    {"key": "var4", "type": "textfield"},
+                    {"key": "var3", "label": "var3", "type": "textfield"},
+                    {"key": "var4", "label": "var4", "type": "textfield"},
                 ]
             },
         )
@@ -70,8 +70,8 @@ class SubmissionVariablesPerformanceTests(APITestCase):
             form=form,
             form_definition__configuration={
                 "components": [
-                    {"key": "var1", "type": "textfield"},
-                    {"key": "var2", "type": "textfield"},
+                    {"key": "var1", "label": "var1", "type": "textfield"},
+                    {"key": "var2", "label": "var2", "type": "textfield"},
                 ]
             },
         )
@@ -79,8 +79,8 @@ class SubmissionVariablesPerformanceTests(APITestCase):
             form=form,
             form_definition__configuration={
                 "components": [
-                    {"key": "var3", "type": "textfield"},
-                    {"key": "var4", "type": "textfield"},
+                    {"key": "var3", "label": "var3", "type": "textfield"},
+                    {"key": "var4", "label": "var4", "type": "textfield"},
                 ]
             },
         )

--- a/src/openforms/submissions/tests/test_variables/test_static_data.py
+++ b/src/openforms/submissions/tests/test_variables/test_static_data.py
@@ -84,6 +84,7 @@ class StaticVariablesTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "name",
+                        "label": "name",
                     },
                 ]
             },
@@ -136,6 +137,7 @@ class StaticVariablesTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "textfield",
                         "key": "name",
+                        "label": "name",
                     },
                 ]
             },

--- a/src/openforms/submissions/tests/test_variables/test_update_with_logic.py
+++ b/src/openforms/submissions/tests/test_variables/test_update_with_logic.py
@@ -28,12 +28,18 @@ class UpdateVariablesWithLogicTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "number",
                         "key": "nGreenApples",
+                        "label": "nGreenApples",
                     },
                     {
                         "type": "number",
                         "key": "nRedApples",
+                        "label": "nRedApples",
                     },
-                    {"type": "number", "key": "totApples"},
+                    {
+                        "type": "number",
+                        "key": "totApples",
+                        "label": "totApples",
+                    },
                 ]
             },
         )
@@ -103,14 +109,28 @@ class UpdateVariablesWithLogicTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "number",
                         "key": "nGreenApples",
+                        "label": "nGreenApples",
                     },
                     {
                         "type": "number",
                         "key": "nRedApples",
+                        "label": "nRedApples",
                     },
-                    {"type": "number", "key": "totApples"},
-                    {"type": "number", "key": "nPeaches"},
-                    {"type": "number", "key": "totFruit"},
+                    {
+                        "type": "number",
+                        "key": "totApples",
+                        "label": "totApples",
+                    },
+                    {
+                        "type": "number",
+                        "key": "nPeaches",
+                        "label": "nPeaches",
+                    },
+                    {
+                        "type": "number",
+                        "key": "totFruit",
+                        "label": "totFruit",
+                    },
                 ]
             },
         )
@@ -222,14 +242,28 @@ class UpdateVariablesWithLogicTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "number",
                         "key": "nGreenApples",
+                        "label": "nGreenApples",
                     },
                     {
                         "type": "number",
                         "key": "nRedApples",
+                        "label": "nRedApples",
                     },
-                    {"type": "number", "key": "totApples"},
-                    {"type": "number", "key": "nPeaches"},
-                    {"type": "number", "key": "totFruit"},
+                    {
+                        "type": "number",
+                        "key": "totApples",
+                        "label": "totApples",
+                    },
+                    {
+                        "type": "number",
+                        "key": "nPeaches",
+                        "label": "nPeaches",
+                    },
+                    {
+                        "type": "number",
+                        "key": "totFruit",
+                        "label": "totFruit",
+                    },
                 ]
             },
         )
@@ -319,10 +353,12 @@ class UpdateVariablesWithLogicTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "number",
                         "key": "nGreenApples",
+                        "label": "nGreenApples",
                     },
                     {
                         "type": "number",
                         "key": "nRedApples",
+                        "label": "nRedApples",
                     },
                 ]
             },
@@ -331,8 +367,8 @@ class UpdateVariablesWithLogicTests(SubmissionsMixin, APITestCase):
             form=form,
             form_definition__configuration={
                 "components": [
-                    {"type": "number", "key": "nPeaches"},
-                    {"type": "number", "key": "totFruit"},
+                    {"type": "number", "key": "nPeaches", "label": "nPeaches"},
+                    {"type": "number", "key": "totFruit", "label": "totFruit"},
                 ]
             },
         )
@@ -417,10 +453,12 @@ class UpdateVariablesWithLogicTests(SubmissionsMixin, APITestCase):
                     {
                         "type": "number",
                         "key": "nGreenApples",
+                        "label": "nGreenApples",
                     },
                     {
                         "type": "number",
                         "key": "nRedApples",
+                        "label": "nRedApples",
                     },
                 ]
             },

--- a/src/openforms/upgrades/tests/test_upgrade_paths.py
+++ b/src/openforms/upgrades/tests/test_upgrade_paths.py
@@ -109,7 +109,14 @@ class ReportLogicWithDeprecatedClearOnHideBehaviorTests(ParametrizedTestCase, Te
                     {
                         "type": "fieldset",
                         "key": "fieldset",
-                        "components": [{"type": "textfield", "key": "textfield"}],
+                        "label": "fieldset",
+                        "components": [
+                            {
+                                "type": "textfield",
+                                "key": "textfield",
+                                "label": "textfield",
+                            }
+                        ],
                     }
                 ]
             },


### PR DESCRIPTION
Extracted from the msgspec branch where strict parsing of the component definitions crashes/throws validation errors. These changes should not cause failures on main.

[skip: e2e]