### PR TITLE
Fix component empty value for complex components

### DIFF
--- a/bin/fix_submission_value_variable_missing_fields.py
+++ b/bin/fix_submission_value_variable_missing_fields.py
@@ -31,11 +31,11 @@ def get_configuration(step):
 
 
 def add_missing_fields_to_existing_submission_value_variables() -> None:
-    from openforms.formio.utils import (
+    from openforms.formio.service import (
         get_component_data_subtype,
         get_component_datatype,
-        iter_components,
     )
+    from openforms.formio.utils import iter_components
     from openforms.submissions.models import SubmissionStep, SubmissionValueVariable
     from openforms.variables.constants import FormVariableSources
 

--- a/src/openforms/appointments/api/serializers.py
+++ b/src/openforms/appointments/api/serializers.py
@@ -7,8 +7,7 @@ from drf_spectacular.types import OpenApiTypes
 from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
-from openforms.formio.service import build_serializer
-from openforms.formio.utils import get_component_empty_value
+from openforms.formio.service import build_serializer, get_component_empty_value
 from openforms.forms.constants import FormTypeChoices
 from openforms.forms.models import Form
 from openforms.submissions.api.fields import PrivacyPolicyAcceptedField

--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -36,7 +36,7 @@ from openforms.utils.date import TIMEZONE_AMS, datetime_in_amsterdam
 from openforms.utils.json_schema import GEO_JSON_COORDINATE_SCHEMAS, to_multiple
 from openforms.utils.validators import BSNValidator, IBANValidator
 from openforms.validations.service import PluginValidator
-from openforms.variables.constants import FormVariableSources
+from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 
 from ..datastructures import FormioData
 from ..dynamic_config.date import mutate as mutate_min_max_validation
@@ -96,6 +96,7 @@ class FormioDateField(serializers.DateField):
 @register("date")
 class Date(BasePlugin[DateComponent]):
     formatter = DateFormatter
+    data_type = FormVariableDataTypes.date
     empty_value = ""
 
     def mutate_config_dynamically(
@@ -188,6 +189,7 @@ def _normalize_validation_datetime(value: str) -> datetime:
 @register("datetime")
 class Datetime(BasePlugin):
     formatter = DateTimeFormatter
+    data_type = FormVariableDataTypes.datetime
     empty_value = ""
 
     def mutate_config_dynamically(
@@ -248,6 +250,7 @@ class Datetime(BasePlugin):
 @register("map")
 class Map(BasePlugin[MapComponent]):
     formatter = MapFormatter
+    data_type = FormVariableDataTypes.object
     empty_value = None
 
     def mutate_config_dynamically(
@@ -333,6 +336,7 @@ class Map(BasePlugin[MapComponent]):
 @register("postcode")
 class Postcode(BasePlugin[Component]):
     formatter = TextFieldFormatter
+    data_type = FormVariableDataTypes.string
     empty_value = ""
 
     @staticmethod
@@ -414,6 +418,7 @@ class FamilyMembersHandler(Protocol):
 class NPFamilyMembers(BasePlugin):
     # not actually relevant, as we transform the component into a different type
     formatter = DefaultFormatter
+    data_type = FormVariableDataTypes.object
     empty_value = {}
 
     def build_serializer_field(self, component: Component) -> serializers.Field:
@@ -501,6 +506,7 @@ class NPFamilyMembers(BasePlugin):
 @register("bsn")
 class BSN(BasePlugin[Component]):
     formatter = TextFieldFormatter
+    data_type = FormVariableDataTypes.string
     empty_value = ""
 
     def build_serializer_field(
@@ -653,6 +659,7 @@ class AddressValueSerializer(serializers.Serializer):
 @register("addressNL")
 class AddressNL(BasePlugin[AddressNLComponent]):
     formatter = AddressNLFormatter
+    data_type = FormVariableDataTypes.object
     # addressNL is a composite field, and rendering it in the UI will cause the
     # sub-paths to be set. We can't use `null` as empty value, as that would
     # lead to inconsistent empty-checks, as you want to reliably point to
@@ -816,6 +823,8 @@ class PartnerListField(serializers.Field):
 @register("partners")
 class Partners(BasePlugin[Component]):
     formatter = DefaultFormatter
+    data_type = FormVariableDataTypes.array
+    data_subtype = FormVariableDataTypes.partners
     empty_value = []
 
     def build_serializer_field(self, component: Component) -> PartnerListField:
@@ -974,6 +983,8 @@ class ChildListField(serializers.Field):
 @register("children")
 class Children(BasePlugin[ChildrenComponent]):
     formatter = DefaultFormatter
+    data_type = FormVariableDataTypes.array
+    data_subtype = FormVariableDataTypes.children
     empty_value = []
 
     def build_serializer_field(self, component: ChildrenComponent) -> ChildListField:
@@ -1007,6 +1018,7 @@ class Children(BasePlugin[ChildrenComponent]):
 @register("cosign")
 class Cosign(BasePlugin):
     formatter = CosignFormatter
+    data_type = FormVariableDataTypes.string
     empty_value = ""
 
     def build_serializer_field(self, component: Component) -> serializers.EmailField:
@@ -1026,6 +1038,7 @@ class Cosign(BasePlugin):
 @register("iban")
 class Iban(BasePlugin):
     formatter = DefaultFormatter
+    data_type = FormVariableDataTypes.string
     empty_value = ""
 
     def build_serializer_field(
@@ -1062,6 +1075,7 @@ class Iban(BasePlugin):
 @register("licenseplate")
 class LicensePlate(BasePlugin):
     formatter = DefaultFormatter
+    data_type = FormVariableDataTypes.string
     empty_value = ""
 
     def build_serializer_field(
@@ -1115,6 +1129,8 @@ class LicensePlate(BasePlugin):
 @register("customerProfile")
 class CustomerProfile(BasePlugin[CustomerProfileComponent]):
     formatter = CustomerProfileFormatter
+    data_type = FormVariableDataTypes.array
+    data_subtype = FormVariableDataTypes.object
 
     def build_serializer_field(
         self, component: CustomerProfileComponent

--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -31,7 +31,7 @@ from openforms.prefill.contrib.family_members.plugin import (
     PLUGIN_IDENTIFIER as FM_PLUGIN_IDENTIFIER,
 )
 from openforms.submissions.models import Submission
-from openforms.typing import JSONObject
+from openforms.typing import JSONObject, JSONValue
 from openforms.utils.date import TIMEZONE_AMS, datetime_in_amsterdam
 from openforms.utils.json_schema import GEO_JSON_COORDINATE_SCHEMAS, to_multiple
 from openforms.utils.validators import BSNValidator, IBANValidator
@@ -96,6 +96,7 @@ class FormioDateField(serializers.DateField):
 @register("date")
 class Date(BasePlugin[DateComponent]):
     formatter = DateFormatter
+    empty_value = ""
 
     def mutate_config_dynamically(
         self, component: DateComponent, submission: Submission, data: FormioData
@@ -187,6 +188,7 @@ def _normalize_validation_datetime(value: str) -> datetime:
 @register("datetime")
 class Datetime(BasePlugin):
     formatter = DateTimeFormatter
+    empty_value = ""
 
     def mutate_config_dynamically(
         self,
@@ -246,6 +248,7 @@ class Datetime(BasePlugin):
 @register("map")
 class Map(BasePlugin[MapComponent]):
     formatter = MapFormatter
+    empty_value = None
 
     def mutate_config_dynamically(
         self, component: MapComponent, submission: Submission, data: FormioData
@@ -330,6 +333,7 @@ class Map(BasePlugin[MapComponent]):
 @register("postcode")
 class Postcode(BasePlugin[Component]):
     formatter = TextFieldFormatter
+    empty_value = ""
 
     @staticmethod
     def normalizer(component: Component, value: str) -> str:
@@ -410,6 +414,7 @@ class FamilyMembersHandler(Protocol):
 class NPFamilyMembers(BasePlugin):
     # not actually relevant, as we transform the component into a different type
     formatter = DefaultFormatter
+    empty_value = {}
 
     def build_serializer_field(self, component: Component) -> serializers.Field:
         raise NotImplementedError()
@@ -496,6 +501,7 @@ class NPFamilyMembers(BasePlugin):
 @register("bsn")
 class BSN(BasePlugin[Component]):
     formatter = TextFieldFormatter
+    empty_value = ""
 
     def build_serializer_field(
         self, component: Component
@@ -647,6 +653,20 @@ class AddressValueSerializer(serializers.Serializer):
 @register("addressNL")
 class AddressNL(BasePlugin[AddressNLComponent]):
     formatter = AddressNLFormatter
+    # addressNL is a composite field, and rendering it in the UI will cause the
+    # sub-paths to be set. We can't use `null` as empty value, as that would
+    # lead to inconsistent empty-checks, as you want to reliably point to
+    # {"var": "myComponent.postcode"} for a test against empty string
+    empty_value = {
+        "postcode": "",
+        "houseNumber": "",
+        "houseLetter": "",
+        "houseNumberAddition": "",
+        "streetName": "",
+        "city": "",
+        "secretStreetCity": "",
+        "autoPopulated": False,
+    }
 
     def build_serializer_field(
         self, component: AddressNLComponent
@@ -796,6 +816,7 @@ class PartnerListField(serializers.Field):
 @register("partners")
 class Partners(BasePlugin[Component]):
     formatter = DefaultFormatter
+    empty_value = []
 
     def build_serializer_field(self, component: Component) -> PartnerListField:
         return PartnerListField(component=component)
@@ -953,6 +974,7 @@ class ChildListField(serializers.Field):
 @register("children")
 class Children(BasePlugin[ChildrenComponent]):
     formatter = DefaultFormatter
+    empty_value = []
 
     def build_serializer_field(self, component: ChildrenComponent) -> ChildListField:
         return ChildListField(component=component)
@@ -985,6 +1007,7 @@ class Children(BasePlugin[ChildrenComponent]):
 @register("cosign")
 class Cosign(BasePlugin):
     formatter = CosignFormatter
+    empty_value = ""
 
     def build_serializer_field(self, component: Component) -> serializers.EmailField:
         validate = component.get("validate", {})
@@ -1003,6 +1026,7 @@ class Cosign(BasePlugin):
 @register("iban")
 class Iban(BasePlugin):
     formatter = DefaultFormatter
+    empty_value = ""
 
     def build_serializer_field(
         self, component: Component
@@ -1038,6 +1062,7 @@ class Iban(BasePlugin):
 @register("licenseplate")
 class LicensePlate(BasePlugin):
     formatter = DefaultFormatter
+    empty_value = ""
 
     def build_serializer_field(
         self, component: Component
@@ -1088,7 +1113,7 @@ class LicensePlate(BasePlugin):
 
 
 @register("customerProfile")
-class CustomerProfile(BasePlugin):
+class CustomerProfile(BasePlugin[CustomerProfileComponent]):
     formatter = CustomerProfileFormatter
 
     def build_serializer_field(
@@ -1118,6 +1143,13 @@ class CustomerProfile(BasePlugin):
     @staticmethod
     def as_json_schema(component: CustomerProfileComponent) -> None:
         raise NotImplementedError()
+
+    def get_empty_value(self, component: CustomerProfileComponent):
+        empty_value: JSONValue = [
+            {"type": channel, "address": "", "preferenceUpdate": "useOnlyOnce"}
+            for channel in component["digitalAddressTypes"]
+        ]
+        return empty_value
 
 
 @register("softRequiredErrors")

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -33,7 +33,7 @@ from openforms.config.models import GlobalConfiguration
 from openforms.submissions.attachments import temporary_upload_from_url
 from openforms.submissions.form_logic import process_visibility
 from openforms.submissions.models import EmailVerification
-from openforms.typing import JSONObject
+from openforms.typing import JSONObject, JSONValue
 from openforms.utils.json_schema import to_multiple
 from openforms.utils.urls import build_absolute_uri
 from openforms.validations.service import PluginValidator
@@ -92,6 +92,7 @@ class Default(BasePlugin):
     """
 
     formatter = DefaultFormatter
+    empty_value = ""
 
     def build_serializer_field(self, component: Component) -> serializers.Field:
         raise NotImplementedError()
@@ -100,6 +101,7 @@ class Default(BasePlugin):
 @register("textfield")
 class TextField(BasePlugin[TextFieldComponent]):
     formatter = TextFieldFormatter
+    empty_value = ""
 
     @staticmethod
     def normalizer(component: Component, value: str) -> str:
@@ -186,6 +188,7 @@ class EmailVerificationValidator:
 @register("email")
 class Email(BasePlugin):
     formatter = EmailFormatter
+    empty_value = ""
 
     def build_serializer_field(
         self, component: Component
@@ -271,6 +274,7 @@ class TimeBetweenValidator:
 @register("time")
 class Time(BasePlugin[Component]):
     formatter = TimeFormatter
+    empty_value = ""
 
     def build_serializer_field(
         self, component: Component
@@ -325,6 +329,7 @@ class Time(BasePlugin[Component]):
 @register("phoneNumber")
 class PhoneNumber(BasePlugin):
     formatter = PhoneNumberFormatter
+    empty_value = ""
 
     def build_serializer_field(
         self, component: Component
@@ -462,6 +467,7 @@ class FileSerializer(serializers.Serializer):
 @register("file")
 class File(BasePlugin[FileComponent]):
     formatter = FileFormatter
+    empty_value = []
 
     @staticmethod
     def rewrite_for_request(component: FileComponent, request: Request):
@@ -549,6 +555,7 @@ class File(BasePlugin[FileComponent]):
 @register("textarea")
 class TextArea(BasePlugin[Component]):
     formatter = TextAreaFormatter
+    empty_value = ""
 
     def build_serializer_field(
         self, component: Component
@@ -590,6 +597,7 @@ class TextArea(BasePlugin[Component]):
 @register("number")
 class Number(BasePlugin):
     formatter = NumberFormatter
+    empty_value = None
 
     def build_serializer_field(
         self, component: Component
@@ -645,6 +653,7 @@ def validate_required_checkbox(value: bool) -> None:
 @register("checkbox")
 class Checkbox(BasePlugin[Component]):
     formatter = CheckboxFormatter
+    empty_value = False
 
     def build_serializer_field(self, component: Component) -> serializers.BooleanField:
         validate = component.get("validate", {})
@@ -786,10 +795,26 @@ class SelectBoxes(BasePlugin[SelectBoxesComponent]):
         # a single compare value, not an object.
         return value.get(compare_value, False)
 
+    def get_empty_value(self, component: SelectBoxesComponent):
+        # Issue 2838
+        # Component selectboxes is of 'object' type, which would return a {} for an
+        # empty component. However, the empty value is with all the options not selected
+        # (ex. {"a": False, "b": False})
+        # Additionally, the `defaultValue` will be empty if the component uses another
+        # variable or reference lists as a data source. We can generate a correct empty
+        # value from the `values` if the formio configuration was updated dynamically.
+        empty_value: JSONValue
+        if not (empty_value := component.get("defaultValue", {})):
+            values = component.get("values", {})
+            if not (len(values) == 1 and values[0]["label"] == ""):
+                empty_value = {item["label"]: False for item in values}
+        return empty_value
+
 
 @register("select")
 class Select(BasePlugin[SelectComponent]):
     formatter = SelectFormatter
+    empty_value = ""
 
     def mutate_config_dynamically(
         self, component, submission: "Submission", data: FormioData
@@ -860,6 +885,7 @@ class Select(BasePlugin[SelectComponent]):
 @register("currency")
 class Currency(BasePlugin[Component]):
     formatter = CurrencyFormatter
+    empty_value = None
 
     def build_serializer_field(self, component: Component) -> serializers.FloatField:
         validate = component.get("validate", {})
@@ -898,6 +924,7 @@ class Currency(BasePlugin[Component]):
 @register("radio")
 class Radio(BasePlugin[RadioComponent]):
     formatter = RadioFormatter
+    empty_value = ""
 
     def mutate_config_dynamically(
         self, component: RadioComponent, submission: "Submission", data: FormioData
@@ -949,6 +976,7 @@ class Radio(BasePlugin[RadioComponent]):
 @register("signature")
 class Signature(BasePlugin[Component]):
     formatter = SignatureFormatter
+    empty_value = ""
 
     def build_serializer_field(self, component: Component) -> serializers.CharField:
         validate = component.get("validate", {})
@@ -1094,6 +1122,8 @@ class EditGridField(serializers.Field):
 
 @register("editgrid")
 class EditGrid(BasePlugin[EditGridComponent]):
+    empty_value = []
+
     def build_serializer_field(self, component: EditGridComponent) -> EditGridField:
         validate = component.get("validate", {})
         required = validate.get("required", False)

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -37,6 +37,7 @@ from openforms.typing import JSONObject, JSONValue
 from openforms.utils.json_schema import to_multiple
 from openforms.utils.urls import build_absolute_uri
 from openforms.validations.service import PluginValidator
+from openforms.variables.constants import FormVariableDataTypes
 
 from ..api.validators import MimeTypeValidator
 from ..datastructures import FormioConfigurationWrapper, FormioData
@@ -92,6 +93,7 @@ class Default(BasePlugin):
     """
 
     formatter = DefaultFormatter
+    data_type = FormVariableDataTypes.string
     empty_value = ""
 
     def build_serializer_field(self, component: Component) -> serializers.Field:
@@ -101,6 +103,7 @@ class Default(BasePlugin):
 @register("textfield")
 class TextField(BasePlugin[TextFieldComponent]):
     formatter = TextFieldFormatter
+    data_type = FormVariableDataTypes.string
     empty_value = ""
 
     @staticmethod
@@ -188,6 +191,7 @@ class EmailVerificationValidator:
 @register("email")
 class Email(BasePlugin):
     formatter = EmailFormatter
+    data_type = FormVariableDataTypes.string
     empty_value = ""
 
     def build_serializer_field(
@@ -274,6 +278,7 @@ class TimeBetweenValidator:
 @register("time")
 class Time(BasePlugin[Component]):
     formatter = TimeFormatter
+    data_type = FormVariableDataTypes.time
     empty_value = ""
 
     def build_serializer_field(
@@ -329,6 +334,7 @@ class Time(BasePlugin[Component]):
 @register("phoneNumber")
 class PhoneNumber(BasePlugin):
     formatter = PhoneNumberFormatter
+    data_type = FormVariableDataTypes.string
     empty_value = ""
 
     def build_serializer_field(
@@ -467,6 +473,9 @@ class FileSerializer(serializers.Serializer):
 @register("file")
 class File(BasePlugin[FileComponent]):
     formatter = FileFormatter
+    # always an array, even for single-file uploads
+    data_type = FormVariableDataTypes.array
+    data_subtype = FormVariableDataTypes.object
     empty_value = []
 
     @staticmethod
@@ -555,6 +564,7 @@ class File(BasePlugin[FileComponent]):
 @register("textarea")
 class TextArea(BasePlugin[Component]):
     formatter = TextAreaFormatter
+    data_type = FormVariableDataTypes.string
     empty_value = ""
 
     def build_serializer_field(
@@ -597,6 +607,7 @@ class TextArea(BasePlugin[Component]):
 @register("number")
 class Number(BasePlugin):
     formatter = NumberFormatter
+    data_type = FormVariableDataTypes.float
     empty_value = None
 
     def build_serializer_field(
@@ -653,6 +664,7 @@ def validate_required_checkbox(value: bool) -> None:
 @register("checkbox")
 class Checkbox(BasePlugin[Component]):
     formatter = CheckboxFormatter
+    data_type = FormVariableDataTypes.boolean
     empty_value = False
 
     def build_serializer_field(self, component: Component) -> serializers.BooleanField:
@@ -725,6 +737,7 @@ class SelectboxesField(serializers.Serializer):
 @register("selectboxes")
 class SelectBoxes(BasePlugin[SelectBoxesComponent]):
     formatter = SelectBoxesFormatter
+    data_type = FormVariableDataTypes.object
 
     def mutate_config_dynamically(
         self,
@@ -814,6 +827,7 @@ class SelectBoxes(BasePlugin[SelectBoxesComponent]):
 @register("select")
 class Select(BasePlugin[SelectComponent]):
     formatter = SelectFormatter
+    data_type = FormVariableDataTypes.string
     empty_value = ""
 
     def mutate_config_dynamically(
@@ -885,6 +899,7 @@ class Select(BasePlugin[SelectComponent]):
 @register("currency")
 class Currency(BasePlugin[Component]):
     formatter = CurrencyFormatter
+    data_type = FormVariableDataTypes.float
     empty_value = None
 
     def build_serializer_field(self, component: Component) -> serializers.FloatField:
@@ -924,6 +939,7 @@ class Currency(BasePlugin[Component]):
 @register("radio")
 class Radio(BasePlugin[RadioComponent]):
     formatter = RadioFormatter
+    data_type = FormVariableDataTypes.string
     empty_value = ""
 
     def mutate_config_dynamically(
@@ -976,6 +992,7 @@ class Radio(BasePlugin[RadioComponent]):
 @register("signature")
 class Signature(BasePlugin[Component]):
     formatter = SignatureFormatter
+    data_type = FormVariableDataTypes.string
     empty_value = ""
 
     def build_serializer_field(self, component: Component) -> serializers.CharField:
@@ -1122,6 +1139,8 @@ class EditGridField(serializers.Field):
 
 @register("editgrid")
 class EditGrid(BasePlugin[EditGridComponent]):
+    data_type = FormVariableDataTypes.array
+    data_subtype = FormVariableDataTypes.editgrid
     empty_value = []
 
     def build_serializer_field(self, component: EditGridComponent) -> EditGridField:

--- a/src/openforms/formio/constants.py
+++ b/src/openforms/formio/constants.py
@@ -1,31 +1,5 @@
 from enum import StrEnum
 
-COMPONENT_DATATYPES = {
-    "date": "date",
-    "time": "time",
-    "file": "array",
-    "currency": "float",
-    "number": "float",
-    "checkbox": "boolean",
-    "selectboxes": "object",
-    "npFamilyMembers": "object",
-    "map": "object",
-    "editgrid": "array",
-    "datetime": "datetime",
-    "partners": "array",
-    "children": "array",
-    "customerProfile": "array",
-}
-
-
-COMPONENT_DATA_SUBTYPES = {
-    "file": "object",
-    "editgrid": "editgrid",
-    "partners": "partners",
-    "children": "children",
-    "customerProfile": "object",
-}
-
 
 class DataSrcOptions(StrEnum):
     manual = "manual"

--- a/src/openforms/formio/migration_converters.py
+++ b/src/openforms/formio/migration_converters.py
@@ -16,8 +16,8 @@ from openforms.formio.typing.vanilla import ColumnsComponent, FileComponent
 from openforms.typing import JSONObject
 
 from .datastructures import FormioConfigurationWrapper
+from .service import get_component_empty_value
 from .typing import AddressNLComponent, Component, MapComponent
-from .utils import get_component_empty_value
 
 logger = structlog.stdlib.get_logger(__name__)
 

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -34,6 +34,7 @@ from rest_framework.request import Request
 from openforms.plugins.plugin import AbstractBasePlugin
 from openforms.plugins.registry import BaseRegistry
 from openforms.typing import JSONObject, JSONValue, VariableValue
+from openforms.variables.constants import FormVariableDataTypes
 
 from .datastructures import FormioConfigurationWrapper, FormioData
 from .typing import Component
@@ -95,6 +96,18 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin, abc.ABC):  # noqa: UP0
     holds_submission_data: ClassVar[bool] = True
     """
     Flag to indicate whether data can be submitted for this component.
+    """
+    data_type: ClassVar[FormVariableDataTypes] = NotImplemented
+    """
+    The intrinsic data type for the component, for the non-multiple case.
+
+    Each component type produces values of a certain data type. :attr:`empty_value` is
+    expected to be an instance of that data type. Note that components that support the
+    ``multiple`` property typically return a list of the intrinsic data type.
+    """
+    data_subtype: ClassVar[FormVariableDataTypes | None] = None
+    """
+    The intrinsic item data type for components that have a collection as data type.
     """
     empty_value: ClassVar[JSONValue] = NotImplemented
     """
@@ -180,7 +193,10 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin, abc.ABC):  # noqa: UP0
         """
         return None
 
-    def get_empty_value(self, component: ComponentT):
+    def get_data_type(self, component: ComponentT) -> FormVariableDataTypes:
+        return self.data_type
+
+    def get_empty_value(self, component: ComponentT) -> JSONValue:
         if component.get("multiple", False):
             return []
         return self.empty_value
@@ -385,7 +401,45 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
 
         return hook(component, submission)
 
-    def get_empty_value(self, component: Component):
+    def get_component_data_type(self, component: Component) -> FormVariableDataTypes:
+        """
+        Determine the data type for the component instance.
+
+        The top-level method takes into account whether the component is scalar or a
+        collection of values. The data type is looked up from the component plugin
+        registry or defaults to the string type.
+        """
+        if component.get("multiple"):
+            return FormVariableDataTypes.array
+        if (component_type := component["type"]) not in self:
+            return FormVariableDataTypes.string
+        return self[component_type].get_data_type(component)
+
+    def get_component_data_subtype(
+        self, component: Component
+    ) -> Literal[""] | FormVariableDataTypes:
+        """
+        Get the data subtype of a component.
+
+        :returns: The original data type of the component if the component is configured
+          as ``multiple``, an empty string otherwise. Components that are already an
+          array (editgrid, files, partners, children and profile) are a special case,
+          as ``multiple`` is not relevant for these.
+        """
+        if (component_type := component["type"]) not in self:
+            component_type = "default"
+
+        if (subtype := self[component_type].data_subtype) is not None:
+            return subtype
+
+        if not component.get("multiple"):
+            return ""
+
+        # get the intrinsic data type
+        _component: Component = {**component, "multiple": False}
+        return self.get_component_data_type(_component)
+
+    def get_empty_value(self, component: Component) -> JSONValue:
         if (component_type := component["type"]) not in self:
             return ""
         return self[component_type].get_empty_value(component)

--- a/src/openforms/formio/registry.py
+++ b/src/openforms/formio/registry.py
@@ -96,6 +96,17 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin, abc.ABC):  # noqa: UP0
     """
     Flag to indicate whether data can be submitted for this component.
     """
+    empty_value: ClassVar[JSONValue] = NotImplemented
+    """
+    The empty value specific to the component type.
+
+    The empty value is used when a component changes visibility state from hidden to
+    visible when the value is not or no longer present in the submission data. It's the
+    intrinsic starting point for a pristine component state in the UI.
+
+    For empty values that depend on component configuration, override
+    :meth:`get_empty_value`.
+    """
 
     @property
     def is_enabled(self) -> Literal[True]:
@@ -168,6 +179,11 @@ class BasePlugin(Generic[ComponentT], AbstractBasePlugin, abc.ABC):  # noqa: UP0
           the child class.
         """
         return None
+
+    def get_empty_value(self, component: ComponentT):
+        if component.get("multiple", False):
+            return []
+        return self.empty_value
 
 
 class ComponentRegistry(BaseRegistry[BasePlugin]):
@@ -368,6 +384,11 @@ class ComponentRegistry(BaseRegistry[BasePlugin]):
         assert hook is not None
 
         return hook(component, submission)
+
+    def get_empty_value(self, component: Component):
+        if (component_type := component["type"]) not in self:
+            return ""
+        return self[component_type].get_empty_value(component)
 
     def holds_submission_data(self, component: Component) -> bool:
         """Return whether data can be submitted for a particular component."""

--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -12,10 +12,9 @@ from openforms.submissions.rendering.base import Node
 from openforms.submissions.rendering.constants import RenderModes
 
 from ..datastructures import FormioData
-from ..service import format_value, holds_submission_data
+from ..service import format_value, get_component_empty_value, holds_submission_data
 from ..typing import Component
 from ..utils import (
-    get_component_empty_value,
     is_visible_in_frontend,
     iterate_components_with_configuration_path,
 )

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -12,11 +12,12 @@ apps/packages:
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal
 
 from opentelemetry import trace
 
 from openforms.typing import JSONObject, JSONValue
+from openforms.variables.constants import FormVariableDataTypes
 
 from .datastructures import DuplicateKeyError, FormioConfigurationWrapper, FormioData
 from .dynamic_config import (
@@ -81,6 +82,26 @@ def normalize_value_for_component(component: Component, value: Any) -> Any:
 def holds_submission_data(component: Component) -> bool:
     """Return whether data can be submitted for a particular component."""
     return register.holds_submission_data(component)
+
+
+def get_component_datatype(component: Component) -> FormVariableDataTypes:
+    """
+    Get the intrinsic data type for a particular component.
+    """
+    return register.get_component_data_type(component)
+
+
+def get_component_data_subtype(
+    component: Component,
+) -> Literal[""] | FormVariableDataTypes:
+    """
+    Get the data subtype of a component.
+
+    :returns: The underlying data type of the component if the component is configured
+      as ``multiple`` or intrinsically has an array data type. Otherwise, an empty
+      string is returned to signal the data subtype is not applicable.
+    """
+    return register.get_component_data_subtype(component)
 
 
 def get_component_empty_value(component: Component) -> JSONValue:

--- a/src/openforms/formio/service.py
+++ b/src/openforms/formio/service.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 
 from opentelemetry import trace
 
-from openforms.typing import JSONObject
+from openforms.typing import JSONObject, JSONValue
 
 from .datastructures import DuplicateKeyError, FormioConfigurationWrapper, FormioData
 from .dynamic_config import (
@@ -29,7 +29,6 @@ from .registry import ComponentRegistry, register
 from .serializers import build_serializer as _build_serializer
 from .typing import Component
 from .utils import (
-    get_component_empty_value,
     get_readable_path_from_configuration_path,
     iter_components,
     iterate_data_with_components,
@@ -82,6 +81,13 @@ def normalize_value_for_component(component: Component, value: Any) -> Any:
 def holds_submission_data(component: Component) -> bool:
     """Return whether data can be submitted for a particular component."""
     return register.holds_submission_data(component)
+
+
+def get_component_empty_value(component: Component) -> JSONValue:
+    """
+    Get the component-specific empty value.
+    """
+    return register.get_empty_value(component)
 
 
 @tracer.start_as_current_span(

--- a/src/openforms/formio/tests/test_utils.py
+++ b/src/openforms/formio/tests/test_utils.py
@@ -7,6 +7,7 @@ from openforms.tests.search_strategies import json_primitives
 from openforms.typing import JSONPrimitive
 
 from ..datastructures import FormioConfigurationWrapper, FormioData
+from ..service import get_component_empty_value
 from ..typing import (
     AddressNLComponent,
     Component,
@@ -14,7 +15,7 @@ from ..typing import (
     MapComponent,
     SelectBoxesComponent,
 )
-from ..utils import get_component_empty_value, is_visible_in_frontend
+from ..utils import is_visible_in_frontend
 
 FORMIO_COMPONENTS: list[Component] = [
     {

--- a/src/openforms/formio/tests/test_utils.py
+++ b/src/openforms/formio/tests/test_utils.py
@@ -7,7 +7,13 @@ from openforms.tests.search_strategies import json_primitives
 from openforms.typing import JSONPrimitive
 
 from ..datastructures import FormioConfigurationWrapper, FormioData
-from ..typing import Component, SelectBoxesComponent
+from ..typing import (
+    AddressNLComponent,
+    Component,
+    CustomerProfileComponent,
+    MapComponent,
+    SelectBoxesComponent,
+)
 from ..utils import get_component_empty_value, is_visible_in_frontend
 
 FORMIO_COMPONENTS: list[Component] = [
@@ -208,3 +214,71 @@ class GetComponentEmptyValueTests(SimpleTestCase):
 
         empty_value = get_component_empty_value(component)
         self.assertEqual(empty_value, {})
+
+    def test_addressnl_empty_value(self):
+        component: AddressNLComponent = {
+            "key": "address",
+            "type": "addressNL",
+            "label": "addressNL",
+            "deriveAddress": False,
+        }
+
+        empty_value = get_component_empty_value(component)
+
+        self.assertEqual(
+            empty_value,
+            {
+                "postcode": "",
+                "houseNumber": "",
+                "houseLetter": "",
+                "houseNumberAddition": "",
+                "streetName": "",
+                "city": "",
+                "secretStreetCity": "",
+                "autoPopulated": False,
+            },
+        )
+
+    def test_map_empty_value(self):
+        component: MapComponent = {
+            "key": "map",
+            "type": "map",
+            "label": "map",
+            "useConfigDefaultMapSettings": True,
+            "interactions": {
+                "marker": True,
+                "polygon": False,
+                "polyline": False,
+            },
+        }
+
+        empty_value = get_component_empty_value(component)
+
+        self.assertIsNone(empty_value)
+
+    def test_customer_profile_empty_value(self):
+        component: CustomerProfileComponent = {
+            "key": "customerProfile",
+            "type": "customerProfile",
+            "label": "customerProfile",
+            "shouldUpdateCustomerData": False,
+            "digitalAddressTypes": ["email", "phoneNumber"],
+        }
+
+        empty_value = get_component_empty_value(component)
+
+        self.assertEqual(
+            empty_value,
+            [
+                {
+                    "type": "email",
+                    "address": "",
+                    "preferenceUpdate": "useOnlyOnce",
+                },
+                {
+                    "type": "phoneNumber",
+                    "address": "",
+                    "preferenceUpdate": "useOnlyOnce",
+                },
+            ],
+        )

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -10,7 +10,7 @@ from opentelemetry import trace
 from typing_extensions import TypeIs
 
 from openforms.typing import JSONObject
-from openforms.variables.constants import DEFAULT_INITIAL_VALUE, FormVariableDataTypes
+from openforms.variables.constants import FormVariableDataTypes
 
 from .constants import COMPONENT_DATA_SUBTYPES, COMPONENT_DATATYPES
 from .typing import Column, ColumnsComponent, Component, FormioConfiguration
@@ -201,56 +201,6 @@ def get_component_data_subtype(component: Component) -> str:
         return ""
 
     return COMPONENT_DATATYPES.get(component["type"], FormVariableDataTypes.string)
-
-
-def get_component_empty_value(component: Component):
-    match component:
-        case {"type": "selectboxes"}:
-            # Issue 2838
-            # Component selectboxes is of 'object' type, which would return a {} for an
-            # empty component. However, the empty value is with all the options not selected
-            # (ex. {"a": False, "b": False})
-            # Additionally, the `defaultValue` will be empty if the component uses another
-            # variable or reference lists as a data source. We can generate a correct empty
-            # value from the `values` if the formio configuration was updated dynamically.
-            if not (empty_value := component.get("defaultValue", {})):
-                values = component.get("values", {})
-                if not (len(values) == 1 and values[0]["label"] == ""):
-                    empty_value = {item["label"]: False for item in values}
-            return empty_value
-
-        case {"type": "map"}:
-            # Issue 5151
-            # Component map is of 'object' type, which would return a {} for an empty component.
-            # However, an empty object would fail validation, as the required properties
-            # `type` and `coordinates` would be missing.
-            return None
-
-        case {"type": "addressNL"}:
-            # addressNL is a composite field, and rendering it in the UI will cause the
-            # sub-paths to be set. We can't use `null` as empty value, as that would
-            # lead to inconsistent empty-checks, as you want to reliably point to
-            # {"var": "myComponent.postcode"} for a test against empty string
-            return {
-                "postcode": "",
-                "houseNumber": "",
-                "houseLetter": "",
-                "houseNumberAddition": "",
-                "streetName": "",
-                "city": "",
-                "secretStreetCity": "",
-                "autoPopulated": False,
-            }
-
-        case {"type": "customerProfile"}:
-            return [
-                {"type": channel, "address": "", "preferenceUpdate": "useOnlyOnce"}
-                for channel in component["digitalAddressTypes"]
-            ]
-
-        case _:
-            data_type = get_component_datatype(component)
-            return DEFAULT_INITIAL_VALUE.get(data_type, "")
 
 
 def get_component_default_value(component: Component) -> Any | None:

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -10,9 +10,7 @@ from opentelemetry import trace
 from typing_extensions import TypeIs
 
 from openforms.typing import JSONObject
-from openforms.variables.constants import FormVariableDataTypes
 
-from .constants import COMPONENT_DATA_SUBTYPES, COMPONENT_DATATYPES
 from .typing import Column, ColumnsComponent, Component, FormioConfiguration
 
 if TYPE_CHECKING:
@@ -174,33 +172,6 @@ def get_readable_path_from_configuration_path(
         previous_path_bit = Path(previous_path_bit, path_bit)
 
     return " > ".join(keys_path)
-
-
-def get_component_datatype(component: Component) -> FormVariableDataTypes:
-    component_type = component["type"]
-    if component.get("multiple"):
-        return FormVariableDataTypes.array
-    return FormVariableDataTypes(
-        COMPONENT_DATATYPES.get(component_type, FormVariableDataTypes.string)
-    )
-
-
-def get_component_data_subtype(component: Component) -> str:
-    """
-    Get the data subtype of a component.
-
-    :returns: The original data type of the component if the component is configured as
-      'multiple', an empty string otherwise. Components that are already an array
-      (editgrid, files, partners, children and profile) are a special case, as 'multiple'
-      is not relevant for these.
-    """
-    if subtype := COMPONENT_DATA_SUBTYPES.get(component["type"], None):
-        return subtype
-
-    if not component.get("multiple"):
-        return ""
-
-    return COMPONENT_DATATYPES.get(component["type"], FormVariableDataTypes.string)
 
 
 def get_component_default_value(component: Component) -> Any | None:

--- a/src/openforms/formio/utils.py
+++ b/src/openforms/formio/utils.py
@@ -176,11 +176,13 @@ def get_readable_path_from_configuration_path(
     return " > ".join(keys_path)
 
 
-def get_component_datatype(component: Component):
+def get_component_datatype(component: Component) -> FormVariableDataTypes:
     component_type = component["type"]
     if component.get("multiple"):
         return FormVariableDataTypes.array
-    return COMPONENT_DATATYPES.get(component_type, FormVariableDataTypes.string)
+    return FormVariableDataTypes(
+        COMPONENT_DATATYPES.get(component_type, FormVariableDataTypes.string)
+    )
 
 
 def get_component_data_subtype(component: Component) -> str:
@@ -202,30 +204,53 @@ def get_component_data_subtype(component: Component) -> str:
 
 
 def get_component_empty_value(component: Component):
-    data_type = get_component_datatype(component)
+    match component:
+        case {"type": "selectboxes"}:
+            # Issue 2838
+            # Component selectboxes is of 'object' type, which would return a {} for an
+            # empty component. However, the empty value is with all the options not selected
+            # (ex. {"a": False, "b": False})
+            # Additionally, the `defaultValue` will be empty if the component uses another
+            # variable or reference lists as a data source. We can generate a correct empty
+            # value from the `values` if the formio configuration was updated dynamically.
+            if not (empty_value := component.get("defaultValue", {})):
+                values = component.get("values", {})
+                if not (len(values) == 1 and values[0]["label"] == ""):
+                    empty_value = {item["label"]: False for item in values}
+            return empty_value
 
-    if component["type"] == "selectboxes":
-        # Issue 2838
-        # Component selectboxes is of 'object' type, which would return a {} for an
-        # empty component. However, the empty value is with all the options not selected
-        # (ex. {"a": False, "b": False})
-        # Additionally, the `defaultValue` will be empty if the component uses another
-        # variable or reference lists as a data source. We can generate a correct empty
-        # value from the `values` if the formio configuration was updated dynamically.
-        if not (empty_value := component.get("defaultValue", {})):
-            values = component.get("values", {})
-            if not (len(values) == 1 and values[0]["label"] == ""):
-                empty_value = {item["label"]: False for item in values}
-        return empty_value
+        case {"type": "map"}:
+            # Issue 5151
+            # Component map is of 'object' type, which would return a {} for an empty component.
+            # However, an empty object would fail validation, as the required properties
+            # `type` and `coordinates` would be missing.
+            return None
 
-    if component["type"] == "map":
-        # Issue 5151
-        # Component map is of 'object' type, which would return a {} for an empty component.
-        # However, an empty object would fail validation, as the required properties
-        # `type` and `coordinates` would be missing.
-        return component.get("defaultValue", None)
+        case {"type": "addressNL"}:
+            # addressNL is a composite field, and rendering it in the UI will cause the
+            # sub-paths to be set. We can't use `null` as empty value, as that would
+            # lead to inconsistent empty-checks, as you want to reliably point to
+            # {"var": "myComponent.postcode"} for a test against empty string
+            return {
+                "postcode": "",
+                "houseNumber": "",
+                "houseLetter": "",
+                "houseNumberAddition": "",
+                "streetName": "",
+                "city": "",
+                "secretStreetCity": "",
+                "autoPopulated": False,
+            }
 
-    return DEFAULT_INITIAL_VALUE.get(data_type, "")
+        case {"type": "customerProfile"}:
+            return [
+                {"type": channel, "address": "", "preferenceUpdate": "useOnlyOnce"}
+                for channel in component["digitalAddressTypes"]
+            ]
+
+        case _:
+            data_type = get_component_datatype(component)
+            return DEFAULT_INITIAL_VALUE.get(data_type, "")
 
 
 def get_component_default_value(component: Component) -> Any | None:

--- a/src/openforms/formio/visibility.py
+++ b/src/openforms/formio/visibility.py
@@ -5,7 +5,6 @@ from openforms.typing import JSONObject, JSONValue
 from .datastructures import FormioConfiguration, FormioConfigurationWrapper, FormioData
 from .registry import register
 from .typing import Column, Component, ConditionalCompareValue
-from .utils import get_component_empty_value as _get_component_empty_value
 
 
 class GetEvaluationData(Protocol):
@@ -77,6 +76,8 @@ def is_hidden(
 
 
 def get_component_empty_value(component: Component) -> JSONValue:
+    from .service import get_component_empty_value as _get_component_empty_value
+
     if component["type"] in ("date", "time", "datetime"):
         return None
     return _get_component_empty_value(component)

--- a/src/openforms/forms/models/form_variable.py
+++ b/src/openforms/forms/models/form_variable.py
@@ -13,10 +13,12 @@ from django.utils.translation import gettext_lazy as _
 import structlog
 from opentelemetry import trace
 
-from openforms.formio.service import holds_submission_data
-from openforms.formio.utils import (
+from openforms.formio.service import (
     get_component_data_subtype,
     get_component_datatype,
+    holds_submission_data,
+)
+from openforms.formio.utils import (
     get_component_default_value,
     iter_components,
 )

--- a/src/openforms/submissions/models/submission_value_variable.py
+++ b/src/openforms/submissions/models/submission_value_variable.py
@@ -19,16 +19,14 @@ from typing_extensions import deprecated
 
 from openforms.formio.service import (
     FormioData,
+    get_component_data_subtype,
+    get_component_datatype,
     get_component_empty_value,
     holds_submission_data,
     normalize_value_for_component,
 )
 from openforms.formio.typing import Component
-from openforms.formio.utils import (
-    get_component_data_subtype,
-    get_component_datatype,
-    iter_components,
-)
+from openforms.formio.utils import iter_components
 from openforms.forms.models.form_variable import FormVariable
 from openforms.typing import (
     JSONEncodable,


### PR DESCRIPTION
Closes #6125

**Changes**

* Fixed addressNL empty value
* Also address map, customer profile
* Refactored implementation to use registry (component data type, sub-type and empty value)

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
