### PR TITLE
Add local admin user privileges check

### DIFF
--- a/src/openforms/accounts/admin.py
+++ b/src/openforms/accounts/admin.py
@@ -8,6 +8,8 @@ from django.http import HttpRequest
 from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
+from maykin_common.accounts.admin import PreventPrivilegeEscalationMixin
+
 from .forms import UserPreferencesForm
 from .models import User, UserPreferences
 
@@ -21,7 +23,7 @@ def _append_field_to_fieldsets(fieldsets, set_name, *field_names):
 
 
 @admin.register(User)
-class _UserAdmin(UserAdmin):
+class _UserAdmin(PreventPrivilegeEscalationMixin, UserAdmin):
     list_display = tuple(UserAdmin.list_display) + (  # pyright: ignore[reportGeneralTypeIssues]
         "employee_id",
         "is_superuser",


### PR DESCRIPTION
It has been known for a long time that staff users that are allowed to edit users could give themselves more permissions. This is default Django behaviour, and Open Forms has operated from the perspective that you only hand out these permissions to users that you trust.

However, we are applying some additional hardening to prevent privilege escalations for organisations where this is not intuitive.

This PR builds on top of #6416, so that needs to be merged first.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
