### PR TITLE
#6155  add CustomerProfile.build_serializer_field

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -2,9 +2,14 @@ import re
 from collections.abc import Mapping, MutableMapping, Sequence
 from copy import deepcopy
 from datetime import date, datetime
-from typing import Protocol
+from typing import Protocol, assert_never
 
-from django.core.validators import MaxValueValidator, MinValueValidator, RegexValidator
+from django.core.validators import (
+    MaxValueValidator,
+    MinValueValidator,
+    RegexValidator,
+    validate_email,
+)
 from django.utils import timezone
 from django.utils.crypto import constant_time_compare
 from django.utils.html import format_html
@@ -62,6 +67,7 @@ from ..typing import (
     DatetimeComponent,
     MapComponent,
 )
+from ..typing.custom import DigitalAddress, SupportedChannels
 from ..utils import conform_to_mask
 from .np_family_members.haal_centraal import get_np_family_members_haal_centraal
 from .np_family_members.stuf_bg import get_np_family_members_stuf_bg
@@ -1178,6 +1184,84 @@ class LicensePlate(BasePlugin):
         return to_multiple(base) if multiple else base
 
 
+class ProfileValueSerializer(serializers.ListSerializer):
+    def validate(self, attrs):
+        attrs: list[DigitalAddress] = super().validate(attrs)
+
+        existing_types: list[SupportedChannels] = []
+        for address_data in attrs:
+            type = address_data["type"]
+            if type in existing_types:
+                raise serializers.ValidationError(
+                    _(
+                        "You cannot submit multiple digital addresses for the type '{type}'."
+                    ).format(type=type)
+                )
+
+            existing_types.append(type)
+
+        return attrs
+
+
+class DigitalAddressSerializer(serializers.Serializer):
+    address = serializers.CharField(
+        label=_("address"), help_text=_("The digital address value.")
+    )
+    type = serializers.ChoiceField(
+        label=_("type"),
+        choices=[],  # overwritten in get_fields
+        help_text=_("The type of digital address."),
+    )
+    preferenceUpdate = serializers.ChoiceField(
+        label=_("preference update"),
+        required=False,
+        choices=["useOnlyOnce", "isNewPreferred"],
+        help_text=_("Indicates if it is a one-off address or not."),
+    )
+
+    class Meta:
+        list_serializer_class = ProfileValueSerializer
+
+    def __init__(self, **kwargs):
+        self.digital_address_types: list[SupportedChannels] = kwargs.pop(
+            "digital_address_types", []
+        )
+        super().__init__(**kwargs)
+
+    def get_fields(self):
+        fields = super().get_fields()  # type: ignore
+
+        fields["address"].allow_blank = not self.required
+        # narrow down choices to the configured in the admin
+        fields["type"].choices = self.digital_address_types
+        return fields
+
+    def validate(self, attrs):
+        attrs = super().validate(attrs)
+
+        type: SupportedChannels = attrs["type"]
+        address = attrs["address"]
+
+        if not address:
+            return attrs
+
+        # validate address value depending on its type
+        match type:
+            case "email":
+                validate_email(address)
+
+            case "phoneNumber":
+                # replicate client-side validation in formio-renderer (buildPhoneNumberValidationSchema)
+                RegexValidator(
+                    regex="^[+0-9][- 0-9]+$", message=_("Enter a valid phone number.")
+                )(address)
+
+            case _:  # pragma: no cover
+                assert_never(type)
+
+        return attrs
+
+
 @register("customerProfile")
 class CustomerProfile(BasePlugin[CustomerProfileComponent]):
     formatter = CustomerProfileFormatter
@@ -1186,9 +1270,16 @@ class CustomerProfile(BasePlugin[CustomerProfileComponent]):
 
     def build_serializer_field(
         self, component: CustomerProfileComponent
-    ) -> serializers.JSONField:
+    ) -> DigitalAddressSerializer:
+
         required = component.get("validate", {}).get("required", False)
-        return serializers.JSONField(required=required, allow_null=True)
+
+        return DigitalAddressSerializer(
+            many=True,
+            digital_address_types=component["digitalAddressTypes"],
+            required=required,
+            allow_null=not required,
+        )
 
     @staticmethod
     def pre_registration_hook(

--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -1300,8 +1300,30 @@ class CustomerProfile(BasePlugin[CustomerProfileComponent]):
         return result
 
     @staticmethod
-    def as_json_schema(component: CustomerProfileComponent) -> None:
-        raise NotImplementedError()
+    def as_json_schema(component: CustomerProfileComponent) -> JSONObject:
+        label = component["label"]
+        schema = {
+            "title": label,
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": ["address", "type"],
+                "properties": {
+                    "address": {"type": "string"},
+                    "type": {
+                        "type": "string",
+                        "enum": component["digitalAddressTypes"],
+                    },
+                    "preferenceUpdate": {
+                        "type": "string",
+                        "enum": ["useOnlyOnce", "isNewPreferred"],
+                    },
+                },
+                "additionalProperties": False,
+            },
+        }
+
+        return schema
 
     def get_empty_value(self, component: CustomerProfileComponent):
         empty_value: JSONValue = [

--- a/src/openforms/formio/tests/test_component_json_schemas.py
+++ b/src/openforms/formio/tests/test_component_json_schemas.py
@@ -10,6 +10,7 @@ from ..typing import (
     ChildrenComponent,
     Component,
     ContentComponent,
+    CustomerProfileComponent,
     DateComponent,
     DatetimeComponent,
     EditGridComponent,
@@ -265,6 +266,16 @@ class ComponentValidJsonSchemaTests(SimpleTestCase):
             "key": "children",
             "type": "children",
             "enableSelection": False,
+        }
+        self.assertComponentSchemaIsValid(component=component)
+
+    def test_profile(self):
+        component: CustomerProfileComponent = {
+            "key": "profile",
+            "label": "profile",
+            "type": "customerProfile",
+            "digitalAddressTypes": ["email", "phoneNumber"],
+            "shouldUpdateCustomerData": True,
         }
         self.assertComponentSchemaIsValid(component=component)
 
@@ -1088,3 +1099,18 @@ class AddressNLTests(SimpleTestCase):
             schema["properties"]["postcode"]["pattern"], r"^1234 [A-Z]{2}$"
         )
         self.assertEqual(schema["properties"]["city"]["pattern"], r"Amsterdam")
+
+
+class CustomerProfileTests(SimpleTestCase):
+    def test_includes_selected_digital_types(self):
+        component: CustomerProfileComponent = {
+            "key": "profile",
+            "label": "profile",
+            "type": "customerProfile",
+            "digitalAddressTypes": ["email"],
+            "shouldUpdateCustomerData": True,
+        }
+
+        schema = as_json_schema(component)
+
+        self.assertEqual(schema["items"]["properties"]["type"]["enum"], ["email"])

--- a/src/openforms/formio/tests/validation/test_profile.py
+++ b/src/openforms/formio/tests/validation/test_profile.py
@@ -1,0 +1,231 @@
+from django.test import TestCase, tag
+from django.utils.translation import gettext_lazy as _
+
+from openforms.submissions.tests.factories import SubmissionFactory
+
+from ...typing.custom import CustomerProfileComponent
+from .helpers import extract_error, validate_formio_data
+
+
+@tag("gh-6155")
+class ProfileValidationTests(TestCase):
+    def test_validate_profile_not_empty_valid(self):
+        component: CustomerProfileComponent = {
+            "key": "profile",
+            "label": "profile",
+            "type": "customerProfile",
+            "digitalAddressTypes": ["email", "phoneNumber"],
+            "shouldUpdateCustomerData": True,
+            "validate": {
+                "required": True,
+            },
+        }
+
+        submission = SubmissionFactory.create(
+            form__generate_minimal_setup=True,
+            form__formstep__form_definition__configuration={"components": [component]},
+        )
+        valid_values = {
+            "profile": [
+                {
+                    "address": "john@smith.org",
+                    "type": "email",
+                },
+                {
+                    "address": "0612345678",
+                    "type": "phoneNumber",
+                },
+            ]
+        }
+
+        is_valid, _ = validate_formio_data(component, valid_values, submission)
+
+        self.assertTrue(is_valid)
+
+    def test_validate_profile_empty_valid(self):
+        component: CustomerProfileComponent = {
+            "key": "profile",
+            "label": "profile",
+            "type": "customerProfile",
+            "digitalAddressTypes": ["email", "phoneNumber"],
+            "shouldUpdateCustomerData": True,
+            "validate": {},
+        }
+        submission = SubmissionFactory.create(
+            form__generate_minimal_setup=True,
+            form__formstep__form_definition__configuration={"components": [component]},
+        )
+        valid_values = {
+            "profile": [
+                {
+                    "address": "",
+                    "type": "email",
+                    "preferenceUpdate": "useOnlyOnce",
+                },
+                {
+                    "address": "",
+                    "type": "phoneNumber",
+                    "preferenceUpdate": "useOnlyOnce",
+                },
+            ]
+        }
+        is_valid, _ = validate_formio_data(component, valid_values, submission)
+
+        self.assertTrue(is_valid)
+
+    def test_validate_profile_wrong_data_format(self):
+        component: CustomerProfileComponent = {
+            "key": "profile",
+            "label": "profile",
+            "type": "customerProfile",
+            "digitalAddressTypes": ["email", "phoneNumber"],
+            "shouldUpdateCustomerData": True,
+        }
+        submission = SubmissionFactory.create(
+            form__generate_minimal_setup=True,
+            form__formstep__form_definition__configuration={"components": [component]},
+        )
+        values = {"profile": "This data makes no sense"}
+
+        is_valid, _ = validate_formio_data(component, values, submission)
+
+        self.assertFalse(is_valid)
+
+    def test_validate_address_type_not_included_into_config(self):
+        component: CustomerProfileComponent = {
+            "key": "profile",
+            "label": "profile",
+            "type": "customerProfile",
+            "digitalAddressTypes": ["email"],
+            "shouldUpdateCustomerData": True,
+        }
+        submission = SubmissionFactory.create(
+            form__generate_minimal_setup=True,
+            form__formstep__form_definition__configuration={"components": [component]},
+        )
+        values = {
+            "profile": [
+                {
+                    "address": "john@smith.org",
+                    "type": "email",
+                    "preferenceUpdate": "useOnlyOnce",
+                },
+                {
+                    "address": "0812345678",
+                    "type": "phoneNumber",
+                    "preferenceUpdate": "useOnlyOnce",
+                },
+            ]
+        }
+
+        is_valid, errors = validate_formio_data(component, values, submission)
+
+        type_error = extract_error(errors["profile"][1], "type")
+
+        self.assertFalse(is_valid)
+        self.assertEqual(type_error.code, "invalid_choice")
+
+    def test_validate_profile_wrong_address_format_email(self):
+        component: CustomerProfileComponent = {
+            "key": "profile",
+            "label": "profile",
+            "type": "customerProfile",
+            "digitalAddressTypes": ["email"],
+            "shouldUpdateCustomerData": True,
+        }
+        submission = SubmissionFactory.create(
+            form__generate_minimal_setup=True,
+            form__formstep__form_definition__configuration={
+                "components": [
+                    component,
+                ]
+            },
+        )
+        values = {
+            "profile": [
+                {
+                    "address": "some-incorrect-email",
+                    "type": "email",
+                },
+            ]
+        }
+
+        is_valid, errors = validate_formio_data(component, values, submission)
+
+        error = extract_error(errors["profile"][0], "non_field_errors")
+
+        self.assertFalse(is_valid)
+        self.assertEqual(error, _("Enter a valid email address."))
+
+    def test_validate_profile_wrong_address_format_phone_number(self):
+        component: CustomerProfileComponent = {
+            "key": "profile",
+            "label": "profile",
+            "type": "customerProfile",
+            "digitalAddressTypes": ["phoneNumber"],
+            "shouldUpdateCustomerData": True,
+        }
+        submission = SubmissionFactory.create(
+            form__generate_minimal_setup=True,
+            form__formstep__form_definition__configuration={
+                "components": [
+                    component,
+                ]
+            },
+        )
+        values = {
+            "profile": [
+                {
+                    "address": "0ABC",
+                    "type": "phoneNumber",
+                },
+            ]
+        }
+        is_valid, errors = validate_formio_data(component, values, submission)
+
+        error = extract_error(errors["profile"][0], "non_field_errors")
+
+        self.assertFalse(is_valid)
+        self.assertEqual(error, _("Enter a valid phone number."))
+
+    def test_validate_profile_duplicated_types(self):
+        component: CustomerProfileComponent = {
+            "key": "profile",
+            "label": "profile",
+            "type": "customerProfile",
+            "digitalAddressTypes": ["email", "phoneNumber"],
+            "shouldUpdateCustomerData": True,
+        }
+        submission = SubmissionFactory.create(
+            form__generate_minimal_setup=True,
+            form__formstep__form_definition__configuration={
+                "components": [
+                    component,
+                ]
+            },
+        )
+        values = {
+            "profile": [
+                {
+                    "address": "john@smith.org",
+                    "type": "email",
+                },
+                {
+                    "address": "another@email.org",
+                    "type": "email",
+                },
+                {
+                    "address": "0812345678",
+                    "type": "phoneNumber",
+                },
+            ]
+        }
+
+        is_valid, errors = validate_formio_data(component, values, submission)
+        error = extract_error(errors["profile"], "non_field_errors")
+
+        self.assertFalse(is_valid)
+        self.assertEqual(
+            error,
+            _("You cannot submit multiple digital addresses for the type 'email'."),
+        )

--- a/src/openforms/submissions/tests/test_submission_step_validate.py
+++ b/src/openforms/submissions/tests/test_submission_step_validate.py
@@ -1,4 +1,3 @@
-from unittest import expectedFailure
 from unittest.mock import patch
 from uuid import UUID
 
@@ -1438,36 +1437,3 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
             },
         )
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
-
-    @tag("gh-6155")
-    @expectedFailure
-    def test_validation_of_profile_component_data(self):
-        submission = SubmissionFactory.create(
-            form__generate_minimal_setup=True,
-            form__formstep__form_definition__configuration={
-                "components": [
-                    {
-                        "key": "profile",
-                        "label": "profile",
-                        "type": "customerProfile",
-                        "digitalAddressTypes": ["email", "phoneNumber"],
-                        "shouldUpdateCustomerData": True,
-                    },
-                ]
-            },
-        )
-        step = submission.form.formstep_set.get()
-        self._add_submission_to_session(submission)
-
-        endpoint = reverse(
-            "api:submission-steps-detail",
-            kwargs={
-                "submission_uuid": submission.uuid,
-                "step_uuid": step.uuid,
-            },
-        )
-
-        response = self.client.put(
-            endpoint, {"data": {"profile": "This data makes no sense"}}
-        )
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
Closes #6155

**Changes**

* add `CustomerProfile.build_serializer_field` (the validation is based on front-end [validation](https://github.com/open-formulieren/formio-renderer/blob/main/src/registry/customerProfile/validationSchema.ts))
* add `CustomerProfile.as_json_schema`
* test them

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
