### PR TITLE
Ensure legacy imports still work

### DIFF
--- a/src/openforms/forms/api/serializers/logic/form_logic.py
+++ b/src/openforms/forms/api/serializers/logic/form_logic.py
@@ -230,6 +230,11 @@ class FormLogicSerializer(
             attrs, self.context["form_variables"].variables, self.context["form_steps"]
         )
 
+        # Remove trigger from step for forms that have new logic evaluation enabled
+        # (which is the default when a form without this flag is imported).
+        if self.context["form"].new_logic_evaluation_enabled:
+            attrs.pop("trigger_from_step", None)
+
     def run_validation(self, data) -> None:
         # Override `run_validation` instead of `validate`, because it runs before
         # `LogicComponentActionSerializer.validate`.

--- a/src/openforms/forms/api/serializers/logic/form_logic.py
+++ b/src/openforms/forms/api/serializers/logic/form_logic.py
@@ -11,6 +11,9 @@ from rest_framework_nested.relations import NestedHyperlinkedRelatedField
 from openforms.api.fields import RelatedFieldFromContext
 from openforms.api.serializers import ListWithChildSerializer
 
+from ....disable_next_import_conversion import (
+    add_form_step_uuid_to_disable_next_actions,
+)
 from ....logic_analysis import (
     CyclesDetected,
     analyze_rules,
@@ -218,3 +221,17 @@ class FormLogicSerializer(
         related_field = self.Meta.model._meta.get_field("form")
         self.fields["form"].help_text = related_field.help_text
         self.fields["form"].label = related_field.verbose_name
+
+    def _handle_import(self, attrs) -> None:
+        if not self.context.get("is_import", False):
+            return
+
+        add_form_step_uuid_to_disable_next_actions(
+            attrs, self.context["form_variables"].variables, self.context["form_steps"]
+        )
+
+    def run_validation(self, data) -> None:
+        # Override `run_validation` instead of `validate`, because it runs before
+        # `LogicComponentActionSerializer.validate`.
+        self._handle_import(data)
+        return super().run_validation(data)

--- a/src/openforms/forms/disable_next_import_conversion.py
+++ b/src/openforms/forms/disable_next_import_conversion.py
@@ -1,0 +1,143 @@
+import uuid
+from collections.abc import Mapping
+from uuid import UUID
+
+from django.db.models import prefetch_related_objects
+
+from openforms.formio.service import iter_components
+from openforms.forms.models import FormStep, FormVariable
+from openforms.typing import JSONObject
+from openforms.utils.json_logic import introspect_json_logic
+from openforms.variables.service import resolve_key
+
+
+def create_action(step):
+    return {
+        "action": {"type": "disable-next"},
+        "form_step_uuid": str(step.uuid),
+        "uuid": str(uuid.uuid4()),
+    }
+
+
+def rule_contains_disable_next_action(rule):
+    for action in rule["actions"]:
+        if action["action"]["type"] == "disable-next":
+            return True
+
+    return False
+
+
+def add_form_step_uuid_to_disable_next_actions(
+    rule: JSONObject,
+    form_variables: Mapping[str, FormVariable],
+    form_step_map: Mapping[UUID, FormStep],
+):
+    if not rule_contains_disable_next_action(rule):
+        return
+
+    if not form_step_map:  # pragma: nocover
+        # Unlikely that a form without steps will be imported, but this avoids a hard
+        # crash.
+        return
+
+    # Mapping from component to step for quick access
+    form_step_list = list(form_step_map.values())
+    prefetch_related_objects(form_step_list, "form_definition")
+    component_to_step = {
+        component["key"]: step
+        for step in form_step_list
+        for component in iter_components(
+            step.form_definition.configuration,
+            recursive=True,
+            recurse_into_editgrid=False,
+        )
+    }
+
+    # Process logic rule
+    # Create a set of input variable steps by analyzing the logic trigger.
+    input_variable_steps = set()
+    first_step = form_step_list[0]
+    for input_var in introspect_json_logic(rule["json_logic_trigger"]).get_input_keys():
+        form_variable_key = resolve_key(input_var.key, form_variables)
+        if (
+            form_variable := form_variables.get(form_variable_key)
+        ) is None:  # pragma: nocover
+            continue
+
+        if form_variable.prefill_plugin:
+            # If the variable has prefill configured -> add the first step.
+            # This is because prefilled data will be available upon submission
+            # creation, so the rule _could_ be triggered on the first step. If
+            # prefill did not succeed, we still need to execute it on step of
+            # the input variable as well, because the user might be asked to
+            # fill in the data manually.
+            input_variable_steps.add(first_step)
+
+        if (step := component_to_step.get(form_variable.key)) is None:
+            # Cannot resolve step -> do nothing (likely because the variable is
+            # user defined).
+            continue
+
+        input_variable_steps.add(step)
+
+    trigger_from_step = rule.get("trigger_from_step")
+    if trigger_from_step is not None:
+        assert isinstance(trigger_from_step, str)
+        # This is dirty, but we cannot get the instance from the serializer without
+        # validating it first, which is not possible without adjusting the disable-next
+        # actions :upside_down_face:
+        step_uuid = trigger_from_step.rsplit("/", 1)[1]
+        # Note that the step UUID should exist in the form step map, because they are
+        # replaced from a UUID map in `import_form_data`. If it doesn't, the
+        # configuration is broken, but a `.get` avoids a hard crash.
+        trigger_from_step = form_step_map.get(UUID(step_uuid))
+
+    new_actions = []
+    for action in rule["actions"]:
+        new_actions.append(action)
+
+        if action["action"]["type"] != "disable-next" or action.get("form_step_uuid"):
+            # Skip non disable-next actions, or if a form step uuid was already
+            # configured -> trust it to be correct, to avoid (possibly incorrectly)
+            # overwriting it.
+            continue
+
+        if len(input_variable_steps) == 0:
+            # There are no input variables from the logic trigger, so assign the
+            # first step as a best guess (unless "trigger_from_step" is
+            # defined).
+            step_to_assign = (
+                trigger_from_step if trigger_from_step is not None else first_step
+            )
+            action["form_step_uuid"] = str(step_to_assign.uuid)
+        elif len(input_variable_steps) == 1:
+            # If there is only one step, assign it to the action (unless
+            # "trigger_from_step" is defined).
+            step_to_assign = (
+                trigger_from_step
+                if trigger_from_step is not None
+                else input_variable_steps.pop()
+            )
+            action["form_step_uuid"] = str(step_to_assign.uuid)
+        else:
+            # If "trigger_from_step" is defined, ensure we add it, and remove
+            # all other input variable steps that are before it.
+            if trigger_from_step:
+                input_variable_steps.add(trigger_from_step)
+                input_variable_steps = [
+                    step
+                    for step in input_variable_steps
+                    if step.order >= trigger_from_step.order
+                ]
+
+            # There are multiple steps, so assign the first step to the current
+            # action, and create new actions for the remaining steps
+            input_variable_steps = sorted(
+                input_variable_steps, key=lambda step: step.order
+            )
+            action["form_step_uuid"] = str(input_variable_steps.pop(0).uuid)
+
+            # Add new actions to the rule
+            new_actions.extend([create_action(step) for step in input_variable_steps])
+
+    rule["actions"] = new_actions

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -25,7 +25,7 @@ from openforms.registrations.contrib.zgw_apis.tests.factories import (
     ZGWApiGroupConfigFactory,
 )
 from openforms.utils.tests.vcr import OFVCRMixin
-from openforms.variables.constants import FormVariableSources
+from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
 
 from ...authentication.tests.factories import AttributeGroupFactory
@@ -1822,6 +1822,254 @@ class ImportExportTests(TempdirMixin, TestCase):
                 "zds_documenttype_omschrijving_inzending": "",
             },
         )
+
+    @tag("gh-6254")
+    def test_import_with_disable_next_actions(self):
+        """
+        Assert that the importing legacy forms still works with the disable-next action
+        rework.
+        """
+        # Form, form definitions, and form steps
+        form = FormFactory.create(name="Form", new_logic_evaluation_enabled=False)
+        FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {"type": "checkbox", "label": "Checkbox", "key": "checkbox"}
+                ]
+            },
+        )
+        step_2 = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {"type": "textfield", "label": "Textfield", "key": "textfield"},
+                    {
+                        "type": "date",
+                        "label": "Date",
+                        "key": "date",
+                        "prefill": {
+                            "plugin": "stufbg",
+                            "attribute": "geboortedatum",
+                            "identifierRole": "main",
+                        },
+                    },
+                ]
+            },
+        )
+        FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [{"type": "time", "label": "Time", "key": "time"}]
+            },
+        )
+
+        # Form variables
+        FormVariableFactory.create(
+            form=form,
+            name="user_defined",
+            key="user_defined",
+            source=FormVariableSources.user_defined,
+            data_type=FormVariableDataTypes.string,
+        )
+        FormVariableFactory.create(
+            form=form,
+            name="user_defined_prefill",
+            key="user_defined_prefill",
+            source=FormVariableSources.user_defined,
+            data_type=FormVariableDataTypes.date,
+            prefill_plugin="stufbg",
+            prefill_attribute="geboortedatum",
+            prefill_identifier_role="main",
+        )
+
+        # Logic rules
+        FormLogicFactory.create(
+            form=form,
+            order=0,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[{"action": {"type": "disable-next"}, "form_step_uuid": ""}],
+        )
+        FormLogicFactory.create(
+            form=form,
+            order=1,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[{"action": {"type": "disable-next"}, "form_step_uuid": ""}],
+            trigger_from_step=step_2,
+        )
+        FormLogicFactory.create(
+            form=form,
+            order=2,
+            json_logic_trigger={"==": [{"var": "date"}, "2000-01-01"]},
+            actions=[{"action": {"type": "disable-next"}, "form_step_uuid": ""}],
+        )
+        FormLogicFactory.create(
+            form=form,
+            order=3,
+            json_logic_trigger={
+                "or": [
+                    {"==": [{"var": "textfield"}, "foo"]},
+                    {"==": [{"var": "checkbox"}, True]},
+                ]
+            },
+            actions=[{"action": {"type": "disable-next"}, "form_step_uuid": ""}],
+            is_advanced=True,
+        )
+        FormLogicFactory.create(
+            form=form,
+            order=4,
+            json_logic_trigger={
+                "or": [
+                    {"==": [{"var": "textfield"}, "foo"]},
+                    {"==": [{"var": "checkbox"}, True]},
+                    {"==": [{"var": "time"}, "12:34"]},
+                ]
+            },
+            actions=[{"action": {"type": "disable-next"}, "form_step_uuid": ""}],
+            trigger_from_step=step_2,
+            is_advanced=True,
+        )
+        FormLogicFactory.create(
+            form=form,
+            order=5,
+            json_logic_trigger={"==": [{"var": "user_defined"}, "foo"]},
+            actions=[{"action": {"type": "disable-next"}, "form_step_uuid": ""}],
+            is_advanced=True,
+        )
+        FormLogicFactory.create(
+            form=form,
+            order=6,
+            json_logic_trigger={
+                "and": [
+                    {"==": [{"var": "user_defined_prefill"}, "2000-01-01"]},
+                    {"==": [{"var": "textfield"}, "foo"]},
+                ]
+            },
+            actions=[{"action": {"type": "disable-next"}, "form_step_uuid": ""}],
+            is_advanced=True,
+        )
+        FormLogic.objects.create(
+            form=form,
+            order=7,
+            json_logic_trigger={"==": [{"var": "checkbox"}, True]},
+            actions=[
+                {
+                    "action": {"type": "disable-next"},
+                    "form_step_uuid": str(step_2.uuid),
+                },
+            ],
+            is_advanced=True,
+        )
+
+        export_form(form.pk, archive_name=self.filepath)
+
+        # Import form
+        import_form(import_file=self.filepath)
+
+        imported_form = Form.objects.last()
+        imported_steps = list(imported_form.formstep_set.all())
+        imported_rules = list(imported_form.formlogic_set.all())
+
+        with self.subTest("Single input variable"):
+            # Only "checkbox" from the first step is in the trigger
+            rule = imported_rules[0]
+            self.assertEqual(len(rule.actions), 1)
+            self.assertEqual(
+                rule.actions[0]["form_step_uuid"], str(imported_steps[0].uuid)
+            )
+
+        with self.subTest("Trigger from step takes precedence"):
+            # The "trigger_from_step" is defined on this rule, so ensure it is assigned
+            # instead of the input trigger variable step (which would be the first step,
+            # where "checkbox" is located)
+            rule = imported_rules[1]
+            self.assertEqual(len(rule.actions), 1)
+            self.assertEqual(
+                rule.actions[0]["form_step_uuid"], str(imported_steps[1].uuid)
+            )
+
+        with self.subTest(
+            "First step is added as well if field has prefill configuration"
+        ):
+            # Components with prefill specified will have a value set upon submission
+            # creation, this means executing the rule on the first step has an effect on
+            # whether the user can continue. Therefore, even though the input trigger
+            # contains "date" from step 2, we need to assign step 1 as well to ensure no
+            # changes in behavior.
+            rule = imported_rules[2]
+            self.assertEqual(len(rule.actions), 2)
+            self.assertEqual(
+                rule.actions[0]["form_step_uuid"], str(imported_steps[0].uuid)
+            )
+            self.assertEqual(
+                rule.actions[1]["form_step_uuid"], str(imported_steps[1].uuid)
+            )
+            self.assertEqual(rule.actions[1]["action"], {"type": "disable-next"})
+
+        with self.subTest("Logic trigger contains input variables from multiple steps"):
+            # The logic trigger contains fields from steps 1 and 2, so ensure we add a
+            # disable-next action for both
+            rule = imported_rules[3]
+            self.assertEqual(len(rule.actions), 2)
+            self.assertEqual(
+                rule.actions[0]["form_step_uuid"], str(imported_steps[0].uuid)
+            )
+            self.assertEqual(
+                rule.actions[1]["form_step_uuid"], str(imported_steps[1].uuid)
+            )
+            self.assertEqual(rule.actions[1]["action"], {"type": "disable-next"})
+
+        with self.subTest(
+            "Logic trigger contains input variables from multiple steps with "
+            "trigger_form_step defined"
+        ):
+            # The trigger also contains "checkbox" from step 1, but it shouldn't be
+            # included in the actions because the "trigger_from_step" is set to step 2.
+            rule = imported_rules[4]
+            self.assertEqual(len(rule.actions), 2)
+            self.assertEqual(
+                rule.actions[0]["form_step_uuid"], str(imported_steps[1].uuid)
+            )
+            self.assertEqual(
+                rule.actions[1]["form_step_uuid"], str(imported_steps[2].uuid)
+            )
+            self.assertEqual(rule.actions[1]["action"], {"type": "disable-next"})
+
+        with self.subTest("With user-defined variable"):
+            # The logic trigger only contains a user-defined variable, and the rule does
+            # not have the "trigger_from_step" defined, so we cannot resolve a step.
+            # Ensure we assign the first step as a best guess.
+            rule = imported_rules[5]
+            self.assertEqual(len(rule.actions), 1)
+            self.assertEqual(
+                rule.actions[0]["form_step_uuid"], str(imported_steps[0].uuid)
+            )
+
+        with self.subTest(
+            "First step is added as well when user-defined variable has prefill "
+            "configuration"
+        ):
+            # The trigger contains "textfield" from the second step, and a user-defined
+            # variable with prefill. Ensure that we add the first and second step in
+            # this case, because prefilled data are available upon submission creation.
+            rule = imported_rules[6]
+            self.assertEqual(len(rule.actions), 2)
+            self.assertEqual(
+                rule.actions[0]["form_step_uuid"], str(imported_steps[0].uuid)
+            )
+            self.assertEqual(
+                rule.actions[1]["form_step_uuid"], str(imported_steps[1].uuid)
+            )
+            self.assertEqual(rule.actions[1]["action"], {"type": "disable-next"})
+
+        with self.subTest("Already configured disable-next action is left alone"):
+            # According to our analysis, the first step should be assigned to this
+            # action, but the second was already configured, so we leave it be.
+            rule = imported_rules[7]
+            self.assertEqual(len(rule.actions), 1)
+            self.assertEqual(
+                rule.actions[0]["form_step_uuid"], str(imported_steps[1].uuid)
+            )
 
 
 class ExportObjectsAPITests(TempdirMixin, TestCase):

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -296,7 +296,7 @@ def import_form_data(
                         "form_variables": FormVariableWrapper(_form),
                         "form_steps": {
                             form_step.uuid: form_step
-                            for form_step in _form.formstep_set.all()
+                            for form_step in _form.formstep_set.all().order_by("order")
                         },
                     }
                 )


### PR DESCRIPTION
Partly closes #6254

[skip: e2e]

**Changes**

* Added disable next import conversion
* Remove `trigger_from_step` from logic rules when new logic evaluation is enabled

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
