### PR TITLE
[#6277] Update jsonLogic calls for variable action according to the library

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -349,7 +349,7 @@ maykin-2fa==2.1.0
     #   maykin-common
 maykin-common==0.20.0
     # via -r requirements/base.in
-maykin-json-logic-py==0.14.0
+maykin-json-logic-py==0.16.0
     # via -r requirements/base.in
 maykin-python3-saml==1.16.1
     # via django-digid-eherkenning

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -605,7 +605,7 @@ maykin-common==0.20.0
     #   -c requirements/base.txt
     #   -r requirements/base.txt
     #   -r requirements/test-tools.in
-maykin-json-logic-py==0.14.0
+maykin-json-logic-py==0.16.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -666,7 +666,7 @@ maykin-common==0.20.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-maykin-json-logic-py==0.14.0
+maykin-json-logic-py==0.16.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -563,7 +563,7 @@ maykin-common==0.20.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-maykin-json-logic-py==0.14.0
+maykin-json-logic-py==0.16.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -652,7 +652,7 @@ maykin-common==0.20.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-maykin-json-logic-py==0.14.0
+maykin-json-logic-py==0.16.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/src/openforms/formio/dynamic_config/dynamic_options.py
+++ b/src/openforms/formio/dynamic_config/dynamic_options.py
@@ -48,7 +48,7 @@ def get_options_from_variable(
     component: Component, data: FormioData, submission: Submission
 ) -> list[tuple[str, str]] | None:
     items_expression = glom(component, "openForms.itemsExpression")
-    items_array = jsonLogic(items_expression, data.data)
+    items_array = jsonLogic(items_expression, data.data, use_var_undefined=True)  # pyright: ignore[reportArgumentType]
     if not items_array:
         return
 

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -12,7 +12,7 @@ from django.core.cache import cache
 from django.core.serializers.json import DjangoJSONEncoder
 
 from glom import assign
-from json_logic import jsonLogic
+from json_logic import UNDEFINED_VALUE, jsonLogic
 
 from openforms.dmn.service import evaluate_dmn
 from openforms.formio.service import (
@@ -430,7 +430,17 @@ class VariableAction(ActionOperation):
         data_for_visible_state: FormioData,
     ) -> DataMapping:
         with log_errors(self.value, self.rule):
-            return {self.variable: jsonLogic(self.value, context.data)}  # pyright: ignore[reportArgumentType]
+            result = jsonLogic(
+                self.value,  # pyright: ignore[reportArgumentType]
+                context.data,  # pyright: ignore[reportArgumentType]
+                use_var_undefined=True,
+            )
+            # variables with None/null values are returned as UNDEFINED_VALUE when
+            # use_var_undefined is set to True and they should not be returned
+            if result is UNDEFINED_VALUE:
+                return {}
+
+            return {self.variable: result}
 
 
 class DataMappingsConfig(TypedDict):

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -436,7 +436,9 @@ class VariableAction(ActionOperation):
                 use_var_undefined=True,
             )
             # variables with None/null values are returned as UNDEFINED_VALUE when
-            # use_var_undefined is set to True and they should not be returned
+            # use_var_undefined is set to True and they are missing from the context
+            # entirely. If they are present in the context and None, then the output
+            # will be None.
             if result is UNDEFINED_VALUE:
                 return {}
 
@@ -646,6 +648,9 @@ class ServiceFetchAction(ActionOperation):
         var = self.rule.form.formvariable_set.get(key=self.variable)
         with log_errors({}, self.rule):  # TODO proper error handling
             result = perform_service_fetch(var, context, str(submission.uuid))
+            if result is None:
+                return {}
+
             return {var.key: result.value}
 
 

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -435,10 +435,9 @@ class VariableAction(ActionOperation):
                 context.data,  # pyright: ignore[reportArgumentType]
                 use_var_undefined=True,
             )
-            # variables with None/null values are returned as UNDEFINED_VALUE when
-            # use_var_undefined is set to True and they are missing from the context
-            # entirely. If they are present in the context and None, then the output
-            # will be None.
+            # variables are returned as UNDEFINED_VALUE when use_var_undefined is set to
+            # True and they are missing from the context entirely. If they are present in
+            # the context and None, then the output will be None.
             if result is UNDEFINED_VALUE:
                 return {}
 

--- a/src/openforms/submissions/logic/rules.py
+++ b/src/openforms/submissions/logic/rules.py
@@ -136,7 +136,13 @@ def iter_evaluate_rules(
         ):
             triggered = False
             with log_errors(rule.json_logic_trigger, rule):
-                triggered = bool(jsonLogic(rule.json_logic_trigger, data.data))
+                triggered = bool(
+                    jsonLogic(
+                        rule.json_logic_trigger,
+                        data.data,  # pyright: ignore[reportArgumentType]
+                        use_var_undefined=True,
+                    )
+                )
 
             # If the rule was not triggered, we still need to handle the clear on hide,
             # as components can be hidden by default and shown when a logic rule is

--- a/src/openforms/submissions/logic/service_fetching.py
+++ b/src/openforms/submissions/logic/service_fetching.py
@@ -6,7 +6,7 @@ from django.core.cache.backends.base import DEFAULT_TIMEOUT
 
 import jq
 import structlog
-from json_logic import jsonLogic
+from json_logic import UNDEFINED_VALUE, jsonLogic
 from zgw_consumers.client import build_client
 
 from openforms.formio.service import FormioData
@@ -29,7 +29,7 @@ class FetchResult:
 
 def perform_service_fetch(
     var: FormVariable, context: FormioData, submission_uuid: str = ""
-) -> FetchResult:
+) -> FetchResult | None:
     """Fetch a value from a http-service, perform a transformation on it and
     return the result.
 
@@ -82,6 +82,12 @@ def perform_service_fetch(
             value = jq.compile(expression).input(raw_value).first()
         case DataMappingTypes.json_logic, expression:
             value = jsonLogic(expression, raw_value, use_var_undefined=True)
+            # variables with None/null values are returned as UNDEFINED_VALUE when
+            # use_var_undefined is set to True and they are missing from the context
+            # entirely. If they are present in the context and None, then the output
+            # will be None.
+            if value is UNDEFINED_VALUE:
+                return None
         case _:
             value = raw_value
 

--- a/src/openforms/submissions/logic/service_fetching.py
+++ b/src/openforms/submissions/logic/service_fetching.py
@@ -82,10 +82,9 @@ def perform_service_fetch(
             value = jq.compile(expression).input(raw_value).first()
         case DataMappingTypes.json_logic, expression:
             value = jsonLogic(expression, raw_value, use_var_undefined=True)
-            # variables with None/null values are returned as UNDEFINED_VALUE when
-            # use_var_undefined is set to True and they are missing from the context
-            # entirely. If they are present in the context and None, then the output
-            # will be None.
+            # variables are returned as UNDEFINED_VALUE when use_var_undefined is set to
+            # True and they are missing from the context entirely. If they are present in
+            # the context and None, then the output will be None.
             if value is UNDEFINED_VALUE:
                 return None
         case _:

--- a/src/openforms/submissions/logic/service_fetching.py
+++ b/src/openforms/submissions/logic/service_fetching.py
@@ -81,7 +81,7 @@ def perform_service_fetch(
             # XXX raise warning if len(result) > 1 ?
             value = jq.compile(expression).input(raw_value).first()
         case DataMappingTypes.json_logic, expression:
-            value = jsonLogic(expression, raw_value)
+            value = jsonLogic(expression, raw_value, use_var_undefined=True)
         case _:
             value = raw_value
 

--- a/src/openforms/submissions/tests/form_logic/test_fetching_form_variable_values_from_services.py
+++ b/src/openforms/submissions/tests/form_logic/test_fetching_form_variable_values_from_services.py
@@ -372,6 +372,23 @@ class ServiceFetchConfigVariableBindingTests(DisableNLXRewritingMixin, SimpleTes
         self.assertEqual(value, "https://httpbin.org/get")
 
     @requests_mock.Mocker()
+    def test_it_applies_jsonlogic_with_use_var_undefined(self, m):
+        m.get("https://httpbin.org/get", json={"url": "https://httpbin.org/get"})
+
+        var = FormVariableFactory.build(
+            service_fetch_configuration=ServiceFetchConfigurationFactory.build(
+                service=self.service,
+                path="get",
+                data_mapping_type=DataMappingTypes.json_logic,
+                mapping_expression={"var": "wrong"},
+            )
+        )
+
+        result = perform_service_fetch(var, FormioData())
+
+        self.assertIsNone(result)
+
+    @requests_mock.Mocker()
     def test_it_applies_jq_on_response(self, m):
         m.get("https://httpbin.org/get", json={"url": "https://httpbin.org/get"})
 

--- a/src/openforms/submissions/tests/form_logic/test_modify_components.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_components.py
@@ -1510,3 +1510,105 @@ class ComponentModificationTests(TestCase):
         state = submission.variables_state
         data = state.get_data(include_unsaved=True)
         self.assertEqual("foo", data["textfield"])
+
+    def test_change_component_to_hidden_and_change_variable_value_action(self):
+        """
+        Test a form where a component with clearOnHide is hidden when a checkbox is checked.
+        Based on its value we update the value of a user defined and a component variable.
+        """
+        form = FormFactory.create()
+        step1 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "textField",
+                        "label": "TextField",
+                        "hidden": False,
+                        "clearOnHide": True,
+                    },
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                        "label": "Checkbox",
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "textField1",
+                        "label": "TextField 1",
+                        "hidden": False,
+                        "clearOnHide": False,
+                    },
+                ]
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="test",
+            user_defined=True,
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "component": "textField",
+                    "action": {
+                        "type": "property",
+                        "property": {"value": "hidden", "type": "bool"},
+                        "state": True,
+                    },
+                },
+                {
+                    "component": "",
+                    "variable": "test",
+                    "action": {"type": "variable", "value": {"var": "textField"}},
+                },
+                {
+                    "component": "",
+                    "variable": "textField1",
+                    "action": {"type": "variable", "value": {"var": "textField"}},
+                },
+            ],
+        )
+
+        form.apply_logic_analysis()
+
+        submission = SubmissionFactory.create(form=form)
+        submission_step = SubmissionStepFactory.create(
+            submission=submission, form_step=step1
+        )
+
+        data = FormioData({"checkbox": True, "textField1": ""})
+
+        configuration = evaluate_form_logic(submission, submission_step, data)
+
+        expected = {
+            "components": [
+                {
+                    "type": "textfield",
+                    "key": "textField",
+                    "label": "TextField",
+                    "hidden": True,
+                    "clearOnHide": True,
+                },
+                {"type": "checkbox", "key": "checkbox", "label": "Checkbox"},
+                {
+                    "type": "textfield",
+                    "key": "textField1",
+                    "label": "TextField 1",
+                    "hidden": False,
+                    "clearOnHide": False,
+                },
+            ]
+        }
+
+        state = submission.variables_state
+        data = state.get_data(include_unsaved=True)
+
+        self.assertEqual(configuration, expected)
+        self.assertEqual(
+            data, {"test": "", "textField": None, "checkbox": True, "textField1": ""}
+        )
+        self.assertTrue(state.variables["textField"].is_undefined)

--- a/src/openforms/submissions/tests/form_logic/test_modify_components.py
+++ b/src/openforms/submissions/tests/form_logic/test_modify_components.py
@@ -1580,7 +1580,8 @@ class ComponentModificationTests(TestCase):
             submission=submission, form_step=step1
         )
 
-        data = FormioData({"checkbox": True, "textField1": ""})
+        # initial state of the data before the checkbox is checked (all fields visible)
+        data = FormioData({"textField": "", "checkbox": True, "textField1": ""})
 
         configuration = evaluate_form_logic(submission, submission_step, data)
 
@@ -1608,6 +1609,9 @@ class ComponentModificationTests(TestCase):
         data = state.get_data(include_unsaved=True)
 
         self.assertEqual(configuration, expected)
+        # test and textField1 have their initial values
+        # the textField (with clearOnHide) is set to undefined and therefore is None
+        # the checkbox has been checked by the user so it's set to True
         self.assertEqual(
             data, {"test": "", "textField": None, "checkbox": True, "textField1": ""}
         )

--- a/src/openforms/submissions/tests/test_variables/test_fetch_with_logic.py
+++ b/src/openforms/submissions/tests/test_variables/test_fetch_with_logic.py
@@ -7,7 +7,11 @@ from zgw_consumers.test.factories import ServiceFactory
 
 from openforms.formio.service import FormioData
 from openforms.forms.constants import LogicActionTypes
-from openforms.forms.tests.factories import FormLogicFactory, FormVariableFactory
+from openforms.forms.tests.factories import (
+    FormLogicFactory,
+    FormVariableFactory,
+)
+from openforms.variables.constants import DataMappingTypes
 from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
 
 from ...form_logic import evaluate_form_logic
@@ -216,3 +220,43 @@ class ServiceFetchWithActionsTest(TestCase):
 
         self.assertEqual(len(m.request_history), 2)
         self.assertEqual(m.request_history[-1].url, "https://httpbin.org/get")
+
+    @requests_mock.Mocker(case_sensitive=True)
+    def test_with_undefined_variable_from_service_fetch(self, m):
+        submission = SubmissionFactory.from_components([])
+        fetch_config = ServiceFetchConfigurationFactory.create(
+            service=self.service,
+            path="get",
+            cache_timeout=30,
+            data_mapping_type=DataMappingTypes.json_logic,
+            mapping_expression={"var": "foo"},
+        )
+        FormVariableFactory.create(
+            key="someVariable",
+            form=submission.form,
+            service_fetch_configuration=fetch_config,
+        )
+
+        FormLogicFactory.create(
+            form=submission.form,
+            order=1,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "variable": "someVariable",
+                    "action": {
+                        "name": "Fetch some field from some server",
+                        "type": LogicActionTypes.fetch_from_service,
+                    },
+                }
+            ],
+        )
+        submission.form.apply_logic_analysis()
+
+        m.get("https://httpbin.org/get", json={})
+
+        evaluate_form_logic(submission, submission.submissionstep_set.first())
+
+        variables_data = submission.variables_state.get_data(include_unsaved=True)
+
+        self.assertEqual(variables_data, {"someVariable": ""})

--- a/src/openforms/utils/tests/test_shared_json_logic.py
+++ b/src/openforms/utils/tests/test_shared_json_logic.py
@@ -31,7 +31,7 @@ def name_to_id(arg: str):
 
 
 def evaluate_and_serialize(expression, input_data):
-    result = jsonLogic(expression, input_data, permissive=True)
+    result = jsonLogic(expression, input_data, permissive=True, use_var_undefined=True)
     return json.loads(json.dumps(result, cls=DjangoJSONEncoder))
 
 


### PR DESCRIPTION
Closes #6277

**Changes**

We use `jsonLogic` function from `json-logic-py` fork, where the `get_var` operation returns `None` in case of None/null values. This needs to change in OF so we adopt to the new flag` use_var_undefined` when we want to have 'undefined' as the return value instead of None. This is properly handled by OF where the logic rule is executed.

- [x] Update the code according to the new version of the library
- [x] Upgrade `json-logic-py` to new version

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
