### PR TITLE
Address console warnings

### DIFF
--- a/src/openforms/conf/tinymce_config.json
+++ b/src/openforms/conf/tinymce_config.json
@@ -24,6 +24,7 @@
     "toolbar": "undo redo | blocks | bold italic backcolor | alignleft aligncenter alignright alignjustify | table bullist numlist outdent indent | link unlink removeformat | help",
     "content_style": "body { font-family:Helvetica,Arial,sans-serif; font-size:14px }",
     "default_link_target": "_blank",
+    "license_key": "gpl",
     "link_default_protocol": "https",
     "link_assume_external_targets": false,
     "convert_urls": false,

--- a/src/openforms/js/components/admin/form_design/FormConfigurationFields.js
+++ b/src/openforms/js/components/admin/form_design/FormConfigurationFields.js
@@ -789,7 +789,7 @@ FormConfigurationFields.propTypes = {
     askPrivacyConsent: statementChoices.isRequired,
     askStatementOfTruth: statementChoices.isRequired,
     appointmentOptions: PropTypes.shape({
-      supportsMultipleProducts: PropTypes.oneOfType([PropTypes.bool, null]),
+      supportsMultipleProducts: PropTypes.oneOfType([PropTypes.bool]),
     }),
     authBackends: PropTypes.arrayOf(
       PropTypes.shape({

--- a/src/openforms/js/components/admin/form_design/FormStepDefinition.js
+++ b/src/openforms/js/components/admin/form_design/FormStepDefinition.js
@@ -63,16 +63,17 @@ const FormStepDefinition = ({
   const isSingleStep = type === 'single_step';
 
   const setSlug = langCode => {
-    // // do nothing if there's already a slug set
-    // if (slug) return;
-    // // sort-of taken from Django's jquery prepopulate module
-    // const name = translations[langCode].name;
-    // onFieldChange({
-    //   target: {
-    //     name: 'slug',
-    //     value: slugify(name),
-    //   },
-    // });
+    // do nothing if there's already a slug set
+    if (slug) return;
+
+    // sort-of taken from Django's jquery prepopulate module
+    const name = translations[langCode].name;
+    onFieldChange({
+      target: {
+        name: 'slug',
+        value: slugify(name),
+      },
+    });
   };
 
   // A 'total configuration': merging all the configurations from the different steps, so that we can figure out if

--- a/src/openforms/js/components/admin/form_design/FormStepDefinition.js
+++ b/src/openforms/js/components/admin/form_design/FormStepDefinition.js
@@ -63,17 +63,16 @@ const FormStepDefinition = ({
   const isSingleStep = type === 'single_step';
 
   const setSlug = langCode => {
-    // do nothing if there's already a slug set
-    if (slug) return;
-
-    // sort-of taken from Django's jquery prepopulate module
-    const name = translations[langCode].name;
-    onFieldChange({
-      target: {
-        name: 'slug',
-        value: slugify(name),
-      },
-    });
+    // // do nothing if there's already a slug set
+    // if (slug) return;
+    // // sort-of taken from Django's jquery prepopulate module
+    // const name = translations[langCode].name;
+    // onFieldChange({
+    //   target: {
+    //     name: 'slug',
+    //     value: slugify(name),
+    //   },
+    // });
   };
 
   // A 'total configuration': merging all the configurations from the different steps, so that we can figure out if

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -86,6 +86,7 @@ import {
 const initialFormState = {
   form: {
     internalName: '',
+    internalRemarks: '',
     uuid: '',
     url: '',
     slug: '',
@@ -109,6 +110,7 @@ const initialFormState = {
     askStatementOfTruth: 'global_setting',
     registrationBackends: [],
     product: null,
+    priceVariableKey: '',
     paymentBackend: '',
     paymentBackendOptions: {},
     submissionsRemovalOptions: {},


### PR DESCRIPTION
These clutter my debugger :-)

* Fixed proptype definition bug
* Fixed defaults for new form which triggers proptype errors
* Added license key option to silence warning for TinyMCE. Note that we use TinyMCE 6 which is MIT licensed, so this is purely noise reduction.

[skip: e2e]