### PR TITLE
Pin codeql actions after all

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -341,6 +341,9 @@ jobs:
       - setup
       - docker_build
 
+    permissions:
+      security-events: write
+
     steps:
       # So the scanner gets commit meta-information
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,7 +366,7 @@ jobs:
           TRIVY_SKIP_JAVA_DB_UPDATE: true
 
       - name: Upload results to GH Security tab
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           sarif_file: 'trivy-results-docker.sarif'
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -32,11 +32,11 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
         with:
           languages: ${{ matrix.language }}
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v4
+        uses: github/codeql-action/autobuild@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,8 +1,0 @@
-rules:
-  unpinned-uses:
-    config:
-      policies:
-        # codeql-action is intentionally ref-pinned rather than hash-pinned.
-        # Its moving tag (@v4) automatically pulls in updated query packs and
-        # detection rules; pinning to a SHA would freeze those at a point in time.
-        github/codeql-action/*: ref-pin


### PR DESCRIPTION
The organization settings do not seem to support exceptions for git SHA pinning when enabling that option, and these actions not being pinned breaks *all* workflows starting.

The future use of CodeQL is uncertain too, given that github will start billing the usage.

[skip: e2e]