### PR TITLE
Fix browser crash/freeze on (new) step name edit

### DIFF
--- a/src/openforms/js/components/admin/form_design/FormStepDefinition.js
+++ b/src/openforms/js/components/admin/form_design/FormStepDefinition.js
@@ -65,6 +65,9 @@ const FormStepDefinition = ({
   const setSlug = langCode => {
     // do nothing if there's already a slug set
     if (slug) return;
+    // the slug is not translated, and based on the default language. Do nothing if
+    // we're not editing the targetting language.
+    if (langCode !== DEFAULT_LANGUAGE) return;
 
     // sort-of taken from Django's jquery prepopulate module
     const name = translations[langCode].name;
@@ -213,7 +216,6 @@ const FormStepDefinition = ({
                     />
                   }
                   required
-                  fieldBox
                 >
                   <TextInput
                     value={translations[langCode].name}
@@ -237,7 +239,6 @@ const FormStepDefinition = ({
                       description="Form step internal name field help text"
                     />
                   }
-                  fieldBox
                   disabled={langCode !== defaultLang}
                 >
                   <TextInput value={internalName} onChange={onFieldChange} />
@@ -259,7 +260,6 @@ const FormStepDefinition = ({
                     />
                   }
                   required
-                  fieldBox
                   disabled={langCode !== defaultLang}
                 >
                   <TextInput value={slug} onChange={onFieldChange} />
@@ -281,7 +281,6 @@ const FormStepDefinition = ({
                         description="Form step next text field help text"
                       />
                     }
-                    fieldBox
                   >
                     <TextInput
                       value={translations[langCode].nextText}
@@ -307,7 +306,6 @@ const FormStepDefinition = ({
                           description="Form step previous text field help text"
                         />
                       }
-                      fieldBox
                     >
                       <TextInput
                         value={translations[langCode].previousText}
@@ -331,7 +329,6 @@ const FormStepDefinition = ({
                           description="Form step save text field help text"
                         />
                       }
-                      fieldBox
                     >
                       <TextInput
                         value={translations[langCode].saveText}

--- a/src/openforms/js/components/admin/form_design/FormStepDefinition.js
+++ b/src/openforms/js/components/admin/form_design/FormStepDefinition.js
@@ -195,7 +195,7 @@ const FormStepDefinition = ({
           />
         }
         collapsible
-        initialCollapsed={hasName && !!slug && !errors.length}
+        initialCollapsed={hasName && slug && !errors.length}
       >
         <LanguageTabs haveErrors={[...erroredLanguages]}>
           {(langCode, defaultLang) => (

--- a/src/openforms/js/components/admin/forms/Fieldset.js
+++ b/src/openforms/js/components/admin/forms/Fieldset.js
@@ -1,6 +1,6 @@
 import classNames from 'classnames';
 import PropTypes from 'prop-types';
-import {useContext, useId} from 'react';
+import {useContext, useId, useState} from 'react';
 
 import {ValidationErrorContext} from './ValidationErrors';
 
@@ -28,12 +28,13 @@ const Fieldset = ({
   fieldNames = [],
   ...extra
 }) => {
+  const [isOpen, setIsOpen] = useState(!initialCollapsed);
   const validationErrors = useContext(ValidationErrorContext);
   const hasErrorsInside = checkHasErrors(validationErrors, fieldNames);
   const titleId = useId();
 
-  if (initialCollapsed && hasErrorsInside) {
-    initialCollapsed = false;
+  if (!isOpen && hasErrorsInside) {
+    setIsOpen(true);
   }
 
   const titleNode = title ? (
@@ -48,8 +49,15 @@ const Fieldset = ({
   return (
     <fieldset className={className} aria-labelledby={title ? titleId : undefined} {...extra}>
       {titleNode && collapsible ? (
-        <details open={!initialCollapsed}>
-          <summary>{titleNode}</summary>
+        <details open={isOpen}>
+          <summary
+            onClick={e => {
+              e.preventDefault();
+              setIsOpen(!isOpen);
+            }}
+          >
+            {titleNode}
+          </summary>
           {children}
         </details>
       ) : (


### PR DESCRIPTION
Closes #6111

**Changes**

The collapsible fieldsets in the React implementation now use local React state rather than both React props/state as input and local browser state that React is not aware of. The proper semantics of the "initial" open/collapsed state are also restored, instead of the prop acting more like a boolean "should be open or closed".

There's a lengthy discussion in the linked (see commit) issue in the React repository and this was crucial for me to understand what could be going wrong.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
