### PR TITLE
Add check for file component catalogue consistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -115,6 +115,7 @@ COPY \
     ./bin/report_component_problems.py \
     ./bin/report_invalid_form_logic.py \
     ./bin/report_logic_with_deprecated_clear_on_hide_behavior.py \
+    ./bin/report_file_component_inconsistent_catalogues.py \
     ./bin/
 
 # prevent writing to the container layer, which would degrade performance.

--- a/bin/report_file_component_inconsistent_catalogues.py
+++ b/bin/report_file_component_inconsistent_catalogues.py
@@ -1,0 +1,191 @@
+#!/usr/bin/env python
+#
+# Introspect file components used in forms with the ZGW or Objects API registration
+# plugin and report which file components resolved to a different catalogue than the
+# one in the registration plugin settings.
+#
+# This check is intended to run *after* the data migrations that copied all the
+# configuration to the individual registration backends. It cannot be run in a
+# preventive manner as upgrade check because these problems cannot be corrected pre-4.0.
+#
+from __future__ import annotations
+
+import sys
+from collections.abc import Iterator
+from dataclasses import dataclass
+from itertools import chain
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+import django
+from django.db.models import Prefetch
+
+import click
+from tabulate import tabulate
+
+SRC_DIR = Path(__file__).parent.parent / "src"
+sys.path.insert(0, str(SRC_DIR.resolve()))
+
+if TYPE_CHECKING:
+    from openforms.formio.typing import FileComponent
+
+
+def iter_file_components(form) -> Iterator[FileComponent]:
+    from openforms.formio.service import iter_components
+
+    step_components_generator = (
+        iter_components(
+            step.form_definition.configuration,
+            recursive=True,
+            recurse_into_editgrid=True,
+        )
+        for step in form.formstep_set.all()
+    )
+    for component in chain.from_iterable(step_components_generator):
+        if component["type"] != "file":
+            continue
+        yield component  # pyright: ignore[reportReturnType]
+
+
+@dataclass
+class Problem:
+    form_name: str
+    form_id: int
+    registration_backend_name: str
+    registration_backend_type: str
+    component_key: str
+
+
+def report_components() -> bool:
+    """
+    Scan forms with file components and ZGW APIs/Objects API registration plugin usage.
+
+    :returns: ``True`` if no problems are detected, ``False`` if there are issues
+      detected.
+    """
+    from openforms.forms.models import Form, FormRegistrationBackend, FormStep
+    from openforms.registrations.contrib.objects_api.constants import (
+        PLUGIN_IDENTIFIER as OBJECTS_API_PLUGIN_IDENTIFIER,
+    )
+    from openforms.registrations.contrib.zgw_apis.plugin import (
+        PLUGIN_IDENTIFIER as ZGW_APIS_PLUGIN_IDENTIFIER,
+    )
+    from openforms.registrations.contrib.zgw_apis.typing import CatalogueOption
+
+    RELEVANT_BACKENDS = {
+        OBJECTS_API_PLUGIN_IDENTIFIER,
+        ZGW_APIS_PLUGIN_IDENTIFIER,
+    }
+
+    forms = (
+        Form.objects.prefetch_related(
+            Prefetch(
+                "registration_backends",
+                queryset=FormRegistrationBackend.objects.filter(
+                    backend__in=RELEVANT_BACKENDS
+                ),
+            ),
+            Prefetch(
+                "formstep_set",
+                queryset=FormStep.objects.select_related("form_definition"),
+            ),
+        )
+        .filter(registration_backends__backend__in=RELEVANT_BACKENDS)
+        .distinct()
+    )
+    problems: list[Problem] = []
+    for form in forms.iterator(chunk_size=10):
+        file_component_catalogues: dict[str, CatalogueOption] = {}
+
+        for file_component in iter_file_components(form):
+            # check the catalogue that's specified or resolved by the migration tool on
+            # 3.5. The data migration copies the configuration, but leaves the old
+            # configuration on the component, so we can easily test this catalogue
+            # against the registration backend catalogues without doing network IO.
+            if not (registration := file_component.get("registration")):
+                continue
+            if not (document_type := registration.get("documentType")):
+                continue
+            if not (catalogue := document_type.get("catalogue")):
+                continue
+            file_component_catalogues[file_component["key"]] = catalogue
+
+        # nothing to check, bail early
+        if not file_component_catalogues:
+            continue
+
+        for backend in form.registration_backends.all():
+            # compare the catalogue of the backend with the files
+            backend_catalogue = backend.options.get("catalogue", {})
+            for key, catalogue in file_component_catalogues.items():
+                if catalogue == backend_catalogue:
+                    continue
+                problems.append(
+                    Problem(
+                        form_name=form.admin_name,
+                        form_id=form.pk,
+                        registration_backend_name=backend.name,
+                        registration_backend_type=backend.backend,
+                        component_key=key,
+                    )
+                )
+
+    if not problems:
+        click.echo(click.style("No inconsistencies found.", fg="green"))
+        return True
+
+    def _report_problems() -> Iterator[tuple[str, str, str, str, str]]:
+        form_id: int = 0
+        backend_name = ""
+
+        for problem in problems:
+            form_id_changed = problem.form_id != form_id
+            form_id = problem.form_id
+
+            backend_name_changed = problem.registration_backend_name != backend_name
+            backend_name = problem.registration_backend_name
+
+            yield (
+                problem.form_name if form_id_changed else "",
+                str(form_id) if form_id_changed else "",
+                backend_name if backend_name_changed else "",
+                problem.registration_backend_type if backend_name_changed else "",
+                problem.component_key,
+            )
+
+    click.echo(
+        click.style(
+            "Found file components with a different catalogue than the registration "
+            "backend.",
+            fg="red",
+        )
+    )
+    click.echo("")
+    click.echo(
+        tabulate(
+            _report_problems(),
+            headers=(
+                "Form admin name",
+                "Form ID",
+                "Registration backend name",
+                "Registration backend type",
+                "File upload component key",
+            ),
+        )
+    )
+
+    return False
+
+
+def main(skip_setup=False) -> bool:
+    from openforms.setup import setup_env
+
+    if not skip_setup:
+        setup_env()
+        django.setup()
+
+    return report_components()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/installation/upgrade-400.rst
+++ b/docs/installation/upgrade-400.rst
@@ -394,3 +394,14 @@ to do anything for this:
 * Document options (document type, organization RSIN, title, confidentiality level...)
   will be moved from the file component configuration into the relevant registration
   backend options.
+
+**Check script**
+
+You can detect possible broken configurations for file component registration when the
+original document type didn't belong to the catalogue specified in the form registration
+options:
+
+.. code-block:: bash
+
+    # in a container/pod
+    python /app/bin/report_file_component_inconsistent_catalogues.py

--- a/src/openforms/upgrades/tests/test_inconsistent_file_component_catalogues_check.py
+++ b/src/openforms/upgrades/tests/test_inconsistent_file_component_catalogues_check.py
@@ -1,0 +1,233 @@
+from uuid import uuid4
+
+from django.test import TestCase
+
+from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
+from openforms.forms.tests.factories import FormFactory, FormRegistrationBackendFactory
+from openforms.registrations.contrib.objects_api.config import (
+    ObjectsAPIOptionsSerializer,
+)
+from openforms.registrations.contrib.objects_api.constants import (
+    PLUGIN_IDENTIFIER as OBJECTS_PLUGIN_IDENTIFIER,
+)
+from openforms.registrations.contrib.objects_api.typing import (
+    RegistrationOptionsV2 as ObjectsRegistrationOptionsV2,
+)
+from openforms.registrations.contrib.zgw_apis.options import ZaakOptionsSerializer
+from openforms.registrations.contrib.zgw_apis.plugin import (
+    PLUGIN_IDENTIFIER as ZGW_PLUGIN_IDENTIFIER,
+)
+from openforms.registrations.contrib.zgw_apis.tests.factories import (
+    ZGWApiGroupConfigFactory,
+)
+from openforms.registrations.contrib.zgw_apis.typing import (
+    RegistrationOptions as ZGWRegistrationOptions,
+)
+
+from ..script_checks import BinScriptCheck
+from .utils import capture_output
+
+check = BinScriptCheck("report_file_component_inconsistent_catalogues")
+
+
+class InconsistentFileComponentCatalogueCheckTests(TestCase):
+    def test_ok_when_no_data_in_environment(self):
+        with capture_output() as outfile:
+            result = check.execute()
+
+        self.assertTrue(result)
+        self.assertIn("No inconsistencies found.", outfile.getvalue())
+
+    def test_ok_for_forms_defs_without_file_components(self):
+        FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "ignoreMe",
+                        "label": "Ignore me",
+                    },
+                ]
+            },
+        )
+
+        with capture_output() as outfile:
+            result = check.execute()
+
+        self.assertTrue(result)
+        self.assertIn("No inconsistencies found.", outfile.getvalue())
+
+    def test_reports_inconsistencies_for_zgw_and_objects_api(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "fieldset",
+                        "key": "fieldset",
+                        "label": "fieldset",
+                        "components": [
+                            {
+                                "type": "file",
+                                "key": "file1",
+                                "label": "file",
+                                "file": {"type": []},
+                                "filePattern": "",
+                                "registration": {
+                                    "documentType": {
+                                        # mismatch
+                                        "catalogue": {
+                                            "domain": "OTHER",
+                                            "rsin": "000000000",
+                                        },
+                                        "description": "Attachment",
+                                    },
+                                },
+                            },
+                            {
+                                "type": "editgrid",
+                                "key": "editgrid",
+                                "label": "Repeating group",
+                                "groupLabel": "Item",
+                                "components": [
+                                    {
+                                        "type": "file",
+                                        "key": "file2",
+                                        "label": "file",
+                                        "file": {"type": []},
+                                        "filePattern": "",
+                                        "registration": {
+                                            "documentType": {
+                                                # mismatch
+                                                "catalogue": {
+                                                    "domain": "TEST",
+                                                    "rsin": "100000009",
+                                                },
+                                                "description": "Attachment",
+                                            },
+                                        },
+                                    },
+                                    {
+                                        "type": "file",
+                                        "key": "file3",
+                                        "label": "file",
+                                        "file": {"type": []},
+                                        "filePattern": "",
+                                        "registration": {
+                                            "documentType": {},
+                                        },
+                                    },
+                                    {
+                                        "type": "file",
+                                        "key": "file4",
+                                        "label": "file",
+                                        "file": {"type": []},
+                                        "filePattern": "",
+                                        "registration": {"titel": "Custom title"},
+                                    },
+                                    {
+                                        "type": "file",
+                                        "key": "file5",
+                                        "label": "file",
+                                        "file": {"type": []},
+                                        "filePattern": "",
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                    {
+                        "type": "file",
+                        "key": "file6",
+                        "label": "file",
+                        "file": {"type": []},
+                        "filePattern": "",
+                        "registration": {
+                            "documentType": {
+                                "catalogue": {
+                                    "domain": "TEST",
+                                    "rsin": "000000000",
+                                },
+                                "description": "Attachment",
+                            },
+                        },
+                    },
+                ]
+            },
+        )
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            catalogue_domain="",
+            catalogue_rsin="",
+            iot_submission_report="",
+            iot_submission_csv="",
+            iot_attachment="",
+            informatieobjecttype_submission_report="",
+            informatieobjecttype_submission_csv="",
+            informatieobjecttype_attachment="",
+        )
+        objects_options: ObjectsRegistrationOptionsV2 = {
+            "catalogue": {
+                "domain": "TEST",
+                "rsin": "000000000",
+            },
+            "iot_submission_report": "",
+            "iot_submission_csv": "",
+            "iot_attachment": "",
+            "version": 2,
+            "objects_api_group": objects_api_group,
+            "objecttype": uuid4(),
+            "objecttype_version": 3,
+            "upload_submission_csv": True,
+            "update_existing_object": False,
+            "auth_attribute_path": [],
+            "organisatie_rsin": "000000000",
+            "transform_to_list": [],
+            "variables_mapping": [],
+        }
+        FormRegistrationBackendFactory.create(
+            form=form,
+            backend=OBJECTS_PLUGIN_IDENTIFIER,
+            options=ObjectsAPIOptionsSerializer(instance=objects_options).data,
+        )
+        zgw_api_group = ZGWApiGroupConfigFactory.create(
+            catalogue_domain="", catalogue_rsin=""
+        )
+        zgw_options: ZGWRegistrationOptions = {
+            "zgw_api_group": zgw_api_group,
+            "catalogue": {
+                "domain": "TEST",
+                "rsin": "000000000",
+            },
+            "case_type_identification": "ZT-001",
+            "document_type_description": "Attachment",
+            "product_url": "",
+            "partners_roltype": "",
+            "partners_description": "",
+            "children_roltype": "",
+            "children_description": "",
+            "objects_api_group": None,
+            "summary_documents": [],
+            "zaaktype": "",
+            "informatieobjecttype": "",
+        }
+        FormRegistrationBackendFactory.create(
+            form=form,
+            backend=ZGW_PLUGIN_IDENTIFIER,
+            options=ZaakOptionsSerializer(instance=zgw_options).data,
+        )
+
+        with capture_output() as outfile:
+            result = check.execute()
+
+        self.assertFalse(result)
+        output = outfile.getvalue()
+        self.assertIn("file1", output)
+        self.assertIn("file2", output)
+        self.assertNotIn("file3", output)
+        self.assertNotIn("file4", output)
+        self.assertNotIn("file5", output)
+        self.assertNotIn("file6", output)
+
+        self.assertIn(ZGW_PLUGIN_IDENTIFIER, output)
+        self.assertIn(OBJECTS_PLUGIN_IDENTIFIER, output)

--- a/src/openforms/upgrades/tests/test_upgrade_paths.py
+++ b/src/openforms/upgrades/tests/test_upgrade_paths.py
@@ -1,6 +1,3 @@
-from io import StringIO
-from unittest.mock import patch
-
 from django.test import SimpleTestCase, TestCase
 
 from unittest_parametrize import ParametrizedTestCase, parametrize
@@ -12,6 +9,7 @@ from openforms.forms.tests.factories import (
 )
 
 from ..script_checks import BinScriptCheck
+from .utils import capture_output
 
 
 class DjangoScriptTests(SimpleTestCase):
@@ -34,7 +32,7 @@ class ReportLogicWithDeprecatedClearOnHideBehaviorTests(ParametrizedTestCase, Te
     def test_no_logic(self):
         FormFactory.create(generate_minimal_setup=True)
 
-        with patch("sys.stdout", new_callable=StringIO) as stdout:
+        with capture_output() as stdout:
             self.assertTrue(self.script.execute())
             self.assertIn(
                 "No logic rules with a risk of behaving differently in Open Forms 4.0",
@@ -54,7 +52,7 @@ class ReportLogicWithDeprecatedClearOnHideBehaviorTests(ParametrizedTestCase, Te
             form=form, json_logic_trigger={"var": {"==": [{"var": "textfield"}, ""]}}
         )
 
-        with patch("sys.stdout", new_callable=StringIO) as stdout:
+        with capture_output() as stdout:
             self.assertTrue(self.script.execute())
             self.assertIn(
                 "No logic rules with a risk of behaving differently in Open Forms 4.0",
@@ -118,7 +116,7 @@ class ReportLogicWithDeprecatedClearOnHideBehaviorTests(ParametrizedTestCase, Te
 
         FormLogicFactory.create(form=form, json_logic_trigger=logic_trigger)
 
-        with patch("sys.stdout", new_callable=StringIO) as stdout:
+        with capture_output() as stdout:
             self.assertFalse(self.script.execute())
             self.assertIn(
                 "Found logic rules with a risk of behaving differently in Open Forms "
@@ -168,7 +166,7 @@ class ReportLogicWithDeprecatedClearOnHideBehaviorTests(ParametrizedTestCase, Te
             form=form, json_logic_trigger={"==": [{"var": "textfield"}, "value"]}
         )
 
-        with patch("sys.stdout", new_callable=StringIO) as stdout:
+        with capture_output() as stdout:
             self.assertTrue(self.script.execute())
             self.assertIn(
                 "No logic rules with a risk of behaving differently in Open Forms 4.0",
@@ -204,7 +202,7 @@ class ReportLogicWithDeprecatedClearOnHideBehaviorTests(ParametrizedTestCase, Te
             form=form, json_logic_trigger={"==": [{"var": "textfield"}, ""]}
         )
 
-        with patch("sys.stdout", new_callable=StringIO) as stdout:
+        with capture_output() as stdout:
             self.assertFalse(self.script.execute())
             self.assertIn(
                 "Found logic rules with a risk of behaving differently in Open Forms "
@@ -243,7 +241,7 @@ class ReportLogicWithDeprecatedClearOnHideBehaviorTests(ParametrizedTestCase, Te
             json_logic_trigger={"==": [{"var": "editgrid.0.selectboxes"}, False]},
         )
 
-        with patch("sys.stdout", new_callable=StringIO) as stdout:
+        with capture_output() as stdout:
             self.assertTrue(self.script.execute())
             self.assertIn(
                 "No logic rules with a risk of behaving differently in Open Forms 4.0",
@@ -259,7 +257,7 @@ class ReportInvalidFormLogicTests(TestCase):
             generate_minimal_setup=True, new_logic_evaluation_enabled=True
         )
 
-        with patch("sys.stdout", new_callable=StringIO) as stdout:
+        with capture_output() as stdout:
             self.assertTrue(self.script.execute())
             self.assertEqual("", stdout.getvalue())
 
@@ -282,7 +280,7 @@ class ReportInvalidFormLogicTests(TestCase):
             ],
         )
 
-        with patch("sys.stdout", new_callable=StringIO) as stdout:
+        with capture_output() as stdout:
             self.assertFalse(self.script.execute())
             self.assertIn(
                 "The following forms have have not been converted to the new logic "
@@ -309,7 +307,7 @@ class ReportInvalidFormLogicTests(TestCase):
             ],
         )
 
-        with patch("sys.stdout", new_callable=StringIO) as stdout:
+        with capture_output() as stdout:
             self.assertFalse(self.script.execute())
             self.assertIn(
                 "The following forms have at least one logic rule with "

--- a/src/openforms/upgrades/tests/utils.py
+++ b/src/openforms/upgrades/tests/utils.py
@@ -1,0 +1,12 @@
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
+from io import StringIO
+
+
+@contextmanager
+def capture_output():
+    outfile = StringIO()
+    with (
+        redirect_stdout(outfile),
+        redirect_stderr(outfile),
+    ):
+        yield outfile


### PR DESCRIPTION
Closes #6304 

[skip: e2e]

**Changes**

* Implemented a bin check script to detect mismatching catalogues
* Small refactor in existing tests for output capture

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
