### PR TITLE
[#6399] Additional logic actions for single step forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/prepare-release.md
+++ b/.github/ISSUE_TEMPLATE/prepare-release.md
@@ -80,6 +80,10 @@ assignees: sergei-maertens
     - [ ] `openforms.registrations.contrib.stuf_zds`
     - [ ] `openforms.registrations.contrib.zgw_apis`
 
+  - Submissions:
+
+    - [ ] `openforms.submissions.tests.test_single_step_form`
+
 - [ ] Release new SDK version
 - [ ] Correct SDK version pinned in `.sdk-release`
 - [ ] Check translations

--- a/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/Actions.js
@@ -115,16 +115,31 @@ const ActionProperty = ({action, errors, onChange}) => {
   );
 };
 
-const ActionVariableValue = ({action, errors, onChange}) => (
-  <>
-    <DSLEditorNode errors={errors.variable}>
-      <VariableSelection name="variable" onChange={onChange} value={action.variable} />
-    </DSLEditorNode>
-    <DSLEditorNode errors={errors.action?.value}>
-      <JsonWidget name="action.value" logic={action.action.value} onChange={onChange} />
-    </DSLEditorNode>
-  </>
-);
+const ActionVariableValue = ({action, errors, onChange}) => {
+  const {form} = useContext(FormContext);
+
+  return (
+    <>
+      <DSLEditorNode errors={errors.variable}>
+        <VariableSelection
+          name="variable"
+          onChange={onChange}
+          value={action.variable}
+          filter={
+            form.type === 'single_step'
+              ? variable => {
+                  return variable.source === 'user_defined';
+                }
+              : undefined
+          }
+        />
+      </DSLEditorNode>
+      <DSLEditorNode errors={errors.action?.value}>
+        <JsonWidget name="action.value" logic={action.action.value} onChange={onChange} />
+      </DSLEditorNode>
+    </>
+  );
+};
 
 const ActionSynchronizeVariables = ({action, errors, onChange}) => {
   const intl = useIntl();

--- a/src/openforms/js/components/admin/form_design/logic/actions/dmn/DMNParametersForm.js
+++ b/src/openforms/js/components/admin/form_design/logic/actions/dmn/DMNParametersForm.js
@@ -1,10 +1,11 @@
 import {parseExpression} from 'feelin';
 import {useFormikContext} from 'formik';
 import produce from 'immer';
-import React, {useEffect} from 'react';
+import React, {useContext, useEffect} from 'react';
 import {FormattedMessage, useIntl} from 'react-intl';
 import {useAsync} from 'react-use';
 
+import {FormContext} from 'components/admin/form_design/Context';
 import {DMN_DECISION_DEFINITIONS_PARAMS_LIST} from 'components/admin/form_design/constants';
 import VariableMapping from 'components/admin/forms/VariableMapping';
 import {FAIcon} from 'components/admin/icons';
@@ -104,6 +105,7 @@ const processInputParams = params => {
 const DMNParametersForm = () => {
   const intl = useIntl();
   const {values, setValues} = useFormikContext();
+  const {form} = useContext(FormContext);
   const {pluginId, decisionDefinitionId, decisionDefinitionVersion, inputMapping, outputMapping} =
     values;
 
@@ -218,6 +220,13 @@ const DMNParametersForm = () => {
             propertyHeading={dmnVariableColumnLabel}
             propertySelectLabel={dmnVariableSelectAriaLabel}
             rowCheck={detectMappingProblems}
+            filter={
+              form.type === 'single_step'
+                ? variable => {
+                    return variable.source === 'user_defined';
+                  }
+                : undefined
+            }
           />
         </div>
       </div>

--- a/src/openforms/js/components/admin/form_design/logic/constants.js
+++ b/src/openforms/js/components/admin/form_design/logic/constants.js
@@ -122,6 +122,20 @@ const REGULAR_FORM_ACTION_TYPES = [
 ];
 const SINGLE_STEP_FORM_ACTION_TYPES = [
   [
+    'variable',
+    defineMessage({
+      description: 'action type "variable" label',
+      defaultMessage: 'change the value of a variable/component',
+    }),
+  ],
+  [
+    'evaluate-dmn',
+    defineMessage({
+      description: 'action type "evaluate-dmn" label',
+      defaultMessage: 'Evaluate DMN',
+    }),
+  ],
+  [
     'set-registration-backend',
     defineMessage({
       description: 'action type "set-registration-backend" label',

--- a/src/openforms/js/components/admin/forms/VariableMapping.js
+++ b/src/openforms/js/components/admin/forms/VariableMapping.js
@@ -46,6 +46,7 @@ const VariableMappingRow = ({
   translatePropertyChoices,
   propertySelectLabel,
   onRemove,
+  filter,
   includeStaticVariables = false,
   alreadyMapped = [],
   rowCheck = undefined,
@@ -81,6 +82,7 @@ const VariableMappingRow = ({
               description: 'Accessible label for (form) variable dropdown',
               defaultMessage: 'Form variable',
             })}
+            filter={filter}
           />
         </Field>
       </td>
@@ -197,7 +199,14 @@ VariableMappingRow.propTypes = {
    * Validation errors from context
    */
   errors: PropTypes.objectOf(PropTypes.string),
+  /**
+   * Optional callback function to filter available variables.
+   *
+   */
+  filter: PropTypes.func,
 };
+
+const allowAny = () => true;
 
 /**
  * Map form variables to other properties.
@@ -219,6 +228,7 @@ const VariableMapping = ({
   propertySelectLabel,
   includeStaticVariables = false,
   rowCheck,
+  filter = allowAny,
 }) => {
   const {values, getFieldProps} = useFormikContext();
   const {value: mappings = []} = getFieldProps(name);
@@ -267,6 +277,7 @@ const VariableMapping = ({
                   alreadyMapped={alreadyMapped}
                   rowCheck={rowCheck}
                   errors={relatedErrors?.[index]}
+                  filter={filter}
                 />
               ))}
             </tbody>
@@ -359,6 +370,11 @@ VariableMapping.propTypes = {
    * of error messages, where `intl` is the context from react-intl's `useIntl()` hook.
    */
   rowCheck: PropTypes.func,
+  /**
+   * Optional callback function to filter available variables.
+   *
+   */
+  filter: PropTypes.func,
 };
 
 export default VariableMapping;

--- a/src/openforms/js/components/admin/forms/VariableMapping.js
+++ b/src/openforms/js/components/admin/forms/VariableMapping.js
@@ -206,8 +206,6 @@ VariableMappingRow.propTypes = {
   filter: PropTypes.func,
 };
 
-const allowAny = () => true;
-
 /**
  * Map form variables to other properties.
  *
@@ -228,7 +226,7 @@ const VariableMapping = ({
   propertySelectLabel,
   includeStaticVariables = false,
   rowCheck,
-  filter = allowAny,
+  filter,
 }) => {
   const {values, getFieldProps} = useFormikContext();
   const {value: mappings = []} = getFieldProps(name);

--- a/src/openforms/submissions/tests/test_single_step_form.py
+++ b/src/openforms/submissions/tests/test_single_step_form.py
@@ -2,11 +2,19 @@ from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
+from django_camunda.models import CamundaConfig
 from rest_framework import status
 from rest_framework.reverse import reverse, reverse_lazy
 from rest_framework.test import APITestCase
 
-from openforms.forms.tests.factories import FormFactory
+from openforms.forms.constants import LogicActionTypes
+from openforms.forms.tests.factories import (
+    FormFactory,
+    FormLogicFactory,
+    FormVariableFactory,
+)
+from openforms.utils.tests.vcr import OFVCRMixin
+from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 
 from ..models import Submission
 
@@ -71,3 +79,249 @@ class SingleStepFormTests(APITestCase):
 
         # 4. make sure the prefill was not called
         m.assert_not_called()
+
+    def test_single_step_form_with_logic_and_variable_action(self):
+        endpoint = reverse_lazy("api:submission-list")
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            is_single_step_form=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "textField",
+                        "label": "Textfield",
+                    },
+                    {
+                        "type": "checkbox",
+                        "key": "checkbox",
+                        "label": "Checkbox",
+                    },
+                ]
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="test",
+            source=FormVariableSources.user_defined,
+            data_type=FormVariableDataTypes.string,
+            form_definition=form.formstep_set.get().form_definition,
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "==": [
+                    {"var": "checkbox"},
+                    True,
+                ]
+            },
+            actions=[
+                {
+                    "action": {
+                        "type": "variable",
+                        "value": {"var": "textField"},
+                    },
+                    "variable": "test",
+                    "component": "",
+                }
+            ],
+        )
+
+        form_url = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
+
+        # 1. create the submission
+        submission_body = {
+            "form": f"http://testserver.com{form_url}",
+            "formUrl": "http://testserver.com/my-form",
+            "anonymous": True,
+            "initialDataReference": "of-or-3452fre3",
+        }
+
+        submission_response = self.client.post(
+            endpoint, submission_body, HTTP_HOST="testserver.com"
+        )
+        submission = Submission.objects.get()
+        form_step = form.formstep_set.get()
+
+        submission.form.apply_logic_analysis()
+
+        self.assertEqual(submission_response.status_code, status.HTTP_201_CREATED)
+
+        # 2. submit step data
+        submit_data_endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": form_step.uuid},
+        )
+        submit_data = {"data": {"textField": "foo", "checkbox": True}}
+        submit_data_response = self.client.put(
+            submit_data_endpoint, submit_data, HTTP_HOST="testserver.com"
+        )
+
+        self.assertEqual(submit_data_response.status_code, status.HTTP_201_CREATED)
+
+        # 3. complete form
+        complete_submission_endpoint = reverse(
+            "api:submission-complete",
+            kwargs={"uuid": submission.uuid},
+        )
+        complete_data = {
+            "privacy_policy_accepted": True,
+            "statementOfTruthAccepted": False,
+        }
+        complete_submission_response = self.client.post(
+            complete_submission_endpoint, complete_data, HTTP_HOST="testserver.com"
+        )
+
+        self.assertEqual(complete_submission_response.status_code, status.HTTP_200_OK)
+
+        # 4. make sure the submission value variables are correctly updated
+        variables = submission.submissionvaluevariable_set.all()
+        expected = {"textField": "foo", "checkbox": True, "test": "foo"}
+
+        for key, expected_value in expected.items():
+            obj = next(o for o in variables if o.key == key)
+            self.assertEqual(obj.value, expected_value)
+
+
+@override_settings(
+    CORS_ALLOW_ALL_ORIGINS=False,
+    ALLOWED_HOSTS=["*"],
+    CORS_ALLOWED_ORIGINS=["http://testserver.com"],
+)
+class SingleStepFormVCRTests(OFVCRMixin, APITestCase):
+    def setUp(self):
+        super().setUp()
+
+        config = CamundaConfig(
+            enabled=True,
+            root_url="http://localhost:8080/",
+            rest_api_path="engine-rest/",
+            auth_header="Basic ZGVtbzpkZW1v",
+        )
+
+        patcher = patch(
+            "openforms.dmn.contrib.camunda.checks.CamundaConfig.get_solo",
+            return_value=config,
+        )
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
+    def test_single_step_form_with_logic_and_dmn_action(self):
+        endpoint = reverse_lazy("api:submission-list")
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            is_single_step_form=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "invoiceAmount",
+                        "label": "Invoice Amount",
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "textField",
+                        "label": "Textfield",
+                    },
+                ]
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="test",
+            source=FormVariableSources.user_defined,
+            data_type=FormVariableDataTypes.string,
+            form_definition=form.formstep_set.get().form_definition,
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "component": "",
+                    "action": {
+                        "type": LogicActionTypes.evaluate_dmn,
+                        "config": {
+                            "plugin_id": "camunda7",
+                            "decision_definition_id": "invoiceClassification",
+                            "decision_definition_version": "2",
+                            "input_mapping": [
+                                {
+                                    "form_variable": "invoiceAmount",
+                                    "dmn_variable": "amount",
+                                },
+                                {
+                                    "form_variable": "textField",
+                                    "dmn_variable": "invoiceCategory",
+                                },
+                            ],
+                            "output_mapping": [
+                                {
+                                    "form_variable": "test",
+                                    "dmn_variable": "invoiceClassification",
+                                }
+                            ],
+                        },
+                    },
+                }
+            ],
+        )
+
+        form_url = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
+
+        # 1. create the submission
+        submission_body = {
+            "form": f"http://testserver.com{form_url}",
+            "formUrl": "http://testserver.com/my-form",
+            "anonymous": True,
+            "initialDataReference": "of-or-3452iou3",
+        }
+
+        submission_response = self.client.post(
+            endpoint, submission_body, HTTP_HOST="testserver.com"
+        )
+        submission = Submission.objects.get()
+        form_step = form.formstep_set.get()
+
+        submission.form.apply_logic_analysis()
+
+        self.assertEqual(submission_response.status_code, status.HTTP_201_CREATED)
+
+        # 2. submit step data
+        submit_data_endpoint = reverse(
+            "api:submission-steps-detail",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": form_step.uuid},
+        )
+        submit_data = {"data": {"textField": "Misc", "invoiceAmount": 100, "test": ""}}
+        submit_data_response = self.client.put(
+            submit_data_endpoint, submit_data, HTTP_HOST="testserver.com"
+        )
+
+        self.assertEqual(submit_data_response.status_code, status.HTTP_201_CREATED)
+
+        # 3. complete form
+        complete_submission_endpoint = reverse(
+            "api:submission-complete",
+            kwargs={"uuid": submission.uuid},
+        )
+        complete_data = {
+            "privacy_policy_accepted": True,
+            "statementOfTruthAccepted": False,
+        }
+        complete_submission_response = self.client.post(
+            complete_submission_endpoint, complete_data, HTTP_HOST="testserver.com"
+        )
+
+        self.assertEqual(complete_submission_response.status_code, status.HTTP_200_OK)
+
+        # 4. make sure the submission value variables are correctly updated
+        variables = submission.submissionvaluevariable_set.all()
+        expected = {
+            "invoiceAmount": 100,
+            "textField": "Misc",
+            "test": "day-to-day expense",
+        }
+
+        for key, expected_value in expected.items():
+            obj = next(o for o in variables if o.key == key)
+            self.assertEqual(obj.value, expected_value)

--- a/src/openforms/submissions/tests/test_single_step_form.py
+++ b/src/openforms/submissions/tests/test_single_step_form.py
@@ -14,7 +14,7 @@ from openforms.forms.tests.factories import (
     FormVariableFactory,
 )
 from openforms.utils.tests.vcr import OFVCRMixin
-from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
+from openforms.variables.constants import FormVariableDataTypes
 
 from ..models import Submission
 
@@ -103,9 +103,8 @@ class SingleStepFormTests(APITestCase):
         FormVariableFactory.create(
             form=form,
             key="test",
-            source=FormVariableSources.user_defined,
+            user_defined=True,
             data_type=FormVariableDataTypes.string,
-            form_definition=form.formstep_set.get().form_definition,
         )
         FormLogicFactory.create(
             form=form,
@@ -229,9 +228,8 @@ class SingleStepFormVCRTests(OFVCRMixin, APITestCase):
         FormVariableFactory.create(
             form=form,
             key="test",
-            source=FormVariableSources.user_defined,
+            user_defined=True,
             data_type=FormVariableDataTypes.string,
-            form_definition=form.formstep_set.get().form_definition,
         )
         FormLogicFactory.create(
             form=form,
@@ -292,7 +290,7 @@ class SingleStepFormVCRTests(OFVCRMixin, APITestCase):
             "api:submission-steps-detail",
             kwargs={"submission_uuid": submission.uuid, "step_uuid": form_step.uuid},
         )
-        submit_data = {"data": {"textField": "Misc", "invoiceAmount": 100, "test": ""}}
+        submit_data = {"data": {"textField": "Misc", "invoiceAmount": 100}}
         submit_data_response = self.client.put(
             submit_data_endpoint, submit_data, HTTP_HOST="testserver.com"
         )

--- a/src/openforms/submissions/tests/test_single_step_form.py
+++ b/src/openforms/submissions/tests/test_single_step_form.py
@@ -2,11 +2,11 @@ from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 
-from django_camunda.models import CamundaConfig
 from rest_framework import status
 from rest_framework.reverse import reverse, reverse_lazy
 from rest_framework.test import APITestCase
 
+from openforms.contrib.camunda.tests.utils import CamundaMixin
 from openforms.forms.constants import LogicActionTypes
 from openforms.forms.tests.factories import (
     FormFactory,
@@ -43,7 +43,7 @@ class SingleStepFormTests(APITestCase):
         }
 
         submission_response = self.client.post(
-            endpoint, submission_body, HTTP_HOST="testserver.com"
+            endpoint, submission_body, headers={"Host": "testserver.com"}
         )
         submission = Submission.objects.get()
         form_step = form.formstep_set.get()
@@ -57,7 +57,7 @@ class SingleStepFormTests(APITestCase):
         )
         submit_data = {"data": {"test-key-0": "foo"}}
         submit_data_response = self.client.put(
-            submit_data_endpoint, submit_data, HTTP_HOST="testserver.com"
+            submit_data_endpoint, submit_data, headers={"Host": "testserver.com"}
         )
 
         self.assertEqual(submit_data_response.status_code, status.HTTP_201_CREATED)
@@ -72,7 +72,9 @@ class SingleStepFormTests(APITestCase):
             "statementOfTruthAccepted": False,
         }
         complete_submission_response = self.client.post(
-            complete_submission_endpoint, complete_data, HTTP_HOST="testserver.com"
+            complete_submission_endpoint,
+            complete_data,
+            headers={"Host": "testserver.com"},
         )
 
         self.assertEqual(complete_submission_response.status_code, status.HTTP_200_OK)
@@ -126,6 +128,8 @@ class SingleStepFormTests(APITestCase):
             ],
         )
 
+        form.apply_logic_analysis()
+
         form_url = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
 
         # 1. create the submission
@@ -133,16 +137,13 @@ class SingleStepFormTests(APITestCase):
             "form": f"http://testserver.com{form_url}",
             "formUrl": "http://testserver.com/my-form",
             "anonymous": True,
-            "initialDataReference": "of-or-3452fre3",
         }
 
         submission_response = self.client.post(
-            endpoint, submission_body, HTTP_HOST="testserver.com"
+            endpoint, submission_body, headers={"Host": "testserver.com"}
         )
         submission = Submission.objects.get()
         form_step = form.formstep_set.get()
-
-        submission.form.apply_logic_analysis()
 
         self.assertEqual(submission_response.status_code, status.HTTP_201_CREATED)
 
@@ -153,7 +154,7 @@ class SingleStepFormTests(APITestCase):
         )
         submit_data = {"data": {"textField": "foo", "checkbox": True}}
         submit_data_response = self.client.put(
-            submit_data_endpoint, submit_data, HTTP_HOST="testserver.com"
+            submit_data_endpoint, submit_data, headers={"Host": "testserver.com"}
         )
 
         self.assertEqual(submit_data_response.status_code, status.HTTP_201_CREATED)
@@ -168,18 +169,18 @@ class SingleStepFormTests(APITestCase):
             "statementOfTruthAccepted": False,
         }
         complete_submission_response = self.client.post(
-            complete_submission_endpoint, complete_data, HTTP_HOST="testserver.com"
+            complete_submission_endpoint,
+            complete_data,
+            headers={"Host": "testserver.com"},
         )
 
         self.assertEqual(complete_submission_response.status_code, status.HTTP_200_OK)
 
         # 4. make sure the submission value variables are correctly updated
-        variables = submission.submissionvaluevariable_set.all()
+        variables_data = submission.variables_state.get_data()
         expected = {"textField": "foo", "checkbox": True, "test": "foo"}
 
-        for key, expected_value in expected.items():
-            obj = next(o for o in variables if o.key == key)
-            self.assertEqual(obj.value, expected_value)
+        self.assertEqual(variables_data, expected)
 
 
 @override_settings(
@@ -187,24 +188,7 @@ class SingleStepFormTests(APITestCase):
     ALLOWED_HOSTS=["*"],
     CORS_ALLOWED_ORIGINS=["http://testserver.com"],
 )
-class SingleStepFormVCRTests(OFVCRMixin, APITestCase):
-    def setUp(self):
-        super().setUp()
-
-        config = CamundaConfig(
-            enabled=True,
-            root_url="http://localhost:8080/",
-            rest_api_path="engine-rest/",
-            auth_header="Basic ZGVtbzpkZW1v",
-        )
-
-        patcher = patch(
-            "openforms.dmn.contrib.camunda.checks.CamundaConfig.get_solo",
-            return_value=config,
-        )
-        patcher.start()
-        self.addCleanup(patcher.stop)
-
+class SingleStepFormVCRTests(CamundaMixin, OFVCRMixin, APITestCase):
     def test_single_step_form_with_logic_and_dmn_action(self):
         endpoint = reverse_lazy("api:submission-list")
         form = FormFactory.create(
@@ -265,6 +249,8 @@ class SingleStepFormVCRTests(OFVCRMixin, APITestCase):
             ],
         )
 
+        form.apply_logic_analysis()
+
         form_url = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
 
         # 1. create the submission
@@ -272,16 +258,13 @@ class SingleStepFormVCRTests(OFVCRMixin, APITestCase):
             "form": f"http://testserver.com{form_url}",
             "formUrl": "http://testserver.com/my-form",
             "anonymous": True,
-            "initialDataReference": "of-or-3452iou3",
         }
 
         submission_response = self.client.post(
-            endpoint, submission_body, HTTP_HOST="testserver.com"
+            endpoint, submission_body, headers={"Host": "testserver.com"}
         )
         submission = Submission.objects.get()
         form_step = form.formstep_set.get()
-
-        submission.form.apply_logic_analysis()
 
         self.assertEqual(submission_response.status_code, status.HTTP_201_CREATED)
 
@@ -292,7 +275,7 @@ class SingleStepFormVCRTests(OFVCRMixin, APITestCase):
         )
         submit_data = {"data": {"textField": "Misc", "invoiceAmount": 100}}
         submit_data_response = self.client.put(
-            submit_data_endpoint, submit_data, HTTP_HOST="testserver.com"
+            submit_data_endpoint, submit_data, headers={"Host": "testserver.com"}
         )
 
         self.assertEqual(submit_data_response.status_code, status.HTTP_201_CREATED)
@@ -307,19 +290,19 @@ class SingleStepFormVCRTests(OFVCRMixin, APITestCase):
             "statementOfTruthAccepted": False,
         }
         complete_submission_response = self.client.post(
-            complete_submission_endpoint, complete_data, HTTP_HOST="testserver.com"
+            complete_submission_endpoint,
+            complete_data,
+            headers={"Host": "testserver.com"},
         )
 
         self.assertEqual(complete_submission_response.status_code, status.HTTP_200_OK)
 
         # 4. make sure the submission value variables are correctly updated
-        variables = submission.submissionvaluevariable_set.all()
+        variables_data = submission.variables_state.get_data()
         expected = {
             "invoiceAmount": 100,
             "textField": "Misc",
             "test": "day-to-day expense",
         }
 
-        for key, expected_value in expected.items():
-            obj = next(o for o in variables if o.key == key)
-            self.assertEqual(obj.value, expected_value)
+        self.assertEqual(variables_data, expected)

--- a/src/openforms/submissions/tests/vcr_cassettes/test_single_step_form/SingleStepFormVCRTests/test_single_step_form_with_logic_and_dmn_action.yaml
+++ b/src/openforms/submissions/tests/vcr_cassettes/test_single_step_form/SingleStepFormVCRTests/test_single_step_form_with_logic_and_dmn_action.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Jul 2026 14:11:18 GMT
+      - Mon, 06 Jul 2026 12:05:58 GMT
       Keep-Alive:
       - timeout=20
       Transfer-Encoding:
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Jul 2026 14:11:18 GMT
+      - Mon, 06 Jul 2026 12:05:58 GMT
       Keep-Alive:
       - timeout=20
       Transfer-Encoding:
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Jul 2026 14:11:18 GMT
+      - Mon, 06 Jul 2026 12:05:58 GMT
       Keep-Alive:
       - timeout=20
       Transfer-Encoding:
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Thu, 02 Jul 2026 14:11:18 GMT
+      - Mon, 06 Jul 2026 12:05:58 GMT
       Keep-Alive:
       - timeout=20
       Transfer-Encoding:

--- a/src/openforms/submissions/tests/vcr_cassettes/test_single_step_form/SingleStepFormVCRTests/test_single_step_form_with_logic_and_dmn_action.yaml
+++ b/src/openforms/submissions/tests/vcr_cassettes/test_single_step_form/SingleStepFormVCRTests/test_single_step_form_with_logic_and_dmn_action.yaml
@@ -1,0 +1,138 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8080/engine-rest/decision-definition?key=invoiceClassification&version=2
+  response:
+    body:
+      string: '[{"id":"invoiceClassification:2:cad9e468-8958-11f0-83f9-5236f7f49fcc","key":"invoiceClassification","category":"http://camunda.org/schema/1.0/dmn","name":"Invoice
+        Classification","version":2,"resource":"invoiceBusinessDecisions.dmn","deploymentId":"cad32da2-8958-11f0-83f9-5236f7f49fcc","tenantId":null,"decisionRequirementsDefinitionId":"invoiceBusinessDecisions:2:cad9bd57-8958-11f0-83f9-5236f7f49fcc","decisionRequirementsDefinitionKey":"invoiceBusinessDecisions","historyTimeToLive":null,"versionTag":null}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 30 Jun 2026 07:02:48 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+- request:
+    body: '{"variables": {"amount": {"type": "Null", "value": null}, "invoiceCategory":
+      {"type": "String", "value": ""}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '110'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8080/engine-rest/decision-definition/invoiceClassification:2:cad9e468-8958-11f0-83f9-5236f7f49fcc/evaluate
+  response:
+    body:
+      string: '[]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 30 Jun 2026 07:02:48 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8080/engine-rest/decision-definition?key=invoiceClassification&version=2
+  response:
+    body:
+      string: '[{"id":"invoiceClassification:2:cad9e468-8958-11f0-83f9-5236f7f49fcc","key":"invoiceClassification","category":"http://camunda.org/schema/1.0/dmn","name":"Invoice
+        Classification","version":2,"resource":"invoiceBusinessDecisions.dmn","deploymentId":"cad32da2-8958-11f0-83f9-5236f7f49fcc","tenantId":null,"decisionRequirementsDefinitionId":"invoiceBusinessDecisions:2:cad9bd57-8958-11f0-83f9-5236f7f49fcc","decisionRequirementsDefinitionKey":"invoiceBusinessDecisions","historyTimeToLive":null,"versionTag":null}]'
+    headers:
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 30 Jun 2026 07:02:48 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+- request:
+    body: '{"variables": {"amount": {"type": "Integer", "value": 100}, "invoiceCategory":
+      {"type": "String", "value": "Misc"}}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '116'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8080/engine-rest/decision-definition/invoiceClassification:2:cad9e468-8958-11f0-83f9-5236f7f49fcc/evaluate
+  response:
+    body:
+      string: '[{"invoiceClassification":{"type":"String","value":"day-to-day expense","valueInfo":{}}}]'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      Date:
+      - Tue, 30 Jun 2026 07:02:48 GMT
+      Keep-Alive:
+      - timeout=20
+      Transfer-Encoding:
+      - chunked
+    status:
+      code: 200
+      message: ''
+version: 1

--- a/src/openforms/submissions/tests/vcr_cassettes/test_single_step_form/SingleStepFormVCRTests/test_single_step_form_with_logic_and_dmn_action.yaml
+++ b/src/openforms/submissions/tests/vcr_cassettes/test_single_step_form/SingleStepFormVCRTests/test_single_step_form_with_logic_and_dmn_action.yaml
@@ -24,7 +24,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 30 Jun 2026 07:02:48 GMT
+      - Thu, 02 Jul 2026 14:11:18 GMT
       Keep-Alive:
       - timeout=20
       Transfer-Encoding:
@@ -59,7 +59,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 30 Jun 2026 07:02:48 GMT
+      - Thu, 02 Jul 2026 14:11:18 GMT
       Keep-Alive:
       - timeout=20
       Transfer-Encoding:
@@ -92,7 +92,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 30 Jun 2026 07:02:48 GMT
+      - Thu, 02 Jul 2026 14:11:18 GMT
       Keep-Alive:
       - timeout=20
       Transfer-Encoding:
@@ -127,7 +127,7 @@ interactions:
       Content-Type:
       - application/json
       Date:
-      - Tue, 30 Jun 2026 07:02:48 GMT
+      - Thu, 02 Jul 2026 14:11:18 GMT
       Keep-Alive:
       - timeout=20
       Transfer-Encoding:


### PR DESCRIPTION
Closes #6399

**Changes**

- Make it possible to select and process *change the value of a variable/component* and *Evaluate DMN* actions in `single_step` forms. The documentation for these will be part of task #6352

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
