### PR TITLE
Fix missing translated validation errors for `addressNL` component

### DIFF
--- a/src/openforms/formio/dynamic_config/__init__.py
+++ b/src/openforms/formio/dynamic_config/__init__.py
@@ -56,13 +56,46 @@ def get_translated_custom_error_messages(
     config_wrapper: FormioConfigurationWrapper, language_code: str
 ) -> FormioConfigurationWrapper:
     for component in config_wrapper:
-        if (
-            not (custom_error_messages := component.get("translatedErrors"))
-            or "errors" in component
-        ):
-            continue
+        # generic mechanism
+        match component:
+            # if there are already errors in the component definition, do not overwrite
+            case {"errors": dict()}:
+                pass
 
-        component["errors"] = custom_error_messages[language_code]
+            # grab the language-specific error messages if they're available and store
+            # them in the resolved errors property
+            case {"translatedErrors": dict(errors_by_language_code)} if (
+                custom_error_messages := errors_by_language_code.get(language_code)
+            ):
+                component["errors"] = custom_error_messages
+
+        # TODO: the msgspec branch is probably the right opportunity to rectify the
+        # component-specific processing. For this hook, there's no matching registry/
+        # plugin hook.
+
+        match component:
+            case {
+                "type": "addressNL",
+                "openForms": {"components": dict(addressnl_components)},
+            } if addressnl_components:
+                for key in ("postcode", "city"):
+                    if not (component_config := addressnl_components.get(key)):
+                        continue
+                    if component_config.get("errors"):
+                        continue
+                    if not (
+                        errors_by_language_code := component_config.get(
+                            "translatedErrors"
+                        )
+                    ):
+                        continue
+                    if not (
+                        custom_error_messages := errors_by_language_code.get(
+                            language_code
+                        )
+                    ):
+                        continue
+                    component_config["errors"] = custom_error_messages
 
     return config_wrapper
 

--- a/src/openforms/formio/dynamic_config/tests/test_custom_errors.py
+++ b/src/openforms/formio/dynamic_config/tests/test_custom_errors.py
@@ -1,12 +1,16 @@
 from django.test import TestCase
 
+from glom import glom
+from unittest_parametrize import ParametrizedTestCase, parametrize
+
+from openforms.formio.typing import AddressNLComponent
 from openforms.submissions.tests.factories import SubmissionFactory
 
 from ...datastructures import FormioConfigurationWrapper
 from .. import get_translated_custom_error_messages
 
 
-class ComponentWithCustomErrorsTests(TestCase):
+class ComponentWithCustomErrorsTests(ParametrizedTestCase, TestCase):
     def test_no_translated_errors(self):
         config = {
             "components": [
@@ -96,3 +100,105 @@ class ComponentWithCustomErrorsTests(TestCase):
                 "test": "test",
             },
         )
+
+    def test_addressnl_custom_error_messages(self):
+        component: AddressNLComponent = {
+            "key": "addressNL",
+            "type": "addressNL",
+            "label": "Address",
+            "deriveAddress": True,
+            "openForms": {
+                "components": {
+                    "city": {
+                        "validate": {"pattern": ""},
+                        "translatedErrors": {
+                            "en": {"pattern": "Custom city error"},
+                            "nl": {"pattern": ""},
+                        },
+                    },
+                    "postcode": {
+                        "validate": {"pattern": ""},
+                        "translatedErrors": {
+                            "en": {"pattern": "Custom postcode error"},
+                            "nl": {"pattern": ""},
+                        },
+                    },
+                },
+            },
+        }
+
+        get_translated_custom_error_messages(
+            FormioConfigurationWrapper({"components": [component]}), "en"
+        )
+
+        assert "errors" in component["openForms"]["components"]["city"]
+        self.assertEqual(
+            component["openForms"]["components"]["city"]["errors"],
+            {"pattern": "Custom city error"},
+        )
+        assert "errors" in component["openForms"]["components"]["postcode"]
+        self.assertEqual(
+            component["openForms"]["components"]["postcode"]["errors"],
+            {"pattern": "Custom postcode error"},
+        )
+
+    def test_addressnl_custom_error_messages_noop(self):
+        component: AddressNLComponent = {
+            "key": "addressNL",
+            "type": "addressNL",
+            "label": "Address",
+            "deriveAddress": True,
+            "openForms": {
+                "components": {
+                    "city": {
+                        "validate": {"pattern": ""},
+                        "errors": {"pattern": "no touch"},  # pyright: ignore[reportAssignmentType]
+                        "translatedErrors": {
+                            "en": {"pattern": "Custom city error"},
+                            "nl": {"pattern": ""},
+                        },
+                    },
+                },
+            },
+        }
+
+        get_translated_custom_error_messages(
+            FormioConfigurationWrapper({"components": [component]}), "en"
+        )
+
+        assert "openForms" in component
+        assert "components" in component["openForms"]
+        assert "city" in component["openForms"]["components"]
+        assert "errors" in component["openForms"]["components"]["city"]
+        self.assertEqual(
+            component["openForms"]["components"]["city"]["errors"],
+            {"pattern": "no touch"},
+        )
+
+    @parametrize(
+        "extensions_config",
+        [
+            None,
+            {"components": {}},
+            {"components": {"postcode": {}}},
+            {"components": {"postcode": {"validate": {"pattern": ""}}}},
+            {"components": {"postcode": {"translatedErrors": {}}}},
+            {"components": {"postcode": {"translatedErrors": {"en": {}}}}},
+        ],
+    )
+    def test_addressnl_custom_error_messages_missing_config(self, extensions_config):
+        component: AddressNLComponent = {
+            "key": "addressNL",
+            "type": "addressNL",
+            "label": "Address",
+            "deriveAddress": True,
+            "openForms": extensions_config,
+        }
+
+        get_translated_custom_error_messages(
+            FormioConfigurationWrapper({"components": [component]}), "en"
+        )
+
+        # assert that no translation is set
+        sub_component = glom(component, "openForms.components.postcode", default={})
+        self.assertNotIn("errors", sub_component)


### PR DESCRIPTION
Closes open-formulieren/formio-renderer#256 (partially)

**Changes**

The `translatedErrors` for the nested component configuration was not properly processed for the `addressNL` component, while the frontend code looks at the resulting `errors` property.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
