### PR TITLE
[#6398] Add static variable for form url

### DIFF
--- a/docs/developers/backend/core/variables.rst
+++ b/docs/developers/backend/core/variables.rst
@@ -46,7 +46,7 @@ Static variables
 ----------------
 
 Static variables are a third type of ``FormVariable``. These are not saved in the database and only live in memory.
-The endpoint ``/api/v1/variables/static`` gives a list of the static variables to which every form will have access to.
+The endpoint ``/api/v2/variables/static`` gives a list of the static variables to which every form will have access to.
 
 Adding new static variables
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/src/openforms/variables/static_variables/static_variables.py
+++ b/src/openforms/variables/static_variables/static_variables.py
@@ -1,4 +1,6 @@
 from datetime import date, datetime
+from typing import TypedDict
+from urllib.parse import ParseResult, parse_qs, urlparse
 
 from django.conf import settings
 from django.utils import timezone
@@ -9,6 +11,12 @@ from openforms.submissions.models import Submission
 from ..base import BaseStaticVariable
 from ..constants import FormVariableDataTypes
 from ..registry import register_static_variable
+
+
+class UrlInfo(TypedDict):
+    domain: str
+    page: str
+    query: dict[str, str]
 
 
 @register_static_variable("now")
@@ -88,3 +96,25 @@ class FormID(BaseStaticVariable):
 
     def as_json_schema(self):
         return {"title": "Form identifier", "type": "string", "format": "uuid"}
+
+
+@register_static_variable("form_url")
+class FormUrl(BaseStaticVariable):
+    name = _("Form Url")
+    data_type = FormVariableDataTypes.object
+
+    def get_initial_value(self, submission: Submission | None = None) -> UrlInfo:
+        form_url = str(submission.form_url) if submission else ""
+        parsed: ParseResult = urlparse(form_url)
+        return {
+            "domain": parsed.netloc,
+            "page": parsed.path if parsed.path.endswith("/") else parsed.path + "/",
+            "query": {k: v[0] for k, v in parse_qs(parsed.query).items()},
+        }
+
+    def as_json_schema(self):
+        return {
+            "title": "Form url metadata",
+            "description": "Details concerning the form's url",
+            "type": ["object", "null"],
+        }

--- a/src/openforms/variables/static_variables/static_variables.py
+++ b/src/openforms/variables/static_variables/static_variables.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping
 from datetime import date, datetime
 from typing import TypedDict
 from urllib.parse import ParseResult, parse_qs, urlparse
@@ -16,7 +17,7 @@ from ..registry import register_static_variable
 class UrlInfo(TypedDict):
     domain: str
     page: str
-    query: dict[str, str]
+    query: Mapping[str, str]
 
 
 @register_static_variable("now")
@@ -108,13 +109,18 @@ class FormUrl(BaseStaticVariable):
         parsed: ParseResult = urlparse(form_url)
         return {
             "domain": parsed.netloc,
-            "page": parsed.path if parsed.path.endswith("/") else parsed.path + "/",
-            "query": {k: v[0] for k, v in parse_qs(parsed.query).items()},
+            "page": parsed.path,
+            "query": {k: v[-1] for k, v in parse_qs(parsed.query).items()},
         }
 
     def as_json_schema(self):
         return {
-            "title": "Form url metadata",
-            "description": "Details concerning the form's url",
-            "type": ["object", "null"],
+            "type": "object",
+            "properties": {
+                "domain": {"type": "string"},
+                "page": {"type": "string"},
+                "query": {"type": "object", "additionalProperties": {"type": "string"}},
+            },
+            "required": ["domain", "page", "query"],
+            "additionalProperties": False,
         }

--- a/src/openforms/variables/tests/test_static_variables.py
+++ b/src/openforms/variables/tests/test_static_variables.py
@@ -123,6 +123,30 @@ class TodayTests(TestCase):
         self.assertEqual(variable.initial_value.day, 24)
 
 
+class FormUrlTests(TestCase):
+    def test_with_submission(self):
+        submission = SubmissionFactory.build(
+            form_url="https://www.example.com/some/value?foo=1&bar=2"
+        )
+        variable = _get_variable("form_url", submission=submission)
+
+        self.assertEqual(
+            variable.initial_value,
+            {
+                "domain": "www.example.com",
+                "page": "/some/value/",
+                "query": {"foo": "1", "bar": "2"},
+            },
+        )
+
+    def test_without_submission(self):
+        variable = _get_variable("form_url")
+
+        self.assertEqual(
+            variable.initial_value, {"domain": "", "page": "/", "query": {}}
+        )
+
+
 class StaticVariablesValidJsonSchemaTests(TestCase):
     validator = Draft202012Validator
 
@@ -161,4 +185,8 @@ class StaticVariablesValidJsonSchemaTests(TestCase):
 
     def test_form_id(self):
         schema = self._get_json_schema("form_id")
+        self.assertValidSchema(schema)
+
+    def test_form_url(self):
+        schema = self._get_json_schema("form_url")
         self.assertValidSchema(schema)

--- a/src/openforms/variables/tests/test_static_variables.py
+++ b/src/openforms/variables/tests/test_static_variables.py
@@ -134,8 +134,23 @@ class FormUrlTests(TestCase):
             variable.initial_value,
             {
                 "domain": "www.example.com",
-                "page": "/some/value/",
+                "page": "/some/value",
                 "query": {"foo": "1", "bar": "2"},
+            },
+        )
+
+    def test_with_submission_and_repeating_query_params(self):
+        submission = SubmissionFactory.build(
+            form_url="https://www.example.com/some/value?foo=1&foo=3&bar=2"
+        )
+        variable = _get_variable("form_url", submission=submission)
+
+        self.assertEqual(
+            variable.initial_value,
+            {
+                "domain": "www.example.com",
+                "page": "/some/value",
+                "query": {"foo": "3", "bar": "2"},
             },
         )
 
@@ -143,7 +158,7 @@ class FormUrlTests(TestCase):
         variable = _get_variable("form_url")
 
         self.assertEqual(
-            variable.initial_value, {"domain": "", "page": "/", "query": {}}
+            variable.initial_value, {"domain": "", "page": "", "query": {}}
         )
 
 


### PR DESCRIPTION
Closes #6398 

**Changes**

- Added new static variable for the form's url details/metadata.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
