### PR TITLE
Apply form theme to suspend and co-sign emails

### DIFF
--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -586,6 +586,7 @@ class SubmissionSuspensionSerializer(serializers.ModelSerializer):
             render_email_template(config.save_form_email_content, context),
             settings.DEFAULT_FROM_EMAIL,
             [email],
+            theme=instance.form.theme,
         )
 
 

--- a/src/openforms/submissions/tasks/emails.py
+++ b/src/openforms/submissions/tasks/emails.py
@@ -146,6 +146,7 @@ def send_email_cosigner(submission_id: int) -> None:
                 from_email=settings.DEFAULT_FROM_EMAIL,
                 recipient_list=[recipient],
                 text_message=content,
+                theme=submission.form.theme,
                 extra_headers={
                     "Content-Language": submission.language_code,
                     X_OF_CONTENT_TYPE_HEADER: EmailContentTypeChoices.submission,

--- a/src/openforms/submissions/tests/test_submission_suspension.py
+++ b/src/openforms/submissions/tests/test_submission_suspension.py
@@ -24,6 +24,7 @@ from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
 from openforms.config.models import GlobalConfiguration
+from openforms.config.tests.factories import ThemeFactory
 from openforms.forms.constants import LogicActionTypes
 from openforms.forms.tests.factories import (
     FormFactory,
@@ -341,3 +342,24 @@ class SubmissionSuspensionTests(SubmissionsMixin, APITestCase):
         self.assertEqual(submission.suspended_on, timezone.now())
         self.assertFalse(submitted_step.completed)
         self.assertIsNone(submitted_step.completed_on)
+
+    def test_email_sent_uses_form_theme(self):
+        theme = ThemeFactory.create(
+            design_token_values={"of": {"page-footer": {"bg": {"value": "#facade"}}}}
+        )
+        submission = SubmissionFactory.create(form__theme=theme)
+        self._add_submission_to_session(submission)
+        endpoint = reverse("api:submission-suspend", kwargs={"uuid": submission.uuid})
+
+        with self.captureOnCommitCallbacks(execute=True):
+            response = self.client.post(endpoint, {"email": "hello@open-forms.nl"})
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(len(mail.outbox), 1)
+
+        message = mail.outbox[0]
+        assert isinstance(message, mail.EmailMultiAlternatives)
+        html_content, _ = message.alternatives[0]
+        assert isinstance(html_content, str)
+
+        self.assertIn("#facade", html_content)

--- a/src/openforms/submissions/tests/test_task_co_sign.py
+++ b/src/openforms/submissions/tests/test_task_co_sign.py
@@ -4,6 +4,7 @@ from django.core import mail
 from django.test import TestCase
 
 from openforms.config.models import GlobalConfiguration
+from openforms.config.tests.factories import ThemeFactory
 from openforms.emails.constants import EmailContentTypeChoices, EmailEventChoices
 from openforms.logging.models import TimelineLogProxy
 
@@ -206,3 +207,29 @@ class OnCompletionTests(TestCase):
                 "X-OF-Event": EmailEventChoices.cosign_request,
             },
         )
+
+    def test_email_uses_form_theme(self):
+        theme = ThemeFactory.create(
+            design_token_values={"of": {"page-footer": {"bg": {"value": "#facade"}}}}
+        )
+        submission = SubmissionFactory.from_components(
+            components_list=[
+                {
+                    "key": "cosign",
+                    "type": "cosign",
+                    "label": "Cosign component",
+                },
+            ],
+            submitted_data={"cosign": "cosigner@example.com"},
+            form__theme=theme,
+        )
+
+        send_email_cosigner(submission.id)
+
+        self.assertEqual(len(mail.outbox), 1)
+        message = mail.outbox[0]
+        assert isinstance(message, mail.EmailMultiAlternatives)
+        html_content, _ = message.alternatives[0]
+        assert isinstance(html_content, str)
+
+        self.assertIn("#facade", html_content)


### PR DESCRIPTION
Closes #6389

**Changes**

This pull request enhances the email functionality in the submissions module by ensuring that emails sent for submission suspension and cosigner requests use the theme associated with the form. It also adds comprehensive tests to verify that the correct theme styling is applied in these emails.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
