### PR TITLE
:bug: Fix submission lookup crash

### DIFF
--- a/src/openforms/emails/tests/test_digest_functions.py
+++ b/src/openforms/emails/tests/test_digest_functions.py
@@ -249,10 +249,18 @@ class FailedPrefillTests(TestCase):
         )
 
         # 1st failure(no values)
-        audit_log.info("prefill_retrieve_empty", submission_uuid=str(submission_1.uuid))
+        audit_log.info(
+            "prefill_retrieve_empty",
+            submission_uuid=str(submission_1.uuid),
+            submission_pk=submission_1.pk,
+        )
 
         # 2nd failure(no values)
-        audit_log.info("prefill_retrieve_empty", submission_uuid=str(submission_2.uuid))
+        audit_log.info(
+            "prefill_retrieve_empty",
+            submission_uuid=str(submission_2.uuid),
+            submission_pk=submission_2.pk,
+        )
 
         # 2nd form with 1 failure in the past 24 hours
         form_2 = FormFactory.create()
@@ -262,6 +270,7 @@ class FailedPrefillTests(TestCase):
         audit_logger.exception(
             "prefill.plugin.retrieve_failure",
             submission_uuid=str(submission.uuid),
+            submission_pk=submission.pk,
             plugin=stufbg_plugin,
             exc_info=NoServiceConfigured(),
         )
@@ -282,6 +291,7 @@ class FailedPrefillTests(TestCase):
         audit_logger.info(
             "prefill_retrieve_empty",
             submission_uuid=str(submission.uuid),
+            submission_pk=submission.pk,
             plugin=hc_plugin,
             attributes=["burgerservicenummer"],
         )

--- a/src/openforms/emails/tests/test_tasks_integration.py
+++ b/src/openforms/emails/tests/test_tasks_integration.py
@@ -193,7 +193,10 @@ class EmailDigestTaskIntegrationTests(TestCase):
         )
         hc_plugin = prefill_register["haalcentraal"]
 
-        audit_log = audit_logger.bind(submission_uuid=str(submission.uuid))
+        audit_log = audit_logger.bind(
+            submission_uuid=str(submission.uuid),
+            submission_pk=submission.pk,
+        )
 
         # trigger failures
         with freeze_time("2023-01-02T12:30:00+01:00"):

--- a/src/openforms/logging/adapter.py
+++ b/src/openforms/logging/adapter.py
@@ -511,11 +511,11 @@ def from_structlog(event_dict: EventDict) -> EventDetails:
         #
         case {
             "event": "prefill_retrieve_success" | "prefill_retrieve_empty" as event,
-            "submission_uuid": str(submission_uuid),
+            "submission_uuid": str(),
             "plugin": PrefillBasePlugin() as plugin,
             "attributes": [*prefill_fields],
         }:
-            submission = Submission.objects.get(uuid=submission_uuid)
+            assert submission is not None
             extra_tags: set[TimelineLogTags] = set()
             if event == "prefill_retrieve_success":
                 extra_tags.add(TimelineLogTags.AVG)
@@ -530,10 +530,10 @@ def from_structlog(event_dict: EventDict) -> EventDetails:
         case {
             "event": "prefill.plugin.retrieve_failure"
             | "prefill.plugin.ownership_check_failure",
-            "submission_uuid": str(submission_uuid),
+            "submission_uuid": str(),
             "plugin": PrefillBasePlugin() as plugin,
         }:
-            submission = Submission.objects.get(uuid=submission_uuid)
+            assert submission is not None
             return EventDetails(
                 event="prefill_retrieve_failure",
                 instance=submission,

--- a/src/openforms/logging/tests/test_admin.py
+++ b/src/openforms/logging/tests/test_admin.py
@@ -98,6 +98,7 @@ class AVGAuditLogListViewTests(WebTest):
         audit_logger.info(
             "prefill_retrieve_success",
             submission_uuid=str(submission.uuid),
+            submission_pk=submission.pk,
             plugin=register["haalcentraal"],
             attributes=["name"],
         )

--- a/src/openforms/prefill/service.py
+++ b/src/openforms/prefill/service.py
@@ -120,46 +120,46 @@ def prefill_variables(submission: Submission, register: Registry | None = None) 
     registry instance will be used.
     """
     register = register or default_register
-
     state = submission.variables_state
 
-    variables_with_attribute: list[SubmissionValueVariable] = []
-    variables_with_options: list[SubmissionValueVariable] = []
-    prefill_data: dict[str, JSONEncodable] = {}
+    with structlog.contextvars.bound_contextvars(submission_pk=submission.pk):
+        variables_with_attribute: list[SubmissionValueVariable] = []
+        variables_with_options: list[SubmissionValueVariable] = []
+        prefill_data: dict[str, JSONEncodable] = {}
 
-    for variable in state.prefilled_variables.values():
-        form_variable = variable.form_variable
-        assert form_variable is not None
-        # variables which have prefill enabled via the component's configuration
-        if (
-            form_variable.source == FormVariableSources.component
-            and form_variable.prefill_plugin
-            and form_variable.prefill_attribute
-        ):
-            variables_with_attribute.append(variable)
-            continue
-
-        if form_variable.source == FormVariableSources.user_defined:
-            # variables which have prefill enabled via the variables tab and define
-            # prefill options
-            if form_variable.prefill_plugin and form_variable.prefill_options:
-                variables_with_options.append(variable)
-
-            # variables which have prefill enabled via the variables tab and define
-            # prefill attribute
-            if form_variable.prefill_plugin and form_variable.prefill_attribute:
+        for variable in state.prefilled_variables.values():
+            form_variable = variable.form_variable
+            assert form_variable is not None
+            # variables which have prefill enabled via the component's configuration
+            if (
+                form_variable.source == FormVariableSources.component
+                and form_variable.prefill_plugin
+                and form_variable.prefill_attribute
+            ):
                 variables_with_attribute.append(variable)
+                continue
 
-    if variables_with_attribute:
-        results_from_attribute = fetch_prefill_values_from_attribute(
-            submission, register, variables_with_attribute
-        )
-        prefill_data.update(**results_from_attribute)
+            if form_variable.source == FormVariableSources.user_defined:
+                # variables which have prefill enabled via the variables tab and define
+                # prefill options
+                if form_variable.prefill_plugin and form_variable.prefill_options:
+                    variables_with_options.append(variable)
 
-    if variables_with_options:
-        results_from_options = fetch_prefill_values_from_options(
-            submission, register, variables_with_options
-        )
-        prefill_data.update(**results_from_options)
+                # variables which have prefill enabled via the variables tab and define
+                # prefill attribute
+                if form_variable.prefill_plugin and form_variable.prefill_attribute:
+                    variables_with_attribute.append(variable)
 
-    state.save_prefill_data(FormioData(prefill_data))
+        if variables_with_attribute:
+            results_from_attribute = fetch_prefill_values_from_attribute(
+                submission, register, variables_with_attribute
+            )
+            prefill_data.update(**results_from_attribute)
+
+        if variables_with_options:
+            results_from_options = fetch_prefill_values_from_options(
+                submission, register, variables_with_options
+            )
+            prefill_data.update(**results_from_options)
+
+        state.save_prefill_data(FormioData(prefill_data))


### PR DESCRIPTION
The patch in 4ea3072ef8fc6784355d6bed98bc7bdd306a60ec was not complete.

While it fixed the missing context propagation, the early resolution of the submission is overwritten in the event-specific handling and leads to a crash due to the transaction still being uncommitted.

I've opted for binding the submission pk in the prefill_variables function in the service, as that's the entrypoint most commonly used in tests.

[skip: e2e]
