### PR TITLE
Fix translations not being "activated" for forms that use client-side logic evaluation

### DIFF
--- a/src/openforms/formio/tests/test_component_translations.py
+++ b/src/openforms/formio/tests/test_component_translations.py
@@ -18,7 +18,7 @@ from ..datastructures import FormioConfigurationWrapper
 from ..formatters.tests.utils import load_json
 from ..registry import register
 from ..service import get_dynamic_configuration
-from ..typing import RadioComponent, SelectComponent
+from ..typing import AddressNLComponent, RadioComponent, SelectComponent
 
 
 def disable_prefill_injection():
@@ -1017,3 +1017,30 @@ class EditGridTranslationTests(SimpleTestCase):
         self.assertNotIn("translations", component["openForms"])
         nested = component["components"][0]
         self.assertEqual(nested["label"], "Textfield")
+
+
+class AddressNLTranslationTests(SimpleTestCase):
+    @given(
+        lang_code=language_code,
+        prop=...,
+        translation=st.text(min_size=1),
+    )
+    def test_translatable_properties_adddressnl(
+        self,
+        lang_code: str,
+        prop: Literal["label", "description", "tooltip"],
+        translation: str,
+    ):
+        component: AddressNLComponent = {
+            "type": "addressNL",
+            "key": "addressNL",
+            "label": "Must always have a label",
+            prop: f"Default {prop} value",
+            "openForms": {"translations": {lang_code: {prop: translation}}},
+            "deriveAddress": False,
+        }
+
+        register.localize_component(component, lang_code, enabled=True)
+
+        self.assertEqual(component.get(prop), translation)
+        self.assertNotIn("translations", component["openForms"])

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -28,6 +28,7 @@ from openforms.formio.api.fields import FormioDataField
 from openforms.formio.service import (
     FormioData,
     build_serializer,
+    get_dynamic_configuration,
     rewrite_formio_components_for_request,
 )
 from openforms.formio.utils import iter_components
@@ -400,6 +401,21 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
             wrapper = deepcopy(instance.form_step.form_definition.configuration_wrapper)
             rewrite_formio_components_for_request(
                 wrapper, request=self.context["request"]
+            )
+            variables_state = instance.submission.variables_state
+            wrapper = get_dynamic_configuration(
+                wrapper,
+                submission=instance.submission,
+                # dynamic formio component configuration may depend on filled out data,
+                # but those cases should land us in the 'require backend' mode for the
+                # logic check and then this whole code branch is irrelevant. However,
+                # static variables can be used as input as well for some dynamic
+                # evaluation, most notably the future/past modes of date/datetime
+                # fields, so we pass a minimal view of the submission data.
+                data=variables_state.get_data(
+                    include_static_variables=True,
+                    include_unsaved=False,
+                ),
             )
             default_configuration = wrapper.configuration
 

--- a/src/openforms/submissions/tests/test_get_submission_step.py
+++ b/src/openforms/submissions/tests/test_get_submission_step.py
@@ -132,6 +132,7 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
         }
         self.assertEqual(response.json(), expected)
 
+    @tag("gh-6320")
     def test_dynamic_form_definition(self):
         register = ComponentRegistry()
         register("selectboxes")(SelectBoxes)
@@ -160,7 +161,7 @@ class ReadSubmissionStepTests(SubmissionsMixin, APITestCase):
             "defaultConfiguration": {
                 "components": [
                     {
-                        "label": "Some field",
+                        "label": "Rewritten label",
                         "key": "someField",
                         "type": "textfield",
                     },
@@ -458,6 +459,7 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
         self.assertEqual(textfield["key"], "bar")
         self.assertEqual(textfield["label"], "Kneipe")
 
+    @tag("gh-6320")
     def test_component_properties_are_translated(self):
         submission = SubmissionFactory.create(
             language_code="en",
@@ -554,39 +556,47 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
             },
         )
 
-        configuration = self.client.get(endpoint).json()["configuration"]
+        response_data = self.client.get(endpoint).json()
 
-        wrapped_configuration = FormioConfigurationWrapper(configuration)
-        expected = {
-            "repeatingGroup1": {
-                "label": "Repeating group 1",
-                "tooltip": "First tip",
-                "groupLabel": "Item",
-            },
-            "text1": {
-                "label": "Text 1",
-            },
-        }
+        for _configuration in ("configuration", "defaultConfiguration"):
+            with self.subTest(configuration=_configuration):
+                configuration = response_data[_configuration]
+                wrapped_configuration = FormioConfigurationWrapper(configuration)
+                expected = {
+                    "repeatingGroup1": {
+                        "label": "Repeating group 1",
+                        "tooltip": "First tip",
+                        "groupLabel": "Item",
+                    },
+                    "text1": {
+                        "label": "Text 1",
+                    },
+                }
 
-        for key, translations in expected.items():
-            for prop, text in translations.items():
-                with self.subTest(component=key, property=prop, expected=text):
-                    component = wrapped_configuration[key]
+                for key, translations in expected.items():
+                    for prop, text in translations.items():
+                        with self.subTest(component=key, property=prop, expected=text):
+                            component = wrapped_configuration[key]
 
-                    self.assertEqual(component[prop], text)
+                            self.assertEqual(component[prop], text)
 
-        self.assertEqual(wrapped_configuration["radio1"]["values"][0]["label"], "One")
-        self.assertEqual(
-            wrapped_configuration["radio1"]["tooltip"],
-            "Radio Giraffe's tip of the week",
-        )
-        self.assertEqual(
-            wrapped_configuration["select1"]["data"]["values"][0]["label"], "1st Choice"
-        )
+                self.assertEqual(
+                    wrapped_configuration["radio1"]["values"][0]["label"], "One"
+                )
+                self.assertEqual(
+                    wrapped_configuration["radio1"]["tooltip"],
+                    "Radio Giraffe's tip of the week",
+                )
+                self.assertEqual(
+                    wrapped_configuration["select1"]["data"]["values"][0]["label"],
+                    "1st Choice",
+                )
 
-        # assert translation doesn't invent attributes.
-        self.assertNotIn("label", wrapped_configuration["radio1"]["values"][1])
-        self.assertNotIn("label", wrapped_configuration["select1"]["data"]["values"][1])
+                # assert translation doesn't invent attributes.
+                self.assertNotIn("label", wrapped_configuration["radio1"]["values"][1])
+                self.assertNotIn(
+                    "label", wrapped_configuration["select1"]["data"]["values"][1]
+                )
 
     def test_dynamic_date_component_config_based_on_variables(self):
         form = FormFactory.create(

--- a/src/openforms/submissions/tests/test_get_submission_step.py
+++ b/src/openforms/submissions/tests/test_get_submission_step.py
@@ -1071,8 +1071,17 @@ class IntegrationTests(SubmissionsMixin, APITestCase, HypothesisTestCase):  # py
             "slug": step.slug,
             "defaultConfiguration": {
                 "components": [
-                    {"type": "date", "key": "dateOfBirth", "label": "Date of birth"},
-                    {"type": "textfield", "key": "textfield", "label": "Textfield"},
+                    {
+                        "type": "date",
+                        "key": "dateOfBirth",
+                        "label": "Date of birth",
+                        "placeholder": "dd-mm-jjjj",
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "textfield",
+                        "label": "Textfield",
+                    },
                 ]
             },
             "configuration": {

--- a/src/openforms/submissions/tests/test_get_submission_step.py
+++ b/src/openforms/submissions/tests/test_get_submission_step.py
@@ -10,12 +10,16 @@ aware step definition.
 """
 
 import uuid
+from datetime import datetime
+from typing import Literal
 from unittest.mock import patch
 
 from django.test import tag
 from django.utils.translation import gettext_lazy as _
 
 from freezegun import freeze_time
+from hypothesis import given
+from hypothesis.extra.django import TestCase as HypothesisTestCase
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
@@ -426,7 +430,7 @@ class GetSubmissionStepTests(SubmissionsMixin, APITestCase):
         self.assertEqual(status.HTTP_200_OK, response.status_code)
 
 
-class IntegrationTests(SubmissionsMixin, APITestCase):
+class IntegrationTests(SubmissionsMixin, APITestCase, HypothesisTestCase):  # pyright: ignore[reportIncompatibleVariableOverride]
     """
     Integration tests where various subsystems come together.
     """
@@ -597,6 +601,56 @@ class IntegrationTests(SubmissionsMixin, APITestCase):
                 self.assertNotIn(
                     "label", wrapped_configuration["select1"]["data"]["values"][1]
                 )
+
+    @tag("gh-6320")
+    @given(mode=..., include_today=...)
+    def test_date_component_dynamic_config_correctly_emitted(
+        self,
+        mode: Literal["past", "future"],
+        include_today: bool,
+    ):
+        config_option = "minDate" if mode == "future" else "maxDate"
+        submission = SubmissionFactory.create(
+            form__generate_minimal_setup=True,
+            form__formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "date",
+                        "key": "date",
+                        "label": "date",
+                        "openForms": {
+                            config_option: {
+                                "mode": mode,
+                                "includeToday": include_today,
+                            }
+                        },
+                    },
+                ]
+            },
+        )
+
+        self._add_submission_to_session(submission)
+        form_step = submission.steps[0].form_step
+        endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={
+                "submission_uuid": submission.uuid,
+                "step_uuid": form_step.uuid,
+            },
+        )
+
+        response_data = self.client.get(endpoint).json()
+
+        self.assertFalse(response_data["requireBackendLogicEvaluation"])
+        default_configuration = response_data["defaultConfiguration"]
+        self.assertIsNotNone(default_configuration)
+        component = default_configuration["components"][0]
+        resolved_date = component["datePicker"][config_option]
+        self.assertIsNotNone(resolved_date)
+        self.assertIsInstance(
+            datetime.fromisoformat(resolved_date),
+            datetime,
+        )
 
     def test_dynamic_date_component_config_based_on_variables(self):
         form = FormFactory.create(


### PR DESCRIPTION
Closes #6320

**Changes**

* Added missing test
* Added regression test
* Ensure formio-level translations are applied for the `defaultConfiguration` which is used by the SDK if backend logic evaluation is not necessary

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
