### PR TITLE
[#6350] Support hiding form title

### DIFF
--- a/docs/developers/embedding.rst
+++ b/docs/developers/embedding.rst
@@ -62,6 +62,12 @@ Available options
     Required. The UUID or slug of the form to embed. This can be obtained via the Open
     Forms admin interface.
 
+
+``showFormTitle``:
+    Optional. When set to ``true`` it shows the form title when the form is rendered. This
+    can be set to ``false`` in case this is needed (for example useful for embedded forms
+    that already have an ``h1`` element / title in the dom).
+
 ``basePath``:
     Optional, but highly recommended. The SDK considers this as the base URL and builds all
     URLs relatively to this URL.

--- a/src/openforms/forms/templates/forms/sdk_snippet.html
+++ b/src/openforms/forms/templates/forms/sdk_snippet.html
@@ -7,6 +7,7 @@
     id="openforms-container"
     data-sdk-module="{{ urls.sdk_esm_url }}"
     data-form-id="{{ form.slug }}"
+    data-show-form-title="true"
     data-base-url="{% api_base_url %}"
     data-base-path="{% if base_path %}{{ base_path }}{% else %}{% url 'forms:form-detail' slug=form.slug %}{% endif %}"
     data-csp-nonce="{{ request.csp_nonce }}"

--- a/src/openforms/forms/tests/test_views.py
+++ b/src/openforms/forms/tests/test_views.py
@@ -82,6 +82,12 @@ class FormDetailViewTests(WebTest):
 
         self.assertTemplateUsed(form_page, "forms/sdk_snippet.html")
 
+    def test_detail_page_contains_default_form_title_visibility_attribute(self):
+        form_page = self.app.get(self.url)
+        element = form_page.pyquery("[data-show-form-title]")
+
+        self.assertTrue(element.attr("data-show-form-title"))
+
     def test_design_tokens_rendered(self):
         theme = ThemeFactory.create(
             design_token_values={"of": {"layout": {"background": {"value": "#ffffff"}}}}

--- a/src/openforms/static/sdk-wrapper.mjs
+++ b/src/openforms/static/sdk-wrapper.mjs
@@ -13,6 +13,7 @@ const initializeSDK = async node => {
   const {
     sdkModule,
     formId,
+    showFormTitle,
     baseUrl,
     basePath,
     cspNonce,
@@ -25,17 +26,18 @@ const initializeSDK = async node => {
   const options = {
     baseUrl,
     formId,
+    showFormTitle: showFormTitle === 'false' ? false : true,
     basePath,
     CSPNonce: cspNonce,
     onLanguageChange: (newLanguageCode, initialDataReference) => {
-        // URL handling in JS requires a proper base since you can't just feed `foo` or `/foo`
-        // to the constructor. We only extract the pathname + query string again at the end.
-        const base = window.location.origin;
-        const url = new URL(basePath, base);
-        if (initialDataReference) {
-            url.searchParams.set('initial_data_reference', initialDataReference);
-        }
-        window.location.replace(`${url.pathname}${url.search}`);
+      // URL handling in JS requires a proper base since you can't just feed `foo` or `/foo`
+      // to the constructor. We only extract the pathname + query string again at the end.
+      const base = window.location.origin;
+      const url = new URL(basePath, base);
+      if (initialDataReference) {
+        url.searchParams.set('initial_data_reference', initialDataReference);
+      }
+      window.location.replace(`${url.pathname}${url.search}`);
     },
   };
   if (sentryDsn) options.sentryDSN = sentryDsn;


### PR DESCRIPTION
Closes #6350 partly

**Changes**

- Added a data attribute which will be picked up by the SDK and will render (or not) the form title.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
