### PR TITLE
:bug: Fix Dutch accessibility tools translation

### DIFF
--- a/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
+++ b/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
@@ -13656,7 +13656,7 @@ msgstr "vrijgeven"
 
 #: openforms/templates/includes/a11y_toolbar.html:2
 msgid "Accessibility tools"
-msgstr "Toegangelijkheidshulpmiddelen"
+msgstr "Toegankelijkheidshulpmiddelen"
 
 #: openforms/templates/includes/a11y_toolbar.html:11
 msgid "Back to top"


### PR DESCRIPTION
## Summary
- Corrects the Dutch translation of "Accessibility tools" from `Toegangelijkheidshulpmiddelen` to `Toegankelijkheidshulpmiddelen`.

## Testing
- Not run; translation-only typo fix.

Fixes #6387
