### PR TITLE
Make ordering explicit in test

### DIFF
--- a/src/openforms/prefill/contrib/objects_api/tests/test_prefill.py
+++ b/src/openforms/prefill/contrib/objects_api/tests/test_prefill.py
@@ -88,7 +88,7 @@ class ObjectsAPIPrefillPluginTests(OFVCRMixin, SubmissionsMixin, APITestCase):
         state = submission.variables_state
 
         self.assertEqual(TimelineLogProxy.objects.count(), 2)
-        ownership_check_log, prefill_log = TimelineLogProxy.objects.all()
+        ownership_check_log, prefill_log = TimelineLogProxy.objects.order_by("pk")
 
         self.assertEqual(
             ownership_check_log.extra_data["log_event"],
@@ -196,7 +196,7 @@ class ObjectsAPIPrefillPluginTests(OFVCRMixin, SubmissionsMixin, APITestCase):
         data = state.get_data(include_unsaved=True)
 
         self.assertEqual(TimelineLogProxy.objects.count(), 2)
-        ownership_check_log, prefill_log = TimelineLogProxy.objects.all()
+        ownership_check_log, prefill_log = TimelineLogProxy.objects.order_by("pk")
 
         self.assertEqual(
             ownership_check_log.extra_data["log_event"],


### PR DESCRIPTION
This is a test that's flaky in CI. The audit logs *are* expected in a particular order and the DB insertion order should match this.

[skip: e2e]