### PR TITLE
Co-sign component in non-applicable step blocks registration

### DIFF
--- a/src/openforms/submissions/cosigning.py
+++ b/src/openforms/submissions/cosigning.py
@@ -103,23 +103,27 @@ class CosignState:
 
         check_submission_logic(self.submission, reset_configuration_wrapper=False)
 
-        # use the complete view on the Formio component tree(s)
-        configuration_wrapper = self.submission.total_configuration_wrapper
-
         # there should only be one cosign component, so we check our flatmap to find the
         # component.
-        for component in configuration_wrapper.component_map.values():
-            if component["type"] == "cosign":
-                # we can't just blindly return the component, as it may be conditionally
-                # displayed, which is equivalent to "cosign not relevant". See
-                # https://github.com/open-formulieren/open-forms/issues/3901
-                state = self.submission.variables_state
-                visible = configuration_wrapper.is_visible_in_frontend(
-                    component["key"], values=state.get_data(include_unsaved=True)
-                )
-                if not visible:
-                    return None
-                return component
+        for step in self.submission.steps:
+            # co-sign components inside non-applicable steps are not relevant
+            if not step.is_applicable:
+                continue
+
+            assert step.form_step is not None
+            configuration_wrapper = step.form_step.form_definition.configuration_wrapper
+            for component in configuration_wrapper:
+                if component["type"] == "cosign":
+                    # we can't just blindly return the component, as it may be conditionally
+                    # displayed, which is equivalent to "cosign not relevant". See
+                    # https://github.com/open-formulieren/open-forms/issues/3901
+                    state = self.submission.variables_state
+                    visible = configuration_wrapper.is_visible_in_frontend(
+                        component["key"], values=state.get_data(include_unsaved=True)
+                    )
+                    if not visible:
+                        return None
+                    return component
         return None
 
     @property

--- a/src/openforms/submissions/rendering/nodes.py
+++ b/src/openforms/submissions/rendering/nodes.py
@@ -57,8 +57,9 @@ class SubmissionStepNode(Node):
         # determine if the step as a whole is relevant or not. The stap may be not
         # applicable because of form logic.
         logic_evaluated = getattr(self.step, "_form_logic_evaluated", False)
-        if not logic_evaluated:
-            # logic should really be evaluated before rendering steps!
+        if not logic_evaluated and self.step.is_applicable:
+            # logic should really be evaluated, for applicable steps, before rendering
+            # steps!
             logger.warning(
                 "submissions.rendering.logic_not_evaluated",
                 submission_uuid=str(self.step.submission.uuid),

--- a/src/openforms/submissions/rendering/renderer.py
+++ b/src/openforms/submissions/rendering/renderer.py
@@ -68,13 +68,15 @@ class Renderer:
         """
         prefetch_related_objects(self.steps, "form_step__logic_rules")
         for step in self.steps:
-            new_configuration = evaluate_form_logic(
-                submission=self.submission, step=step
-            )
-            # update the configuration for introspection - note that we are mutating
-            # an instance here without persisting it to the backend on purpose!
-            # this replicates the run-time behaviour while filling out the form
-            step.form_step.form_definition.configuration = new_configuration
+            if step.is_applicable:
+                new_configuration = evaluate_form_logic(
+                    submission=self.submission, step=step
+                )
+                # update the configuration for introspection - note that we are mutating
+                # an instance here without persisting it to the backend on purpose!
+                # this replicates the run-time behaviour while filling out the form
+                step.form_step.form_definition.configuration = new_configuration
+
             submission_step_node = SubmissionStepNode(renderer=self, step=step)
             if not submission_step_node.is_visible:
                 continue

--- a/src/openforms/submissions/tests/renderer/test_renderer.py
+++ b/src/openforms/submissions/tests/renderer/test_renderer.py
@@ -138,3 +138,36 @@ class FormNodeTests(TestCase):
         # 3. Query the form logic rules for the submission form (and this is cached)
         with self.assertNumQueries(3):
             list(renderer)
+
+    def test_renderer_export_mode_with_form_logic_and_disabled_step(self):
+        """
+        Assert that the renderer contains all steps when exporting, even if some are
+        disabled.
+        """
+        # set up logic
+        form = self.submission.form
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "form_step_uuid": f"{self.sstep2.form_step.uuid}",
+                    "action": {
+                        "name": "Step is not applicable",
+                        "type": "step-not-applicable",
+                    },
+                }
+            ],
+        )
+        form.apply_logic_analysis()
+
+        renderer = Renderer(
+            submission=self.submission, mode=RenderModes.export, as_html=True
+        )
+
+        nodes = [node for node in renderer if isinstance(node, SubmissionStepNode)]
+
+        self.assertEqual(len(nodes), 2)
+        enabled_step_node, non_applicable_step_node = nodes
+        self.assertEqual(enabled_step_node.step, self.sstep1)
+        self.assertEqual(non_applicable_step_node.step, self.sstep2)

--- a/src/openforms/submissions/tests/test_post_submission_event.py
+++ b/src/openforms/submissions/tests/test_post_submission_event.py
@@ -13,7 +13,7 @@ from openforms.authentication.service import AuthAttribute
 from openforms.config.models import GlobalConfiguration
 from openforms.emails.tests.factories import ConfirmationEmailTemplateFactory
 from openforms.forms.constants import LogicActionTypes, PropertyTypes
-from openforms.forms.tests.factories import FormLogicFactory
+from openforms.forms.tests.factories import FormLogicFactory, FormStepFactory
 from openforms.logging.models import TimelineLogProxy
 from openforms.payments.constants import PaymentStatus
 from openforms.payments.tests.factories import SubmissionPaymentFactory
@@ -26,7 +26,7 @@ from openforms.tests.utils import log_flaky
 from ..constants import PostSubmissionEvents, RegistrationStatuses
 from ..models import SubmissionReport
 from ..tasks import on_post_submission_event
-from .factories import SubmissionFactory
+from .factories import SubmissionFactory, SubmissionStepFactory
 
 
 @temp_private_root()
@@ -1196,6 +1196,76 @@ class TaskOrchestrationPostSubmissionEventTests(TestCase):
             datetime(2024, 2, 16, 21, 15).replace(tzinfo=UTC),
         )
         self.assertEqual(submission.registration_attempts, 1)
+
+    def test_required_cosign_in_non_applicable_step_via_logic_proceeds_with_registration(
+        self,
+    ):
+        submission = SubmissionFactory.create(
+            completed=True,
+            cosign_complete=False,
+            form__registration_backend="email",
+            form__registration_backend_options={"to_emails": ["test@registration.nl"]},
+            auth_info__attribute=AuthAttribute.bsn,
+            auth_info__value="111222333",
+            language_code="en",
+        )
+
+        form_step = FormStepFactory.create(
+            form=submission.form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "checkbox",
+                        "type": "checkbox",
+                        "label": "Checkbox",
+                    }
+                ]
+            },
+        )
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=form_step,
+            data={
+                "checkbox": True,
+            },
+        )
+
+        # The form step that will become non-applicable through form logic
+        form_step2 = FormStepFactory.create(
+            form=submission.form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "cosign",
+                        "type": "cosign",
+                        "label": "Cosign component",
+                        "validate": {"required": True},
+                    },
+                ]
+            },
+        )
+        SubmissionStepFactory.create(
+            submission=submission, form_step=form_step2, data={}
+        )
+
+        # Make the second form step non-applicable
+        FormLogicFactory.create(
+            form=submission.form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "action": {"type": LogicActionTypes.step_not_applicable},
+                    "form_step_uuid": str(form_step2.uuid),
+                },
+            ],
+        )
+        submission.form.apply_logic_analysis()
+        assert submission.registration_status == RegistrationStatuses.pending
+
+        on_post_submission_event(submission.pk, PostSubmissionEvents.on_completion)
+
+        submission.refresh_from_db()
+        self.assertEqual(submission.registration_status, RegistrationStatuses.success)
 
 
 @temp_private_root()

--- a/src/openforms/submissions/tests/test_post_submission_event.py
+++ b/src/openforms/submissions/tests/test_post_submission_event.py
@@ -1267,6 +1267,131 @@ class TaskOrchestrationPostSubmissionEventTests(TestCase):
         submission.refresh_from_db()
         self.assertEqual(submission.registration_status, RegistrationStatuses.success)
 
+    def test_required_cosign_in_hidden_fieldset_via_logic_proceeds_with_registration(
+        self,
+    ):
+        submission = SubmissionFactory.from_components(
+            components_list=[
+                {
+                    "type": "fieldset",
+                    "key": "fieldset",
+                    "label": "Fieldset",
+                    "components": [
+                        {
+                            "key": "cosign",
+                            "type": "cosign",
+                            "label": "Cosign component",
+                            "validate": {"required": True},
+                        },
+                    ],
+                },
+            ],
+            submitted_data={},
+            completed=True,
+            cosign_complete=False,
+            form__registration_backend="email",
+            form__registration_backend_options={"to_emails": ["test@registration.nl"]},
+            auth_info__attribute=AuthAttribute.bsn,
+            auth_info__value="111222333",
+            language_code="en",
+        )
+        FormLogicFactory.create(
+            form=submission.form,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "action": {
+                        "type": LogicActionTypes.property,
+                        "property": {
+                            "type": PropertyTypes.bool,
+                            "value": "hidden",
+                        },
+                        "state": True,
+                    },
+                    "component": "fieldset",
+                }
+            ],
+        )
+        submission.form.apply_logic_analysis()
+        assert submission.registration_status == RegistrationStatuses.pending
+
+        on_post_submission_event(submission.pk, PostSubmissionEvents.on_completion)
+
+        submission.refresh_from_db()
+        self.assertEqual(submission.registration_status, RegistrationStatuses.success)
+
+    def test_empty_required_cosign_in_applicable_step_via_logic_does_not_proceed_with_registration(
+        self,
+    ):
+        submission = SubmissionFactory.create(
+            completed=True,
+            cosign_complete=False,
+            form__registration_backend="email",
+            form__registration_backend_options={"to_emails": ["test@registration.nl"]},
+            auth_info__attribute=AuthAttribute.bsn,
+            auth_info__value="111222333",
+            language_code="en",
+        )
+
+        form_step = FormStepFactory.create(
+            form=submission.form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "checkbox",
+                        "type": "checkbox",
+                        "label": "Checkbox",
+                    }
+                ]
+            },
+        )
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=form_step,
+            data={
+                "checkbox": True,
+            },
+        )
+
+        # The form step that will become applicable through form logic
+        form_step2 = FormStepFactory.create(
+            form=submission.form,
+            is_applicable=False,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "cosign",
+                        "type": "cosign",
+                        "label": "Cosign component",
+                        "validate": {"required": True},
+                    },
+                ]
+            },
+        )
+        SubmissionStepFactory.create(
+            submission=submission, form_step=form_step2, data={}
+        )
+
+        # Make the second form step applicable
+        FormLogicFactory.create(
+            form=submission.form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "action": {"type": LogicActionTypes.step_applicable},
+                    "form_step_uuid": str(form_step2.uuid),
+                },
+            ],
+        )
+        submission.form.apply_logic_analysis()
+        assert submission.registration_status == RegistrationStatuses.pending
+
+        on_post_submission_event(submission.pk, PostSubmissionEvents.on_completion)
+
+        submission.refresh_from_db()
+        # Registration status should still be pending, as cosign is missing
+        self.assertEqual(submission.registration_status, RegistrationStatuses.pending)
+
 
 @temp_private_root()
 @override_settings(CELERY_TASK_ALWAYS_EAGER=True)

--- a/src/openforms/submissions/tests/test_tasks_pdf.py
+++ b/src/openforms/submissions/tests/test_tasks_pdf.py
@@ -9,14 +9,16 @@ from freezegun import freeze_time
 from privates.test import temp_private_root
 from pyquery import PyQuery as pq
 
+from openforms.authentication.constants import AuthAttribute
 from openforms.logging.models import TimelineLogProxy
 from openforms.config.models import GlobalConfiguration
 from openforms.formio.constants import DataSrcOptions
-from openforms.forms.tests.factories import FormLogicFactory
+from openforms.forms.constants import LogicActionTypes
+from openforms.forms.tests.factories import FormLogicFactory, FormStepFactory
 
 from ..models import SubmissionReport
 from ..tasks.pdf import generate_submission_report
-from .factories import SubmissionFactory, SubmissionReportFactory
+from .factories import SubmissionFactory, SubmissionReportFactory, SubmissionStepFactory
 
 
 @temp_private_root()
@@ -678,6 +680,73 @@ class SubmissionReportGenerationTests(TestCase):
             "pdf_generation_failure"
         )
         self.assertEqual(logs.count(), 1)
+
+    def test_cosign_component_in_non_applicable_step_does_not_fail_pdf_render(self):
+        submission = SubmissionFactory.create(
+            completed=True,
+            cosign_complete=False,
+            form__registration_backend="email",
+            form__registration_backend_options={"to_emails": ["test@registration.nl"]},
+            auth_info__attribute=AuthAttribute.bsn,
+            auth_info__value="111222333",
+            language_code="en",
+            with_report=True,
+        )
+
+        # Empty filler form step
+        form_step = FormStepFactory.create(
+            form=submission.form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "checkbox",
+                        "type": "checkbox",
+                        "label": "Checkbox",
+                    }
+                ]
+            },
+        )
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=form_step,
+            data={
+                "checkbox": True,
+            },
+        )
+
+        # The form step that will become non-applicable through form logic
+        form_step2 = FormStepFactory.create(
+            form=submission.form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "key": "cosign",
+                        "type": "cosign",
+                        "label": "Cosign component",
+                        "validate": {"required": True},
+                    },
+                ]
+            },
+        )
+        SubmissionStepFactory.create(
+            submission=submission, form_step=form_step2, data={}
+        )
+
+        # Make the second form step non-applicable
+        FormLogicFactory.create(
+            form=submission.form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "action": {"type": LogicActionTypes.step_not_applicable},
+                    "form_step_uuid": str(form_step2.uuid),
+                },
+            ],
+        )
+        submission.form.apply_logic_analysis()
+
+        with self.assertNoLogs(level=logging.ERROR):
+            submission.report.generate_submission_report_pdf()
 
 
 @temp_private_root()


### PR DESCRIPTION
Closes #6259

**Changes**

Ensures that co-sign components in non-applicable don't block the registration and PDF rendering of a form submission.

- [x] Registration
- [x] PDF rendering

I've tried to find a more generic/global solution, but couldn't find a good place to add this check (i tried it with the `total_configuration_wrapper` of `submissions/model/submission.py`, but couldn't get it to work). Let me know if there is a more suitable place/solution for this problem.


### The problem, as far as i understand it, is as follows:

The `CosignState._find_component()` method would search across all form components, looking of a `co-sign` component.  `_find_component` did take into account hidden and hidden parent situations, but it didn't account for non-applicable form steps. So `_find_component` would find a `co-sign` component, which didn't have any data (because the form step was non-applicable), and complain about it.

Next we have the `evaluate_form_logic` method, which corrects the form step data as part of the final "Update relevant data structures" step. This would set the form step `unsaved_data` to an empty dict.

Finally comes the submission report / PDF generation, which also looks for `co-sign` components as part of the `confirmation_page_content` code. This again goes through the same steps as before, checking the `CosignState`, calling `_find_component()` and applying form logic rules. This would then crash when applying the logic rules, due to the previous change in `evaluate_form_logic`.

When `StepNotApplicableAction.apply` is called, it expects the step `unsaved_date` to be `None`. Normally, when applying the logic action when using the form, this is the case. But as the `evaluate_form_logic` changed the `unsaved_date` to a dict, this crashes the PDF generation.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
