### PR TITLE
Make migration more resilient against broken forms

### DIFF
--- a/src/openforms/forms/migrations/0120_change_disable_next_logic_action.py
+++ b/src/openforms/forms/migrations/0120_change_disable_next_logic_action.py
@@ -59,6 +59,10 @@ def add_form_step_uuid_to_disable_next_actions(apps: StateApps, _):
 
         # Mapping from component to step for quick access
         form_steps = form.formstep_set.select_related("form_definition")
+        if form_steps.count() == 0:
+            # We cannot do anything if the form has relevant logic rules, but no steps.
+            # Those are broken forms.
+            continue
         component_to_step = {
             component["key"]: step
             for step in form_steps.iterator()

--- a/src/openforms/forms/tests/test_migrations.py
+++ b/src/openforms/forms/tests/test_migrations.py
@@ -227,6 +227,15 @@ class ChangeDisableLogicActionMigrationTests(MigratorTestCase):
         step_2 = FormStep.objects.create(form=form, form_definition=fd_2, order=1)
         FormStep.objects.create(form=form, form_definition=fd_3, order=2)
 
+        # Form without steps (and broken logic rule)
+        form_2 = Form.objects.create(name="Form without steps")
+        FormLogic.objects.create(
+            form=form_2,
+            order=0,
+            json_logic_trigger=True,
+            actions=[{"action": {"type": "disable-next"}, "form_step_uuid": ""}],
+        )
+
         # Form variables
         FormVariable.objects.create(
             form=form,
@@ -360,7 +369,7 @@ class ChangeDisableLogicActionMigrationTests(MigratorTestCase):
 
     def test_migration(self):
         Form = self.new_state.apps.get_model("forms", "Form")
-        form = Form.objects.get()
+        form = Form.objects.get(name="Form")
 
         steps = list(form.formstep_set.all())
         rules = list(form.formlogic_set.all())


### PR DESCRIPTION
Discovered during the production upgrade to 3.5.3. If a form has relevant logic rules but no steps, the migration would crash. We can simply skip these forms, because they are broken anyway :)

[skip: e2e]

**Changes**

Added an early exit if the form has no steps

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
