### PR TITLE
[#6360] strip filename characters

### DIFF
--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -425,6 +425,8 @@ class FileSerializer(serializers.Serializer):
         # Here we apply the same changes to the "originalName" attribute, so it won't differ
         # from the stored file name
         attrs["originalName"] = sanitize_file_name(attrs["originalName"])
+        attrs["name"] = sanitize_file_name(attrs["name"])
+        attrs["data"]["name"] = sanitize_file_name(attrs["data"]["name"])
 
         for root_key, nested_key in (
             ("url", "url"),
@@ -450,7 +452,7 @@ class FileSerializer(serializers.Serializer):
                 {"size": _("Size does not match the uploaded file.")}
             )
 
-        if attrs["originalName"] != temporary_upload.file_name:
+        if attrs["originalName"] != sanitize_file_name(temporary_upload.file_name):
             raise serializers.ValidationError(
                 {"originalName": _("Name does not match the uploaded file.")}
             )

--- a/src/openforms/submissions/tests/test_submission_step_validate.py
+++ b/src/openforms/submissions/tests/test_submission_step_validate.py
@@ -756,8 +756,8 @@ class SubmissionStepValidationTests(SubmissionsMixin, APITestCase):
         )
         file = SubmittedFileFactory.create(
             temporary_upload=temporary_file_upload,
-            temporary_upload__data_name="Schermafbeelding 2025-07-08 om 09.39.36.png",  # no soft-hyphen
-            temporary_upload__original_name="Scherm­afbeelding 2025-07-08 om 09.39.36.png",  # soft-hyphen
+            temporary_upload__data_name="Scherm­afbeelding 2025-07-08 om 09.39.36.png",  # soft-hyphen
+            temporary_upload__original_name="Scherm­­afbeelding 2025-07-08 om 09.39.36.png",  # soft-hyphen
         )
 
         submission = temporary_file_upload.submission


### PR DESCRIPTION
Partly closes #6360

**Changes**

Allows uploading filenames with soft-hyphens.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
