### PR TITLE
(Re?)-introduce the `DISABLE_2FA` envvar (for prod/staging settings)

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -796,6 +796,10 @@ MAYKIN_2FA_ALLOW_MFA_BYPASS_BACKENDS = [
     "mozilla_django_oidc_db.backends.OIDCAuthenticationBackend",
 ]
 
+if config("DISABLE_2FA", default=False):  # pragma: no cover
+    # None of the authentication backends require two-factor authentication.
+    MAYKIN_2FA_ALLOW_MFA_BYPASS_BACKENDS = AUTHENTICATION_BACKENDS
+
 #
 # CELERY - async task queue
 #

--- a/src/openforms/conf/dev.py
+++ b/src/openforms/conf/dev.py
@@ -14,6 +14,7 @@ os.environ.setdefault(
 )
 os.environ.setdefault("IS_HTTPS", "no")
 os.environ.setdefault("SESSION_COOKIE_SAMESITE", "Lax")
+os.environ.setdefault("DISABLE_2FA", "yes")
 os.environ.setdefault("VERSION_TAG", "dev")
 
 os.environ.setdefault("DB_NAME", "openforms")
@@ -139,10 +140,6 @@ if DISABLE_CSP_RATELIMITING:
 for _setting in (CONTENT_SECURITY_POLICY, CONTENT_SECURITY_POLICY_REPORT_ONLY):
     if _setting and "EXCLUDE_URL_PREFIXES" in _setting:
         _setting["EXCLUDE_URL_PREFIXES"] += ("/dev/", "/_healthz/")
-
-# None of the authentication backends require two-factor authentication.
-if config("DISABLE_2FA", default=True):  # pragma: no cover
-    MAYKIN_2FA_ALLOW_MFA_BYPASS_BACKENDS = AUTHENTICATION_BACKENDS
 
 # THOU SHALT NOT USE NAIVE DATETIMES
 warnings.filterwarnings(

--- a/src/openforms/conf/dev.py
+++ b/src/openforms/conf/dev.py
@@ -15,7 +15,6 @@ os.environ.setdefault(
 os.environ.setdefault("IS_HTTPS", "no")
 os.environ.setdefault("SESSION_COOKIE_SAMESITE", "Lax")
 os.environ.setdefault("DISABLE_2FA", "yes")
-os.environ.setdefault("VERSION_TAG", "dev")
 
 os.environ.setdefault("DB_NAME", "openforms")
 os.environ.setdefault("DB_USER", "openforms")
@@ -24,9 +23,6 @@ os.environ.setdefault("DB_PASSWORD", "openforms")
 os.environ.setdefault("ENVIRONMENT", "development")
 os.environ.setdefault("NUM_PROXIES", "0")
 
-os.environ.setdefault(
-    "EHERKENNING_PRIVACY_POLICY", "https://maykin.nl/nl/privacy-page/"
-)
 os.environ.setdefault("RELEASE", "dev")
 os.environ.setdefault("SDK_RELEASE", "latest")
 # otherwise the test suite is flaky due to logging config lookups to the DB in


### PR DESCRIPTION
Necessary to be able to disable MFA for the Open Forms event instance where we need simple username/password logins for 8-10 groups of attendees.

Backport to 3.5 is sufficient, so we can deploy `stable/3.5.x` for that instance (currently on 3.5.3).

[skip: e2e]