### PR TITLE
Ensure hooks are not called conditionally

### DIFF
--- a/src/openforms/js/components/admin/form_design/FormLogic.js
+++ b/src/openforms/js/components/admin/form_design/FormLogic.js
@@ -341,6 +341,13 @@ const Rule = ({
     defaultMessage: 'Advanced',
   });
 
+  const {ConfirmationModal, confirmationModalProps, openConfirmationModal} = useConfirm();
+  const onConvertToAdvancedClick = async () => {
+    if (await openConfirmationModal()) {
+      onChange({target: {name: '_logicType', value: 'advanced'}});
+    }
+  };
+
   // if no logicType has been set yet, we first present the type selection before the
   // actual rule can be set up.
   if (!_logicType) {
@@ -351,13 +358,6 @@ const Rule = ({
       />
     );
   }
-
-  const {ConfirmationModal, confirmationModalProps, openConfirmationModal} = useConfirm();
-  const onConvertToAdvancedClick = async () => {
-    if (await openConfirmationModal()) {
-      onChange({target: {name: '_logicType', value: 'advanced'}});
-    }
-  };
 
   const boundaryErrorMessage = (
     <div className="logic-rule-error">


### PR DESCRIPTION
Follow up from #6393 

Not skipping e2e tests now to make sure :)

**Changes**

Fixed placement of `useConfirm` hook in `Rule`

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
