### PR TITLE
#6343 support case object registration objects for ZGW APIs

### DIFF
--- a/docs/manual/registration/zgw-apis.rst
+++ b/docs/manual/registration/zgw-apis.rst
@@ -83,3 +83,16 @@ Daarnaast is er een verschil tussen burgers, bedrijven en vestigingen:
 * voor vestigingen geldt dezelfde beperking.
 * voor niet-natuurijke personen (bedrijven, zonder vestiging) wordt het bezoekadres
   gevuld en geldt deze beperking niet.
+
+
+Zaakobjecten
+============
+
+Op het tabblad “Zaakobjecten” kun je de kenmerken configureren van de zaakobjecten die tijdens
+het registratieproces zijn aangemaakt.
+
+.. note:: De functioneel beheerder dient een aantal
+   Open Formulieren ondersteunt alleen het objecttype “overige”.
+
+Het kenmerk “overige gegevens” is een sjabloon en je kunt formuliervariabelen gebruiken om dit
+in te vullen. Voor meer informatie over welke variabelen en expressies beschikbaar zijn, ga je naar :ref:`zgw_api_registratie`.

--- a/docs/manual/templates.rst
+++ b/docs/manual/templates.rst
@@ -815,6 +815,9 @@ kan deze allemaal individueel gebruiken in de sjablonen.
 ZGW API registratie
 ===================
 
+Zaken
+-----
+
 De ZGW API-registratiebackend maakt een zaak aan in de geconfigureerde Zaken API met de gegevens van een
 inzending. Een verkort voorbeeld van de JSON die naar de Zaken API wordt gestuurd:
 
@@ -835,6 +838,29 @@ Je kunt de volgende kenmerken in sjablonen instellen:
 
 - ``omschrijving``
 - ``toelichting``
+
+Zaakobjecten
+============
+
+Op het tabblad “Zaakobjecten” kun je de kenmerken configureren van de zaakobjecten die tijdens
+het registratieproces zijn aangemaakt.
+
+Een voorbeeld van de JSON die naar de Zaken API wordt gestuurd:
+
+.. code:: json
+
+    {
+      "zaak": "http://zaken-example.nl/zaken/api/v1/zaaken/123",
+      "objectType": "overige",
+      "objectTypeOverige": "gebouw in aanbouw",
+      "objectIdentificatie": {
+        "overigeData": "naam: Centrum Roxmeer"
+      }
+    }
+
+Je kunt de volgende kenmerken in sjablonen instellen:
+
+- ``overigeData``
 
 .. note ::
 

--- a/src/openforms/contrib/zgw/clients/zaken.py
+++ b/src/openforms/contrib/zgw/clients/zaken.py
@@ -1,3 +1,6 @@
+from collections.abc import Mapping
+from typing import Any
+
 from django.utils import timezone
 
 import structlog
@@ -135,7 +138,7 @@ class ZakenClient(LoggingMixin, NLXClient):
 
         return response.json()
 
-    def create_zaakobject(
+    def create_zaakobject_with_object(
         self, zaak: dict, object: str, objecttype_version: str
     ) -> dict:
         data = {
@@ -147,6 +150,25 @@ class ZakenClient(LoggingMixin, NLXClient):
                 "schema": ".jsonSchema",
                 "objectData": ".record.data",
             },
+        }
+
+        response = self.post("zaakobjecten", json=data)
+        response.raise_for_status()
+
+        return response.json()
+
+    def create_zaakobject_with_object_identification(
+        self,
+        zaak: dict,
+        object_type: str,
+        object_type_overige: str,
+        object_identification: Mapping[str, Any],
+    ) -> dict:
+        data = {
+            "zaak": zaak["url"],
+            "objectType": object_type,
+            "objectTypeOverige": object_type_overige,
+            "objectIdentificatie": object_identification,
         }
 
         response = self.post("zaakobjecten", json=data)

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -653,6 +653,12 @@
       "value": "Comma-separate list values"
     }
   ],
+  "4iYhbx": [
+    {
+      "type": 0,
+      "value": "Object type overige"
+    }
+  ],
   "4sFGgA": [
     {
       "type": 0,
@@ -1937,6 +1943,12 @@
       "value": "This field is required."
     }
   ],
+  "Dvovhl": [
+    {
+      "type": 0,
+      "value": "Add case object"
+    }
+  ],
   "DxGKNm": [
     {
       "type": 0,
@@ -2919,6 +2931,12 @@
     {
       "type": 0,
       "value": "Affixes"
+    }
+  ],
+  "M4Kbw3": [
+    {
+      "type": 0,
+      "value": "Data for the 'overige' case object in a free format. You can use form variables here."
     }
   ],
   "M8nTet": [
@@ -4391,6 +4409,16 @@
       "value": "Previous text"
     }
   ],
+  "ZJQmio": [
+    {
+      "type": 0,
+      "value": "Case object "
+    },
+    {
+      "type": 1,
+      "value": "count"
+    }
+  ],
   "ZMIEED": [
     {
       "type": 0,
@@ -4487,6 +4515,12 @@
     {
       "type": 0,
       "value": " attribute"
+    }
+  ],
+  "aE4IrY": [
+    {
+      "type": 0,
+      "value": "Overige data"
     }
   ],
   "aWwaAq": [
@@ -6015,6 +6049,12 @@
       "value": "Show character counter"
     }
   ],
+  "l/D4PL": [
+    {
+      "type": 0,
+      "value": "Object type"
+    }
+  ],
   "l1fi1t": [
     {
       "type": 0,
@@ -6303,6 +6343,20 @@
     {
       "type": 0,
       "value": "Bronorganisatie"
+    }
+  ],
+  "nXKEYN": [
+    {
+      "type": 0,
+      "value": "Case objects ("
+    },
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": ")"
     }
   ],
   "nYePys": [
@@ -6673,6 +6727,12 @@
     {
       "type": 0,
       "value": "Include partners"
+    }
+  ],
+  "qntXTt": [
+    {
+      "type": 0,
+      "value": "Description of the 'overige' object type."
     }
   ],
   "qo1UbS": [
@@ -7281,6 +7341,12 @@
     {
       "type": 0,
       "value": "Custom error messages"
+    }
+  ],
+  "vhmWn1": [
+    {
+      "type": 0,
+      "value": "Type of the case object. Now only 'overige' value is supported."
     }
   ],
   "viEfGU": [

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -653,12 +653,6 @@
       "value": "Comma-separate list values"
     }
   ],
-  "4iYhbx": [
-    {
-      "type": 0,
-      "value": "Object type overige"
-    }
-  ],
   "4sFGgA": [
     {
       "type": 0,
@@ -2937,6 +2931,12 @@
     {
       "type": 0,
       "value": "Data for the 'overige' case object in a free format. You can use form variables here."
+    }
+  ],
+  "M765u8": [
+    {
+      "type": 0,
+      "value": "Object type description"
     }
   ],
   "M8nTet": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -653,6 +653,12 @@
       "value": "Door komma's gescheiden waarden"
     }
   ],
+  "4iYhbx": [
+    {
+      "type": 0,
+      "value": "Objecttype overige"
+    }
+  ],
   "4sFGgA": [
     {
       "type": 0,
@@ -1924,6 +1930,12 @@
       "value": "Dit veld is verplicht."
     }
   ],
+  "Dvovhl": [
+    {
+      "type": 0,
+      "value": "Zaakobject toevoegen"
+    }
+  ],
   "DxGKNm": [
     {
       "type": 0,
@@ -2906,6 +2918,12 @@
     {
       "type": 0,
       "value": "Voorvoegsels"
+    }
+  ],
+  "M4Kbw3": [
+    {
+      "type": 0,
+      "value": "Gegevens voor het zaakobject ‘overige’ in een vrije indeling. Je kunt hier formuliervariabelen gebruiken."
     }
   ],
   "M8nTet": [
@@ -4375,6 +4393,16 @@
       "value": "'Vorige' tekst"
     }
   ],
+  "ZJQmio": [
+    {
+      "type": 0,
+      "value": "Zaakobject "
+    },
+    {
+      "type": 1,
+      "value": "count"
+    }
+  ],
   "ZMIEED": [
     {
       "type": 0,
@@ -4471,6 +4499,12 @@
     {
       "type": 0,
       "value": "-attribuut"
+    }
+  ],
+  "aE4IrY": [
+    {
+      "type": 0,
+      "value": "Overige data"
     }
   ],
   "aWwaAq": [
@@ -6003,6 +6037,12 @@
       "value": "Toon aantal karakters"
     }
   ],
+  "l/D4PL": [
+    {
+      "type": 0,
+      "value": "Objecttype"
+    }
+  ],
   "l1fi1t": [
     {
       "type": 0,
@@ -6291,6 +6331,20 @@
     {
       "type": 0,
       "value": "Bronorganisatie"
+    }
+  ],
+  "nXKEYN": [
+    {
+      "type": 0,
+      "value": "Zaakobjecten ("
+    },
+    {
+      "type": 1,
+      "value": "count"
+    },
+    {
+      "type": 0,
+      "value": ")"
     }
   ],
   "nYePys": [
@@ -6661,6 +6715,12 @@
     {
       "type": 0,
       "value": "Inclusief partner(s)"
+    }
+  ],
+  "qntXTt": [
+    {
+      "type": 0,
+      "value": "Beschrijving van het objecttype ‘overige’."
     }
   ],
   "qo1UbS": [
@@ -7265,6 +7325,12 @@
     {
       "type": 0,
       "value": "Foutmeldingen"
+    }
+  ],
+  "vhmWn1": [
+    {
+      "type": 0,
+      "value": "Type van het zaakobject. Momenteel wordt alleen de waarde ‘overige’ ondersteund."
     }
   ],
   "viEfGU": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -653,12 +653,6 @@
       "value": "Door komma's gescheiden waarden"
     }
   ],
-  "4iYhbx": [
-    {
-      "type": 0,
-      "value": "Objecttype overige"
-    }
-  ],
   "4sFGgA": [
     {
       "type": 0,
@@ -2924,6 +2918,12 @@
     {
       "type": 0,
       "value": "Gegevens voor het zaakobject ‘overige’ in een vrije indeling. Je kunt hier formuliervariabelen gebruiken."
+    }
+  ],
+  "M765u8": [
+    {
+      "type": 0,
+      "value": "Beschrijving van het objecttype"
     }
   ],
   "M8nTet": [

--- a/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/RegistrationFields.stories.js
@@ -59,6 +59,16 @@ export default {
               enum: ['pdf', 'json'],
               enumNames: ['PDF document', 'JSON document'],
             },
+            caseObjects: {
+              items: {
+                properties: {
+                  caseObjectType: {
+                    enum: ['overige'],
+                    enumNames: ['Overige'],
+                  },
+                },
+              },
+            },
           },
         },
       },

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/CaseObjects.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/CaseObjects.js
@@ -1,0 +1,186 @@
+import {FieldArray, useField, useFormikContext} from 'formik';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import ButtonContainer from 'components/admin/forms/ButtonContainer';
+import Field from 'components/admin/forms/Field';
+import Fieldset from 'components/admin/forms/Fieldset';
+import FormRow from 'components/admin/forms/FormRow';
+import {TextArea, TextInput} from 'components/admin/forms/Inputs';
+import ReactSelect from 'components/admin/forms/ReactSelect';
+import {DeleteIcon} from 'components/admin/icons';
+
+const OverigeFields = ({index}) => {
+  const name = `caseObjects.${index}.caseObjectIdentification.overigeData`;
+  const [fieldProps] = useField(name);
+  return (
+    <FormRow>
+      <Field
+        name={name}
+        label={
+          <FormattedMessage
+            description="ZGW APIs registration options 'overigeData' label"
+            defaultMessage="Overige data"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="ZGW APIs registration options 'overigeData' help text"
+            defaultMessage={`Data for the 'overige' case object in a free format. You can use form variables here.`}
+          />
+        }
+      >
+        <TextArea id={`id_${name}`} rows={2} cols={85} {...fieldProps} />
+      </Field>
+    </FormRow>
+  );
+};
+
+// mapping of caseObjectType and related objectIdentification fields
+// now we support only 'overige' type
+export const CASE_OBJECT_TYPES_FIELDS = {
+  overige: OverigeFields,
+};
+
+const CaseObjectType = ({index, options}) => {
+  const name = `caseObjects.${index}.caseObjectType`;
+  return (
+    <FormRow>
+      <Field
+        name={name}
+        required
+        label={
+          <FormattedMessage
+            description="ZGW APIs registration options 'caseObjectType' label"
+            defaultMessage="Object type"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="ZGW APIs registration options 'caseObjectType' help text"
+            defaultMessage={`Type of the case object. Now only 'overige' value is supported.`}
+          />
+        }
+      >
+        <ReactSelect
+          name={name}
+          options={options.map(([value, label]) => ({
+            value,
+            label,
+          }))}
+          isClearable
+        />
+      </Field>
+    </FormRow>
+  );
+};
+
+const CaseObjectTypeOverige = ({index}) => {
+  const name = `caseObjects.${index}.caseObjectTypeOverige`;
+  const [fieldProps] = useField(name);
+  return (
+    <FormRow>
+      <Field
+        name={name}
+        label={
+          <FormattedMessage
+            description="ZGW APIs registration options 'caseObjectTypeOverige' label"
+            defaultMessage="Object type overige"
+          />
+        }
+        helpText={
+          <FormattedMessage
+            description="ZGW APIs registration options 'caseObjectTypeOverige' help text"
+            defaultMessage={`Description of the 'overige' object type.`}
+          />
+        }
+      >
+        <TextInput id={`id_${name}`} {...fieldProps} />
+      </Field>
+    </FormRow>
+  );
+};
+
+const CaseObjectFieldset = ({index, caseObjectTypeChoices, onDelete}) => {
+  const prefix = `caseObjects.${index}`;
+  const [{value: caseObjectTypeValue}] = useField(`${prefix}.caseObjectType`);
+  const ObjectIdentificationFields = CASE_OBJECT_TYPES_FIELDS[caseObjectTypeValue];
+
+  const formik = useFormikContext();
+  console.log('Formik values:', formik.values);
+
+  return (
+    <Fieldset
+      title={
+        <>
+          <FormattedMessage
+            description="ZGW APIs registration: case objects fieldset title"
+            defaultMessage="Case object {count}"
+            values={{
+              count: index + 1,
+            }}
+          />
+          <DeleteIcon onConfirm={onDelete} />
+        </>
+      }
+      fieldNames={[
+        `${prefix}.caseObjectType`,
+        `${prefix}.caseObjectTypeOverige`,
+        `${prefix}.caseObjectIdentification`,
+      ]}
+    >
+      <CaseObjectType index={index} options={caseObjectTypeChoices} />
+      <CaseObjectTypeOverige index={index} />
+
+      {ObjectIdentificationFields ? <ObjectIdentificationFields index={index} /> : null}
+    </Fieldset>
+  );
+};
+
+const CaseObjectFieldsets = ({caseObjectTypeChoices}) => {
+  const {
+    values: {caseObjects = []},
+  } = useFormikContext();
+
+  return (
+    <FieldArray name="caseObjects">
+      {arrayHelpers => (
+        <>
+          {caseObjects.map((value, index) => (
+            <CaseObjectFieldset
+              key={index}
+              index={index}
+              caseObjectTypeChoices={caseObjectTypeChoices}
+              onDelete={() => arrayHelpers.remove(index)}
+            />
+          ))}
+          <ButtonContainer
+            onClick={() =>
+              arrayHelpers.push({
+                caseObjectType: '',
+                caseObjectTypeOverige: '',
+                caseObjectIdentification: {
+                  overigeData: '',
+                },
+              })
+            }
+          >
+            <FormattedMessage
+              description="Add case object (mapping) button"
+              defaultMessage="Add case object"
+            />
+          </ButtonContainer>
+        </>
+      )}
+    </FieldArray>
+  );
+};
+
+CaseObjectFieldsets.propTypes = {
+  caseObjectTypeChoices: PropTypes.arrayOf(
+    PropTypes.arrayOf(PropTypes.string) // value & label are both string
+  ).isRequired,
+};
+
+export default CaseObjectFieldsets;

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/CaseObjects.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/CaseObjects.js
@@ -99,7 +99,7 @@ const CaseObjectTypeOverige = ({index}) => {
         label={
           <FormattedMessage
             description="ZGW APIs registration options 'caseObjectTypeOverige' label"
-            defaultMessage="Object type overige"
+            defaultMessage="Object type description"
           />
         }
         helpText={

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/CaseObjects.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/CaseObjects.js
@@ -38,6 +38,10 @@ const OverigeFields = ({index}) => {
   );
 };
 
+OverigeFields.propTypes = {
+  index: PropTypes.number.isRequired,
+};
+
 // mapping of caseObjectType and related objectIdentification fields
 // now we support only 'overige' type
 export const CASE_OBJECT_TYPES_FIELDS = {
@@ -78,6 +82,13 @@ const CaseObjectType = ({index, options}) => {
   );
 };
 
+CaseObjectType.propTypes = {
+  index: PropTypes.number.isRequired,
+  options: PropTypes.arrayOf(
+    PropTypes.arrayOf(PropTypes.string) // value & label are both string
+  ).isRequired,
+};
+
 const CaseObjectTypeOverige = ({index}) => {
   const name = `caseObjects.${index}.caseObjectTypeOverige`;
   const [fieldProps] = useField(name);
@@ -102,6 +113,10 @@ const CaseObjectTypeOverige = ({index}) => {
       </Field>
     </FormRow>
   );
+};
+
+CaseObjectTypeOverige.propTypes = {
+  index: PropTypes.number.isRequired,
 };
 
 const CaseObjectFieldset = ({index, caseObjectTypeChoices, onDelete}) => {
@@ -138,6 +153,14 @@ const CaseObjectFieldset = ({index, caseObjectTypeChoices, onDelete}) => {
       {ObjectIdentificationFields ? <ObjectIdentificationFields index={index} /> : null}
     </Fieldset>
   );
+};
+
+CaseObjectFieldset.propTypes = {
+  index: PropTypes.number.isRequired,
+  caseObjectTypeChoices: PropTypes.arrayOf(
+    PropTypes.arrayOf(PropTypes.string) // value & label are both string
+  ).isRequired,
+  onDelete: PropTypes.func.isRequired,
 };
 
 const CaseObjectFieldsets = ({caseObjectTypeChoices}) => {

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/CaseObjects.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/CaseObjects.js
@@ -18,6 +18,7 @@ const OverigeFields = ({index}) => {
     <FormRow>
       <Field
         name={name}
+        required
         label={
           <FormattedMessage
             description="ZGW APIs registration options 'overigeData' label"
@@ -31,7 +32,7 @@ const OverigeFields = ({index}) => {
           />
         }
       >
-        <TextArea id={`id_${name}`} rows={2} cols={85} {...fieldProps} />
+        <TextArea id={`id_${name}`} rows={2} cols={85} required {...fieldProps} />
       </Field>
     </FormRow>
   );
@@ -65,6 +66,7 @@ const CaseObjectType = ({index, options}) => {
       >
         <ReactSelect
           name={name}
+          required
           options={options.map(([value, label]) => ({
             value,
             label,

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/CaseObjects.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/CaseObjects.js
@@ -124,9 +124,6 @@ const CaseObjectFieldset = ({index, caseObjectTypeChoices, onDelete}) => {
   const [{value: caseObjectTypeValue}] = useField(`${prefix}.caseObjectType`);
   const ObjectIdentificationFields = CASE_OBJECT_TYPES_FIELDS[caseObjectTypeValue];
 
-  const formik = useFormikContext();
-  console.log('Formik values:', formik.values);
-
   return (
     <Fieldset
       title={

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsForm.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsForm.js
@@ -11,8 +11,17 @@ import ZGWFormFields from './ZGWOptionsFormFields';
 const ZGWOptionsForm = ({name, label, schema, formData, onChange}) => {
   const validationErrors = useContext(ValidationErrorContext);
 
-  const {zgwApiGroup, zaakVertrouwelijkheidaanduiding, objectsApiGroup, summaryDocuments} =
-    schema.properties;
+  const {
+    zgwApiGroup,
+    zaakVertrouwelijkheidaanduiding,
+    objectsApiGroup,
+    summaryDocuments,
+    caseObjects: {
+      items: {
+        properties: {caseObjectType},
+      },
+    },
+  } = schema.properties;
   const apiGroupChoices = getChoicesFromSchema(zgwApiGroup.enum, zgwApiGroup.enumNames);
   const objectsApiGroupChoices = getChoicesFromSchema(
     objectsApiGroup.enum,
@@ -26,6 +35,8 @@ const ZGWOptionsForm = ({name, label, schema, formData, onChange}) => {
     summaryDocuments.enum,
     summaryDocuments.enumNames
   );
+
+  const caseObjectTypeChoices = getChoicesFromSchema(caseObjectType.enum, caseObjectType.enumNames);
 
   const numErrors = filterErrors(name, validationErrors).length;
   const defaultGroup = apiGroupChoices.length === 1 ? apiGroupChoices[0][0] : undefined;
@@ -60,6 +71,7 @@ const ZGWOptionsForm = ({name, label, schema, formData, onChange}) => {
         // Ensure that this is explicitly set to null instead of undefined,
         // because the field is required by the serializer
         objectsApiGroup: null,
+        caseObjects: [],
         // saved data, overwrites defaults
         ...formData,
         // Ensure that if there's only one option, it is automatically selected.
@@ -74,6 +86,7 @@ const ZGWOptionsForm = ({name, label, schema, formData, onChange}) => {
         objectsApiGroupChoices={objectsApiGroupChoices}
         confidentialityLevelChoices={confidentialityLevelChoices}
         summaryDocumentChoices={summaryDocumentChoices}
+        caseObjectTypeChoices={caseObjectTypeChoices}
       />
     </ModalOptionsConfiguration>
   );
@@ -100,6 +113,16 @@ ZGWOptionsForm.propTypes = {
         enum: PropTypes.arrayOf(PropTypes.string).isRequired,
         enumNames: PropTypes.arrayOf(PropTypes.string).isRequired,
       }).isRequired,
+      caseObjects: PropTypes.shape({
+        items: PropTypes.shape({
+          properties: PropTypes.shape({
+            caseObjectType: PropTypes.shape({
+              enum: PropTypes.arrayOf(PropTypes.string).isRequired,
+              enumNames: PropTypes.arrayOf(PropTypes.string).isRequired,
+            }).isRequired,
+          }).isRequired,
+        }).isRequired,
+      }).isRequired,
     }).isRequired,
   }).isRequired,
   formData: PropTypes.shape({
@@ -125,6 +148,15 @@ ZGWOptionsForm.propTypes = {
     objecttypeVersion: PropTypes.string,
     contentJson: PropTypes.string,
     summaryDocuments: PropTypes.arrayOf(PropTypes.string),
+    caseObjects: PropTypes.arrayOf(
+      PropTypes.shape({
+        caseObjectType: PropTypes.string,
+        caseObjectTypeOverige: PropTypes.string,
+        caseObjectIdentification: PropTypes.shape({
+          overigeData: PropTypes.string,
+        }),
+      })
+    ),
   }),
   onChange: PropTypes.func.isRequired,
 };

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.js
@@ -12,6 +12,7 @@ import {
 } from 'components/admin/forms/ValidationErrors';
 
 import BasicOptionsFieldset from './BasicOptionsFieldset';
+import CaseObjectFieldsets from './CaseObjects';
 import ManageVariableToPropertyMappings from './ManageVariableToPropertyMappings';
 import ObjectsAPIOptionsFieldset from './ObjectsAPIOptionsFieldset';
 import OptionalOptionsFieldset from './OptionalOptionsFieldset';
@@ -23,9 +24,10 @@ const ZGWFormFields = ({
   objectsApiGroupChoices,
   confidentialityLevelChoices,
   summaryDocumentChoices,
+  caseObjectTypeChoices,
 }) => {
   const {
-    values: {propertyMappings = []},
+    values: {propertyMappings = [], caseObjects = []},
   } = useFormikContext();
   const validationErrors = useContext(ValidationErrorContext);
   const relevantErrors = filterErrors(name, validationErrors);
@@ -36,6 +38,8 @@ const ZGWFormFields = ({
 
   const numCasePropertyErrors = filterErrors(`${name}.propertyMappings`, validationErrors).length;
   const numBaseErrors = relevantErrors.length - numCasePropertyErrors;
+  // fixme
+  const numCaseObjectErrors = 0;
 
   return (
     <ValidationErrorsProvider errors={relevantErrors}>
@@ -53,6 +57,15 @@ const ZGWFormFields = ({
               defaultMessage="Case properties ({count})"
               values={{
                 count: propertyMappings.length,
+              }}
+            />
+          </Tab>
+          <Tab hasErrors={numCaseObjectErrors > 0}>
+            <FormattedMessage
+              description="ZGW APIs registration backend options, 'case objects' tab label"
+              defaultMessage="Case objects ({count})"
+              values={{
+                count: caseObjects.length,
               }}
             />
           </Tab>
@@ -78,6 +91,11 @@ const ZGWFormFields = ({
         {/* zaakeigenschappen / case properties */}
         <TabPanel>
           <ManageVariableToPropertyMappings />
+        </TabPanel>
+
+        {/* zaakobjecten / case objects */}
+        <TabPanel>
+          <CaseObjectFieldsets caseObjectTypeChoices={caseObjectTypeChoices} />
         </TabPanel>
       </Tabs>
     </ValidationErrorsProvider>
@@ -106,6 +124,9 @@ ZGWFormFields.propTypes = {
     PropTypes.arrayOf(PropTypes.string) // value & label are both string
   ).isRequired,
   summaryDocumentChoices: PropTypes.arrayOf(
+    PropTypes.arrayOf(PropTypes.string) // value & label are both string
+  ).isRequired,
+  objectTypeChoices: PropTypes.arrayOf(
     PropTypes.arrayOf(PropTypes.string) // value & label are both string
   ).isRequired,
 };

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.js
@@ -37,9 +37,8 @@ const ZGWFormFields = ({
     useCatalogueOptions();
 
   const numCasePropertyErrors = filterErrors(`${name}.propertyMappings`, validationErrors).length;
-  const numBaseErrors = relevantErrors.length - numCasePropertyErrors;
-  // fixme
-  const numCaseObjectErrors = 0;
+  const numCaseObjectErrors = filterErrors(`${name}.caseObjects`, validationErrors).length;
+  const numBaseErrors = relevantErrors.length - numCasePropertyErrors - numCaseObjectErrors;
 
   return (
     <ValidationErrorsProvider errors={relevantErrors}>

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.stories.js
@@ -26,6 +26,7 @@ const render = ({
   objectsApiGroupChoices,
   confidentialityLevelChoices,
   summaryDocumentChoices,
+  caseObjectTypeChoices,
   formData,
 }) => (
   <Formik
@@ -47,6 +48,7 @@ const render = ({
       // Ensure that this is explicitly set to null instead of undefined,
       // because the field is required by the serializer
       objectsApiGroup: null,
+      caseObjects: [],
       // saved data, overwrites defaults
       ...formData,
     }}
@@ -60,6 +62,7 @@ const render = ({
         objectsApiGroupChoices={objectsApiGroupChoices}
         confidentialityLevelChoices={confidentialityLevelChoices}
         summaryDocumentChoices={summaryDocumentChoices}
+        caseObjectTypeChoices={caseObjectTypeChoices}
       />
     </Form>
   </Formik>
@@ -89,6 +92,7 @@ export default {
       ['pdf', 'PDF document'],
       ['json', 'JSON document'],
     ],
+    caseObjectTypeChoices: [['overige', 'Overige']],
     formData: {},
     availableComponents: {
       textField1: {
@@ -233,5 +237,54 @@ export const CataloguesLoadingFails = {
         catalogues: [mockCataloguesGetError()],
       },
     },
+  },
+};
+
+export const caseObjects = {
+  args: {
+    formData: {
+      propertyMappings: [],
+      caseObjects: [
+        {
+          caseObjectType: 'overige',
+          caseObjectTypeOverige: 'objects in construction',
+          caseObjectIdentification: {
+            overigeData: 'some address of the object',
+          },
+        },
+      ],
+    },
+  },
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('tab', {name: /Case objects/}));
+  },
+};
+
+export const ValidationErrorsCaseObjectsTab = {
+  args: {
+    formData: {
+      caseObjects: [
+        {
+          caseObjectType: '',
+          caseObjectTypeOverige: '',
+          caseObjectIdentification: {
+            overigeData: '',
+          },
+        },
+      ],
+    },
+    validationErrors: [
+      [`${NAME}.caseObjects.0.caseObjectType`, 'Computer says no'],
+      [`${NAME}.caseObjects.0.caseObjectTypeOverige`, 'Computer says no'],
+      [`${NAME}.caseObjects.0.caseObjectIdentification.overigeData`, 'Computer says no'],
+    ],
+  },
+
+  play: async ({canvasElement}) => {
+    const canvas = within(canvasElement);
+
+    await userEvent.click(canvas.getByRole('tab', {name: /Case objects/}));
   },
 };

--- a/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.stories.js
+++ b/src/openforms/js/components/admin/form_design/registrations/zgw/ZGWOptionsFormFields.stories.js
@@ -258,7 +258,7 @@ export const caseObjects = {
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByRole('tab', {name: /Case objects/}));
+    await userEvent.click(canvas.getByRole('tab', {name: /Zaakobjecten/}));
   },
 };
 
@@ -285,6 +285,6 @@ export const ValidationErrorsCaseObjectsTab = {
   play: async ({canvasElement}) => {
     const canvas = within(canvasElement);
 
-    await userEvent.click(canvas.getByRole('tab', {name: /Case objects/}));
+    await userEvent.click(canvas.getByRole('tab', {name: /Zaakobjecten/}));
   },
 };

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -274,6 +274,11 @@
     "description": "StUF-ZDS extraElement serializeListToCsv label",
     "originalDefault": "Comma-separate list values"
   },
+  "4iYhbx": {
+    "defaultMessage": "Object type overige",
+    "description": "ZGW APIs registration options 'caseObjectTypeOverige' label",
+    "originalDefault": "Object type overige"
+  },
   "4sFGgA": {
     "defaultMessage": "The expressions here are extracted from the selected decision definition. It's possible certain inputs are displayed here that are already provided by a dependency of the selected decision, due to the complexity of the input expression.",
     "description": "DMN input expressions warning about extraction accuracy",
@@ -854,6 +859,11 @@
     "description": "Required error message",
     "originalDefault": "This field is required."
   },
+  "Dvovhl": {
+    "defaultMessage": "Add case object",
+    "description": "Add case object (mapping) button",
+    "originalDefault": "Add case object"
+  },
   "DxGKNm": {
     "defaultMessage": "Logic",
     "description": "Logic fieldset title",
@@ -1403,6 +1413,11 @@
     "defaultMessage": "Change text",
     "description": "literals.changeText form label",
     "originalDefault": "Change text"
+  },
+  "M4Kbw3": {
+    "defaultMessage": "Data for the 'overige' case object in a free format. You can use form variables here.",
+    "description": "ZGW APIs registration options 'overigeData' help text",
+    "originalDefault": "Data for the 'overige' case object in a free format. You can use form variables here."
   },
   "M8nTet": {
     "defaultMessage": "Whether the user is allowed to submit this form or not, and whether the overview page should be shown if they are not. Submission is always allowed for the single step forms.",
@@ -2064,6 +2079,11 @@
     "description": "Form step previous text label",
     "originalDefault": "Previous text"
   },
+  "ZJQmio": {
+    "defaultMessage": "Case object {count}",
+    "description": "ZGW APIs registration: case objects fieldset title",
+    "originalDefault": "Case object {count}"
+  },
   "ZP5B/v": {
     "defaultMessage": "The processing (\"verwerking\") for queries to the BRP Persoon API.",
     "description": "Form 'BRP Personen processing header value' field help text",
@@ -2118,6 +2138,11 @@
     "defaultMessage": "Mapped to the {geometryPath} attribute",
     "description": "'Mapped to geometry' registration summary message",
     "originalDefault": "Mapped to the {geometryPath} attribute"
+  },
+  "aE4IrY": {
+    "defaultMessage": "Overige data",
+    "description": "ZGW APIs registration options 'overigeData' label",
+    "originalDefault": "Overige data"
   },
   "aXJpiI": {
     "defaultMessage": "This field is required.",
@@ -2774,6 +2799,11 @@
     "description": "Email registration options 'toEmails' label",
     "originalDefault": "The email addresses to which the submission details will be sent"
   },
+  "l/D4PL": {
+    "defaultMessage": "Object type",
+    "description": "ZGW APIs registration options 'caseObjectType' label",
+    "originalDefault": "Object type"
+  },
   "l1fi1t": {
     "defaultMessage": "(missing information)",
     "description": "JSON editor: unknown FormIO component key",
@@ -2888,6 +2918,11 @@
     "defaultMessage": "Email content template HTML",
     "description": "Email registration options 'emailContentTemplateHtml' label",
     "originalDefault": "Email content template HTML"
+  },
+  "nXKEYN": {
+    "defaultMessage": "Case objects ({count})",
+    "description": "ZGW APIs registration backend options, 'case objects' tab label",
+    "originalDefault": "Case objects ({count})"
   },
   "nYePys": {
     "defaultMessage": "Something went wrong while retrieving the available object type versions.",
@@ -3058,6 +3093,11 @@
     "defaultMessage": "If enabled, then no access control on the referenced object is performed. Ensure that it does not contain private data before checking this!",
     "description": "Objects API registration: skipOwnershipCheck helpText",
     "originalDefault": "If enabled, then no access control on the referenced object is performed. Ensure that it does not contain private data before checking this!"
+  },
+  "qntXTt": {
+    "defaultMessage": "Description of the 'overige' object type.",
+    "description": "ZGW APIs registration options 'caseObjectTypeOverige' help text",
+    "originalDefault": "Description of the 'overige' object type."
   },
   "qo1UbS": {
     "defaultMessage": "Export",
@@ -3333,6 +3373,11 @@
     "defaultMessage": "Save the document in the Documents API with the selected document type. The document type will be resolved against the {catalogueLabel, select, empty {specified} other {''{catalogueLabel}''} } catalogue in the plugin options. If left blank, the default attachment document type configured in the plugin options will be used.",
     "description": "Document upload: document type option help text",
     "originalDefault": "Save the document in the Documents API with the selected document type. The document type will be resolved against the {catalogueLabel, select, empty {specified} other {''{catalogueLabel}''} } catalogue in the plugin options. If left blank, the default attachment document type configured in the plugin options will be used."
+  },
+  "vhmWn1": {
+    "defaultMessage": "Type of the case object. Now only 'overige' value is supported.",
+    "description": "ZGW APIs registration options 'caseObjectType' help text",
+    "originalDefault": "Type of the case object. Now only 'overige' value is supported."
   },
   "viEfGU": {
     "defaultMessage": "The content of the submission confirmation page. It can contain variables that will be templated from the submitted form data. If not specified, the global template will be used.",

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -274,11 +274,6 @@
     "description": "StUF-ZDS extraElement serializeListToCsv label",
     "originalDefault": "Comma-separate list values"
   },
-  "4iYhbx": {
-    "defaultMessage": "Object type overige",
-    "description": "ZGW APIs registration options 'caseObjectTypeOverige' label",
-    "originalDefault": "Object type overige"
-  },
   "4sFGgA": {
     "defaultMessage": "The expressions here are extracted from the selected decision definition. It's possible certain inputs are displayed here that are already provided by a dependency of the selected decision, due to the complexity of the input expression.",
     "description": "DMN input expressions warning about extraction accuracy",
@@ -1418,6 +1413,11 @@
     "defaultMessage": "Data for the 'overige' case object in a free format. You can use form variables here.",
     "description": "ZGW APIs registration options 'overigeData' help text",
     "originalDefault": "Data for the 'overige' case object in a free format. You can use form variables here."
+  },
+  "M765u8": {
+    "defaultMessage": "Object type description",
+    "description": "ZGW APIs registration options 'caseObjectTypeOverige' label",
+    "originalDefault": "Object type description"
   },
   "M8nTet": {
     "defaultMessage": "Whether the user is allowed to submit this form or not, and whether the overview page should be shown if they are not. Submission is always allowed for the single step forms.",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -276,11 +276,6 @@
     "description": "StUF-ZDS extraElement serializeListToCsv label",
     "originalDefault": "Comma-separate list values"
   },
-  "4iYhbx": {
-    "defaultMessage": "Objecttype overige",
-    "description": "ZGW APIs registration options 'caseObjectTypeOverige' label",
-    "originalDefault": "Object type overige"
-  },
   "4sFGgA": {
     "defaultMessage": "De expressies hieronder komen uit de geselecteerde beslisdefinitie. Het is mogelijk dat sommige inputs zichtbaar zijn die al ingevuld worden door een eerdere definitie. Dit komt door de complexiteit van de expressie.",
     "description": "DMN input expressions warning about extraction accuracy",
@@ -1429,6 +1424,11 @@
     "defaultMessage": "Gegevens voor het zaakobject ‘overige’ in een vrije indeling. Je kunt hier formuliervariabelen gebruiken.",
     "description": "ZGW APIs registration options 'overigeData' help text",
     "originalDefault": "Data for the 'overige' case object in a free format. You can use form variables here."
+  },
+  "M765u8": {
+    "defaultMessage": "Beschrijving van het objecttype",
+    "description": "ZGW APIs registration options 'caseObjectTypeOverige' label",
+    "originalDefault": "Object type description"
   },
   "M8nTet": {
     "defaultMessage": "Geeft aan of de gebruiker het formulier kan verzenden en of de overzichtspagina getoond wordt als het formulier niet verzonden kan worden. Inzenden is altijd toegestaan voor de `enkele stap` formulieren.",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -276,6 +276,11 @@
     "description": "StUF-ZDS extraElement serializeListToCsv label",
     "originalDefault": "Comma-separate list values"
   },
+  "4iYhbx": {
+    "defaultMessage": "Objecttype overige",
+    "description": "ZGW APIs registration options 'caseObjectTypeOverige' label",
+    "originalDefault": "Object type overige"
+  },
   "4sFGgA": {
     "defaultMessage": "De expressies hieronder komen uit de geselecteerde beslisdefinitie. Het is mogelijk dat sommige inputs zichtbaar zijn die al ingevuld worden door een eerdere definitie. Dit komt door de complexiteit van de expressie.",
     "description": "DMN input expressions warning about extraction accuracy",
@@ -864,6 +869,11 @@
     "description": "Required error message",
     "originalDefault": "This field is required."
   },
+  "Dvovhl": {
+    "defaultMessage": "Zaakobject toevoegen",
+    "description": "Add case object (mapping) button",
+    "originalDefault": "Add case object"
+  },
   "DxGKNm": {
     "defaultMessage": "Logica",
     "description": "Logic fieldset title",
@@ -1414,6 +1424,11 @@
     "defaultMessage": "'Wijzigen' tekst",
     "description": "literals.changeText form label",
     "originalDefault": "Change text"
+  },
+  "M4Kbw3": {
+    "defaultMessage": "Gegevens voor het zaakobject ‘overige’ in een vrije indeling. Je kunt hier formuliervariabelen gebruiken.",
+    "description": "ZGW APIs registration options 'overigeData' help text",
+    "originalDefault": "Data for the 'overige' case object in a free format. You can use form variables here."
   },
   "M8nTet": {
     "defaultMessage": "Geeft aan of de gebruiker het formulier kan verzenden en of de overzichtspagina getoond wordt als het formulier niet verzonden kan worden. Inzenden is altijd toegestaan voor de `enkele stap` formulieren.",
@@ -2084,6 +2099,11 @@
     "description": "Form step previous text label",
     "originalDefault": "Previous text"
   },
+  "ZJQmio": {
+    "defaultMessage": "Zaakobject {count}",
+    "description": "ZGW APIs registration: case objects fieldset title",
+    "originalDefault": "Case object {count}"
+  },
   "ZP5B/v": {
     "defaultMessage": "De waarde voor \"verwerking\" die meegestuurd wordt bij het bevragen van de BRP Personen API. Mogelijke waarden hiervoor zijn afhankelijk van je gateway-leverancier.",
     "description": "Form 'BRP Personen processing header value' field help text",
@@ -2138,6 +2158,11 @@
     "defaultMessage": "Gekoppeld aan het {geometryPath}-attribuut",
     "description": "'Mapped to geometry' registration summary message",
     "originalDefault": "Mapped to the {geometryPath} attribute"
+  },
+  "aE4IrY": {
+    "defaultMessage": "Overige data",
+    "description": "ZGW APIs registration options 'overigeData' label",
+    "originalDefault": "Overige data"
   },
   "aXJpiI": {
     "defaultMessage": "Dit veld is verplicht.",
@@ -2797,6 +2822,11 @@
     "description": "Email registration options 'toEmails' label",
     "originalDefault": "The email addresses to which the submission details will be sent"
   },
+  "l/D4PL": {
+    "defaultMessage": "Objecttype",
+    "description": "ZGW APIs registration options 'caseObjectType' label",
+    "originalDefault": "Object type"
+  },
   "l1fi1t": {
     "defaultMessage": "(ontbrekende informatie)",
     "description": "JSON editor: unknown FormIO component key",
@@ -2911,6 +2941,11 @@
     "defaultMessage": "Sjabloon emailinhoud (HTML)",
     "description": "Email registration options 'emailContentTemplateHtml' label",
     "originalDefault": "Email content template HTML"
+  },
+  "nXKEYN": {
+    "defaultMessage": "Zaakobjecten ({count})",
+    "description": "ZGW APIs registration backend options, 'case objects' tab label",
+    "originalDefault": "Case objects ({count})"
   },
   "nYePys": {
     "defaultMessage": "Er ging iets fout bij het ophalen van de objecttypeversies.",
@@ -3082,6 +3117,11 @@
     "defaultMessage": "Indien aangevinkt, dan worden geen controles uitgevoerd of de (ingelogde) gebruiker toegang heeft op het gerefereerde object. Valideer dat de objecten geen privacy-gevoelige gegevens bevatten voor je dit aanvinkt!",
     "description": "Objects API registration: skipOwnershipCheck helpText",
     "originalDefault": "If enabled, then no access control on the referenced object is performed. Ensure that it does not contain private data before checking this!"
+  },
+  "qntXTt": {
+    "defaultMessage": "Beschrijving van het objecttype ‘overige’.",
+    "description": "ZGW APIs registration options 'caseObjectTypeOverige' help text",
+    "originalDefault": "Description of the 'overige' object type."
   },
   "qo1UbS": {
     "defaultMessage": "Exporteren",
@@ -3358,6 +3398,11 @@
     "defaultMessage": "Sla het document op in de Documenten-API met het geselecteerde documenttype. Het documenttype wordt gevalideerd tegen de {catalogueLabel, select, empty {ingestelde} other {''{catalogueLabel}''} } catalogus in de plugin opties. Als je dit leeglaat, dan wordt het standaarddocumenttype gebruikt.",
     "description": "Document upload: document type option help text",
     "originalDefault": "Save the document in the Documents API with the selected document type. The document type will be resolved against the {catalogueLabel, select, empty {specified} other {''{catalogueLabel}''} } catalogue in the plugin options. If left blank, the default attachment document type configured in the plugin options will be used."
+  },
+  "vhmWn1": {
+    "defaultMessage": "Type van het zaakobject. Momenteel wordt alleen de waarde ‘overige’ ondersteund.",
+    "description": "ZGW APIs registration options 'caseObjectType' help text",
+    "originalDefault": "Type of the case object. Now only 'overige' value is supported."
   },
   "viEfGU": {
     "defaultMessage": "De inhoud van bevestigingspagina na het versturen van de inzending. Dit sjabloon mag variabelen bevatten met inzendings-gegevens. Laat dit veld leeg om de standaardinstelling te gebruiken.",

--- a/src/openforms/registrations/contrib/zgw_apis/constants.py
+++ b/src/openforms/registrations/contrib/zgw_apis/constants.py
@@ -5,3 +5,7 @@ from django.utils.translation import gettext_lazy as _
 class SummaryDocumentChoices(models.TextChoices):
     json = "json", _("JSON document")
     pdf = "pdf", _("PDF document")
+
+
+class CaseObjectTypeChoices(models.TextChoices):
+    overige = "overige", _("Overige")

--- a/src/openforms/registrations/contrib/zgw_apis/options.py
+++ b/src/openforms/registrations/contrib/zgw_apis/options.py
@@ -123,6 +123,7 @@ class CaseObjectSerializer(serializers.Serializer):
     case_object_type_overige = serializers.CharField(
         label=_("Object type overige"),
         max_length=100,
+        allow_blank=True,
         help_text=_("Description of the 'overige' case object type."),
     )
     case_object_identification = ObjectOverigeSerializer(

--- a/src/openforms/registrations/contrib/zgw_apis/options.py
+++ b/src/openforms/registrations/contrib/zgw_apis/options.py
@@ -27,7 +27,7 @@ from openforms.utils.mixins import JsonSchemaSerializerMixin
 from openforms.utils.validators import validate_rsin
 
 from .client import get_catalogi_client
-from .constants import SummaryDocumentChoices
+from .constants import CaseObjectTypeChoices, SummaryDocumentChoices
 from .models import ZGWApiGroupConfig
 from .typing import RegistrationOptions
 
@@ -97,6 +97,41 @@ class FileComponentOptionsSerializer(serializers.Serializer):
             "name is used."
         ),
         allow_blank=True,
+    )
+
+
+class ObjectOverigeSerializer(serializers.Serializer):
+    overige_data = serializers.CharField(
+        label=_("Overige data"),
+        help_text=_(
+            "Data for the 'overige' object in a free format. You can use the expressions like "
+            "'{{ form_name }}' or other variables here."
+        ),
+        validators=[
+            DjangoTemplateValidator(backend="openforms.template.openforms_backend")
+        ],
+    )
+
+
+class CaseObjectSerializer(serializers.Serializer):
+    # in the future this field can be turned to Discriminator for PolymorphicSerializer
+    # but for now it will over-complicate things without benefits, so let's do KISS
+    case_object_type = serializers.ChoiceField(
+        label=_("object type"),
+        choices=CaseObjectTypeChoices.choices,
+        help_text=_("Type of the case object. Now only 'overige' value is supported."),
+    )
+    case_object_type_overige = serializers.CharField(
+        label=_("Object type overige"),
+        max_length=100,
+        help_text=_("Description of the 'overige' case object type."),
+    )
+    case_object_identification = ObjectOverigeSerializer(
+        label=_("Object identification"),
+        help_text=_(
+            "Data, which describes the object. The shape depends on the 'case_object_type'. "
+            "Now only 'overige' data shape is supported."
+        ),
     )
 
 
@@ -295,6 +330,13 @@ class ZaakOptionsSerializer(JsonSchemaSerializerMixin, serializers.Serializer):
             "level. If unspecified, the backend configuration is used."
         ),
         allow_null=False,
+    )
+    # Zaakobjecten
+    case_objects = CaseObjectSerializer(
+        many=True,
+        label=_("Case Objects"),
+        required=False,
+        help_text=_("List of case objects."),
     )
 
     def _handle_import(self, attrs) -> None:

--- a/src/openforms/registrations/contrib/zgw_apis/options.py
+++ b/src/openforms/registrations/contrib/zgw_apis/options.py
@@ -104,8 +104,7 @@ class ObjectOverigeSerializer(serializers.Serializer):
     overige_data = serializers.CharField(
         label=_("Overige data"),
         help_text=_(
-            "Data for the 'overige' object in a free format. You can use the expressions like "
-            "'{{ form_name }}' or other variables here."
+            "Data for the 'overige' object in a free format. You can use form variables here."
         ),
         validators=[
             DjangoTemplateValidator(backend="openforms.template.openforms_backend")

--- a/src/openforms/registrations/contrib/zgw_apis/options.py
+++ b/src/openforms/registrations/contrib/zgw_apis/options.py
@@ -116,18 +116,18 @@ class CaseObjectSerializer(serializers.Serializer):
     # in the future this field can be turned to Discriminator for PolymorphicSerializer
     # but for now it will over-complicate things without benefits, so let's do KISS
     case_object_type = serializers.ChoiceField(
-        label=_("object type"),
+        label=_("Case object type"),
         choices=CaseObjectTypeChoices.choices,
         help_text=_("Type of the case object. Now only 'overige' value is supported."),
     )
     case_object_type_overige = serializers.CharField(
-        label=_("Object type overige"),
+        label=_("Case object type overige"),
         max_length=100,
         allow_blank=True,
         help_text=_("Description of the 'overige' case object type."),
     )
     case_object_identification = ObjectOverigeSerializer(
-        label=_("Object identification"),
+        label=_("Case object identification"),
         help_text=_(
             "Data, which describes the object. The shape depends on the 'case_object_type'. "
             "Now only 'overige' data shape is supported."

--- a/src/openforms/registrations/contrib/zgw_apis/plugin.py
+++ b/src/openforms/registrations/contrib/zgw_apis/plugin.py
@@ -55,12 +55,18 @@ from .client import get_catalogi_client, get_documents_client, get_zaken_client
 from .constants import SummaryDocumentChoices
 from .models import ZGWApiGroupConfig
 from .options import ZaakOptionsSerializer
-from .typing import CatalogueOption, RegistrationOptions
+from .typing import CaseObjectType, CatalogueOption, ObjectOverige, RegistrationOptions
 from .utils import process_according_to_eigenschap_format
 
 logger = structlog.stdlib.get_logger(__name__)
 
 PLUGIN_IDENTIFIER = "zgw-create-zaak"
+
+
+# All case object attributes inside CaseObjectIdentification object, which support templating
+TEMPLATED_CASE_OBJECT_ATTRIBUTES: Mapping[CaseObjectType, list[str]] = {
+    "overige": ["overige_data"]
+}
 
 
 class VariablesProperties(TypedDict):
@@ -204,6 +210,25 @@ def transform_addressnl_to_verblijfsadres(value):
         "aoaHuisletter": value.get("houseLetter") or "",
         "aoaHuisnummertoevoeging": value.get("houseNumberAddition") or "",
     }
+
+
+def render_case_object_identification(
+    case_object_type: CaseObjectType,
+    case_object_identification: ObjectOverige,
+    context: ZaakTemplateContext,
+) -> ObjectOverige:
+    """
+    Render case_object_identification with templated attributes using the provided context.
+    """
+    result = case_object_identification.copy()
+
+    templated_attributes = TEMPLATED_CASE_OBJECT_ATTRIBUTES[case_object_type]
+    for attribute in templated_attributes:
+        result[attribute] = render_from_string(
+            result[attribute], context, backend=openforms_backend
+        )
+
+    return result
 
 
 @register(PLUGIN_IDENTIFIER)
@@ -781,7 +806,7 @@ class ZGWRegistration(BasePlugin[RegistrationOptions]):
 
             result["zaakobject"] = execute_unless_result_exists(
                 partial(
-                    zaken_client.create_zaakobject,
+                    zaken_client.create_zaakobject_with_object,
                     zaak,
                     result["objects_api_object"]["url"],
                     objecttype_version.url,
@@ -838,6 +863,34 @@ class ZGWRegistration(BasePlugin[RegistrationOptions]):
                         created_zaakeigenschap,
                         missing=dict,
                     )
+
+        # register configured case objects
+        if case_objects := options.get("case_objects"):
+            context = _get_template_context(submission)
+            for i, case_object in enumerate(case_objects):
+                created_zaakobject = execute_unless_result_exists(
+                    partial(
+                        zaken_client.create_zaakobject_with_object_identification,
+                        zaak,
+                        object_type=case_object["case_object_type"],
+                        object_type_overige=case_object["case_object_type_overige"],
+                        object_identification=render_case_object_identification(
+                            case_object_type=case_object["case_object_type"],
+                            case_object_identification=case_object[
+                                "case_object_identification"
+                            ],
+                            context=context,
+                        ),
+                    ),
+                    submission,
+                    f"intermediate.zaakobjecten.{i}",
+                )
+                assign(
+                    result,
+                    f"zaakobjecten.{i}",
+                    created_zaakobject,
+                    missing=dict,
+                )
 
         submission.registration_result = result
         submission.save()

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 from django.test import TestCase, override_settings, tag
 
+from glom import glom
 from privates.test import temp_private_root
 from unittest_parametrize import ParametrizedTestCase, parametrize
 from zgw_consumers.constants import AuthTypes
@@ -3288,7 +3289,7 @@ class ObjectsAPITests(BaseRegistrationTestCase):
         # we need to patch the ZGW client `create_zaakobject` method so that we can
         # fix up the object URL since Open Zaak validates the format and needs to resolve
         # this inside the container network
-        original_create_zaakobject = ZakenClient.create_zaakobject
+        original_create_zaakobject = ZakenClient.create_zaakobject_with_object
 
         def wrapped_create_zaakobject(
             self,
@@ -3307,7 +3308,7 @@ class ObjectsAPITests(BaseRegistrationTestCase):
 
         with patch.object(
             ZakenClient,
-            "create_zaakobject",
+            "create_zaakobject_with_object",
             side_effect=wrapped_create_zaakobject,
             autospec=True,
         ):
@@ -3739,3 +3740,103 @@ class SummaryDocumentTests(BaseRegistrationTestCase):
         pdf_details = document_results["report"]["document"]
         self.assertEqual(pdf_details["titel"], "Public form name (PDF)")
         self.assertTrue("json" not in document_results)
+
+
+class CaseObjectsTests(BaseRegistrationTestCase):
+    def test_submission_with_case_objects_creation(self):
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "key": "textField1",
+                    "type": "textfield",
+                },
+                {
+                    "key": "textField2",
+                    "type": "textfield",
+                },
+            ],
+            submitted_data={
+                "textField1": "Maple Avenue 3B",
+                "textField2": "de Pijp 4199",
+            },
+            bsn="123456782",
+            completed=True,
+            # Pin to a known case type version (2024-10-31)
+            completed_on=datetime(2024, 11, 9, 15, 30, 0, tzinfo=UTC),
+            with_report=True,
+        )
+        options: RegistrationOptions = {
+            "zgw_api_group": self.zgw_group,
+            "catalogue": {
+                "domain": "TEST",
+                "rsin": "000000000",
+            },
+            "case_type_identification": "ZT-001",
+            "document_type_description": "Attachment Informatieobjecttype",
+            "product_url": "",
+            "property_mappings": [],
+            "objects_api_group": None,
+            "partners_roltype": "",
+            "partners_description": "",
+            "children_roltype": "",
+            "children_description": "",
+            "summary_documents": [],
+            "case_objects": [
+                {
+                    "case_object_type": "overige",
+                    "case_object_type_overige": "building in construction",
+                    "case_object_identification": {
+                        "overige_data": "Building: {{variables.textField1}}"
+                    },
+                },
+                {
+                    "case_object_type": "overige",
+                    "case_object_type_overige": "parking in construction",
+                    "case_object_identification": {
+                        "overige_data": "Parking: {{variables.textField2}}"
+                    },
+                },
+            ],
+        }
+        client = get_zaken_client(self.zgw_group)
+        self.addCleanup(client.close)
+        plugin = ZGWRegistration("zgw")
+        pre_registration_result = plugin.pre_register_submission(submission, options)
+        assert submission.registration_result is not None
+        submission.registration_result.update(pre_registration_result.data)  # type: ignore
+        submission.save()
+
+        # perform the actual registration
+        result = plugin.register_submission(submission, options)
+        assert result is not None
+
+        self.assertEqual(len(result["zaakobjecten"]), 2)
+        # verify the created case objects
+        zaakobjecten = client.get("zaakobjecten").json()
+        partial_zaakobjecten = glom(
+            zaakobjecten["results"],
+            [
+                {
+                    "object_type": "objectType",
+                    "object_type_overige": "objectTypeOverige",
+                    "object_identification": "objectIdentificatie",
+                }
+            ],
+        )
+        self.assertEqual(
+            partial_zaakobjecten,
+            [
+                {
+                    "object_type": "overige",
+                    "object_type_overige": "parking in construction",
+                    "object_identification": {"overigeData": "Parking: de Pijp 4199"},
+                },
+                {
+                    "object_type": "overige",
+                    "object_type_overige": "building in construction",
+                    "object_identification": {
+                        "overigeData": "Building: Maple Avenue 3B"
+                    },
+                },
+            ],
+        )

--- a/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/test_backend.py
@@ -3286,7 +3286,7 @@ class ObjectsAPITests(BaseRegistrationTestCase):
         }
         plugin = ZGWRegistration("zgw")
         _run_preregistration(submission, plugin, options)
-        # we need to patch the ZGW client `create_zaakobject` method so that we can
+        # we need to patch the ZGW client `create_zaakobject_with_object` method so that we can
         # fix up the object URL since Open Zaak validates the format and needs to resolve
         # this inside the container network
         original_create_zaakobject = ZakenClient.create_zaakobject_with_object

--- a/src/openforms/registrations/contrib/zgw_apis/tests/vcr_cassettes/test_backend/CaseObjectsTests/test_submission_with_case_objects_creation.yaml
+++ b/src/openforms/registrations/contrib/zgw_apis/tests/vcr_cassettes/test_backend/CaseObjectsTests/test_submission_with_case_objects_creation.yaml
@@ -1,0 +1,567 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=TEST&rsin=000000000
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc","http://localhost:8003/catalogi/api/v1/zaaktypen/b79d9c2f-5ec4-4e23-bb66-ec6dd959a400","http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","http://localhost:8003/catalogi/api/v1/zaaktypen/fcc3499a-04d4-421c-b115-7e3cba2127ac","http://localhost:8003/catalogi/api/v1/zaaktypen/6cc5c7eb-9adf-4262-98ab-1b26b738a5ae"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1345'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/zaaktypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fbd58635c-793e-446d-a7e0-460d7b04829d&identificatie=ZT-001&datumGeldigheid=2024-11-09
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","identificatie":"ZT-001","omschrijving":"Test","omschrijvingGeneriek":"","vertrouwelijkheidaanduiding":"intern","doel":"testen","aanleiding":"integratietests","toelichting":"","indicatieInternOfExtern":"intern","handelingInitiator":"Formulier
+        indienen","onderwerp":"Testformulier","handelingBehandelaar":"Controleren","doorlooptijd":"P1D","servicenorm":null,"opschortingEnAanhoudingMogelijk":false,"verlengingMogelijk":false,"verlengingstermijn":null,"trefwoorden":[],"publicatieIndicatie":false,"publicatietekst":"","verantwoordingsrelatie":[],"productenOfDiensten":["http://localhost:81/product/1234abcd-12ab-34cd-56ef-12345abcde10"],"selectielijstProcestype":"https://selectielijst.openzaak.nl/api/v1/procestypen/aa8aa2fd-b9c6-4e34-9a6c-58a677f60ea0","referentieproces":{"naam":"Testen","link":""},"concept":false,"verantwoordelijke":"Ontwikkelaar","beginGeldigheid":"2024-10-31","eindeGeldigheid":null,"versiedatum":"2024-10-31","beginObject":"2023-01-01","eindeObject":null,"catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","statustypen":["http://localhost:8003/catalogi/api/v1/statustypen/018ec0c2-50d0-4225-a5bb-5ad7c48d6f2b","http://localhost:8003/catalogi/api/v1/statustypen/2937ee1d-9ea1-4048-b642-5a4dfd51fb47"],"resultaattypen":["http://localhost:8003/catalogi/api/v1/resultaattypen/e84e6028-c52a-420b-a098-d10897395c52"],"eigenschappen":["http://localhost:8003/catalogi/api/v1/eigenschappen/3a094e33-7a20-4018-bd60-3c15d06a1555","http://localhost:8003/catalogi/api/v1/eigenschappen/f376c43d-97f6-423c-a25c-9264142db235"],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71"],"roltypen":["http://localhost:8003/catalogi/api/v1/roltypen/bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8","http://localhost:8003/catalogi/api/v1/roltypen/d44d68c2-1e06-461e-9657-adf174a922fb"],"besluittypen":[],"deelzaaktypen":[],"gerelateerdeZaaktypen":[],"zaakobjecttypen":[]}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '2325'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zaaktype": "http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774",
+      "bronorganisatie": "000000000", "verantwoordelijkeOrganisatie": "000000000",
+      "registratiedatum": "2026-07-06", "startdatum": "2026-07-06", "productenOfDiensten":
+      [], "omschrijving": "Form 000", "toelichting": "", "betalingsindicatie": "nvt",
+      "identificatie": "OF-MTJU4V"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Crs:
+      - EPSG:4326
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '372'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8003/zaken/api/v1/zaken
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/zaken/api/v1/zaken/5ee030af-870d-430a-ac7c-2a7dc47d7bce","uuid":"5ee030af-870d-430a-ac7c-2a7dc47d7bce","identificatie":"OF-MTJU4V","bronorganisatie":"000000000","omschrijving":"Form
+        000","toelichting":"","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","registratiedatum":"2026-07-06","verantwoordelijkeOrganisatie":"000000000","startdatum":"2026-07-06","einddatum":null,"einddatumGepland":null,"uiterlijkeEinddatumAfdoening":null,"publicatiedatum":null,"communicatiekanaal":"","communicatiekanaalNaam":"","productenOfDiensten":[],"vertrouwelijkheidaanduiding":"intern","betalingsindicatie":"nvt","betalingsindicatieWeergave":"Er
+        is geen sprake van te betalen, met de zaak gemoeide, kosten.","laatsteBetaaldatum":null,"zaakgeometrie":null,"verlenging":null,"opschorting":{"indicatie":false,"reden":""},"selectielijstklasse":"","hoofdzaak":null,"deelzaken":[],"relevanteAndereZaken":[],"eigenschappen":[],"rollen":[],"status":null,"zaakinformatieobjecten":[],"zaakobjecten":[],"kenmerken":[],"archiefnominatie":null,"archiefstatus":"nog_te_archiveren","archiefactiedatum":null,"resultaat":null,"opdrachtgevendeOrganisatie":"","processobjectaard":"","startdatumBewaartermijn":null,"processobject":{"datumkenmerk":"","identificatie":"","objecttype":"","registratie":""}}'
+    headers:
+      API-version:
+      - 1.5.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Crs:
+      - EPSG:4326
+      Content-Length:
+      - '1346'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/zaken/api/v1/zaken/5ee030af-870d-430a-ac7c-2a7dc47d7bce
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/catalogussen?domein=TEST&rsin=000000000
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","domein":"TEST","rsin":"000000000","contactpersoonBeheerNaam":"Test
+        name","contactpersoonBeheerTelefoonnummer":"","contactpersoonBeheerEmailadres":"","zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/1f41885e-23fc-4462-bbc8-80be4ae484dc","http://localhost:8003/catalogi/api/v1/zaaktypen/b79d9c2f-5ec4-4e23-bb66-ec6dd959a400","http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","http://localhost:8003/catalogi/api/v1/zaaktypen/fcc3499a-04d4-421c-b115-7e3cba2127ac","http://localhost:8003/catalogi/api/v1/zaaktypen/6cc5c7eb-9adf-4262-98ab-1b26b738a5ae"],"besluittypen":[],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7a474713-0833-402a-8441-e467c08ac55b","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/b2d83b94-9b9b-4e80-a82f-73ff993c62f3","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e"],"naam":"Test
+        catalog","versie":"","begindatumVersie":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1345'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/informatieobjecttypen?catalogus=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fcatalogussen%2Fbd58635c-793e-446d-a7e0-460d7b04829d&omschrijving=Attachment+Informatieobjecttype&datumGeldigheid=2024-11-09
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","omschrijving":"Attachment
+        Informatieobjecttype","vertrouwelijkheidaanduiding":"openbaar","beginGeldigheid":"2024-07-10","eindeGeldigheid":null,"concept":false,"besluittypen":[],"informatieobjectcategorie":"Test
+        category","trefwoord":[],"omschrijvingGeneriek":{"informatieobjecttypeOmschrijvingGeneriek":"","definitieInformatieobjecttypeOmschrijvingGeneriek":"","herkomstInformatieobjecttypeOmschrijvingGeneriek":"","hierarchieInformatieobjecttypeOmschrijvingGeneriek":"","opmerkingInformatieobjecttypeOmschrijvingGeneriek":""},"zaaktypen":["http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","http://localhost:8003/catalogi/api/v1/zaaktypen/6cc5c7eb-9adf-4262-98ab-1b26b738a5ae"],"beginObject":"2024-03-19","eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1022'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","identificatie":"ZT-001","omschrijving":"Test","omschrijvingGeneriek":"","vertrouwelijkheidaanduiding":"intern","doel":"testen","aanleiding":"integratietests","toelichting":"","indicatieInternOfExtern":"intern","handelingInitiator":"Formulier
+        indienen","onderwerp":"Testformulier","handelingBehandelaar":"Controleren","doorlooptijd":"P1D","servicenorm":null,"opschortingEnAanhoudingMogelijk":false,"verlengingMogelijk":false,"verlengingstermijn":null,"trefwoorden":[],"publicatieIndicatie":false,"publicatietekst":"","verantwoordingsrelatie":[],"productenOfDiensten":["http://localhost:81/product/1234abcd-12ab-34cd-56ef-12345abcde10"],"selectielijstProcestype":"https://selectielijst.openzaak.nl/api/v1/procestypen/aa8aa2fd-b9c6-4e34-9a6c-58a677f60ea0","referentieproces":{"naam":"Testen","link":""},"concept":false,"verantwoordelijke":"Ontwikkelaar","beginGeldigheid":"2024-10-31","eindeGeldigheid":null,"versiedatum":"2024-10-31","beginObject":"2023-01-01","eindeObject":null,"catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","statustypen":["http://localhost:8003/catalogi/api/v1/statustypen/018ec0c2-50d0-4225-a5bb-5ad7c48d6f2b","http://localhost:8003/catalogi/api/v1/statustypen/2937ee1d-9ea1-4048-b642-5a4dfd51fb47"],"resultaattypen":["http://localhost:8003/catalogi/api/v1/resultaattypen/e84e6028-c52a-420b-a098-d10897395c52"],"eigenschappen":["http://localhost:8003/catalogi/api/v1/eigenschappen/3a094e33-7a20-4018-bd60-3c15d06a1555","http://localhost:8003/catalogi/api/v1/eigenschappen/f376c43d-97f6-423c-a25c-9264142db235"],"informatieobjecttypen":["http://localhost:8003/catalogi/api/v1/informatieobjecttypen/531f6c1a-97f7-478c-85f0-67d2f23661c7","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/7755ab0f-9e37-4834-8bbf-158f9f2da38e","http://localhost:8003/catalogi/api/v1/informatieobjecttypen/29b63e5c-3835-4f68-8fad-f2aea9ae6b71"],"roltypen":["http://localhost:8003/catalogi/api/v1/roltypen/bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8","http://localhost:8003/catalogi/api/v1/roltypen/d44d68c2-1e06-461e-9657-adf174a922fb"],"besluittypen":[],"deelzaaktypen":[],"gerelateerdeZaaktypen":[],"zaakobjecttypen":[]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, PUT, PATCH, DELETE, HEAD, OPTIONS
+      Content-Length:
+      - '2273'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      ETag:
+      - '"14cb0d757ba364562edbb66412778d30"'
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/roltypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2Ff609b6fe-449a-46dc-a0af-de55dc5f6774&omschrijvingGeneriek=initiator
+  response:
+    body:
+      string: '{"count":1,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/roltypen/bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","zaaktypeIdentificatie":"ZT-001","omschrijving":"Initiator","omschrijvingGeneriek":"initiator","catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","beginGeldigheid":null,"eindeGeldigheid":null,"beginObject":null,"eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '524'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/5ee030af-870d-430a-ac7c-2a7dc47d7bce",
+      "betrokkeneType": "natuurlijk_persoon", "roltype": "http://localhost:8003/catalogi/api/v1/roltypen/bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8",
+      "roltoelichting": "inzender formulier", "indicatieMachtiging": "", "betrokkeneIdentificatie":
+      {"inpBsn": "123456782"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '346'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8003/zaken/api/v1/rollen
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/zaken/api/v1/rollen/414e3fbc-ee91-4b16-8087-5ac701129509","uuid":"414e3fbc-ee91-4b16-8087-5ac701129509","zaak":"http://localhost:8003/zaken/api/v1/zaken/5ee030af-870d-430a-ac7c-2a7dc47d7bce","betrokkene":"","betrokkeneType":"natuurlijk_persoon","afwijkendeNaamBetrokkene":"","roltype":"http://localhost:8003/catalogi/api/v1/roltypen/bd37e337-e0fd-4e11-a6ed-45a71e1c7aa8","omschrijving":"Initiator","omschrijvingGeneriek":"initiator","roltoelichting":"inzender
+        formulier","registratiedatum":"2026-07-06T14:54:04.525044Z","indicatieMachtiging":"","contactpersoonRol":{"emailadres":"","functie":"","telefoonnummer":"","naam":""},"statussen":[],"betrokkeneIdentificatie":{"inpBsn":"123456782","anpIdentificatie":"","inpA_nummer":"","geslachtsnaam":"","voorvoegselGeslachtsnaam":"","voorletters":"","voornamen":"","geslachtsaanduiding":"","geboortedatum":"","verblijfsadres":null,"subVerblijfBuitenland":null}}'
+    headers:
+      API-version:
+      - 1.5.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '935'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/zaken/api/v1/rollen/414e3fbc-ee91-4b16-8087-5ac701129509
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/catalogi/api/v1/statustypen?zaaktype=http%3A%2F%2Flocalhost%3A8003%2Fcatalogi%2Fapi%2Fv1%2Fzaaktypen%2Ff609b6fe-449a-46dc-a0af-de55dc5f6774
+  response:
+    body:
+      string: '{"count":2,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/catalogi/api/v1/statustypen/2937ee1d-9ea1-4048-b642-5a4dfd51fb47","omschrijving":"Ontvangen","omschrijvingGeneriek":"","statustekst":"","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","zaaktypeIdentificatie":"ZT-001","volgnummer":1,"isEindstatus":false,"informeren":false,"doorlooptijd":null,"toelichting":null,"checklistitemStatustype":[],"catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","eigenschappen":[],"zaakobjecttypen":[],"beginGeldigheid":null,"eindeGeldigheid":null,"beginObject":null,"eindeObject":null},{"url":"http://localhost:8003/catalogi/api/v1/statustypen/018ec0c2-50d0-4225-a5bb-5ad7c48d6f2b","omschrijving":"Afgerond","omschrijvingGeneriek":"","statustekst":"","zaaktype":"http://localhost:8003/catalogi/api/v1/zaaktypen/f609b6fe-449a-46dc-a0af-de55dc5f6774","zaaktypeIdentificatie":"ZT-001","volgnummer":2,"isEindstatus":true,"informeren":false,"doorlooptijd":null,"toelichting":null,"checklistitemStatustype":[],"catalogus":"http://localhost:8003/catalogi/api/v1/catalogussen/bd58635c-793e-446d-a7e0-460d7b04829d","eigenschappen":[],"zaakobjecttypen":[],"beginGeldigheid":null,"eindeGeldigheid":null,"beginObject":null,"eindeObject":null}]}'
+    headers:
+      API-version:
+      - 1.3.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '1343'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/5ee030af-870d-430a-ac7c-2a7dc47d7bce",
+      "statustype": "http://localhost:8003/catalogi/api/v1/statustypen/2937ee1d-9ea1-4048-b642-5a4dfd51fb47",
+      "datumStatusGezet": "2026-07-06T14:54:04.573193+00:00", "statustoelichting":
+      ""}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '274'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8003/zaken/api/v1/statussen
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/zaken/api/v1/statussen/f1efa185-7e07-4743-ba27-0922832acfdc","uuid":"f1efa185-7e07-4743-ba27-0922832acfdc","zaak":"http://localhost:8003/zaken/api/v1/zaken/5ee030af-870d-430a-ac7c-2a7dc47d7bce","statustype":"http://localhost:8003/catalogi/api/v1/statustypen/2937ee1d-9ea1-4048-b642-5a4dfd51fb47","datumStatusGezet":"2026-07-06T14:54:04.573193Z","statustoelichting":"","indicatieLaatstGezetteStatus":true,"gezetdoor":null,"zaakinformatieobjecten":[]}'
+    headers:
+      API-version:
+      - 1.5.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '479'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/zaken/api/v1/statussen/f1efa185-7e07-4743-ba27-0922832acfdc
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/5ee030af-870d-430a-ac7c-2a7dc47d7bce",
+      "objectType": "overige", "objectTypeOverige": "building in construction", "objectIdentificatie":
+      {"overige_data": "Building: Maple Avenue 3B"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '233'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8003/zaken/api/v1/zaakobjecten
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/zaken/api/v1/zaakobjecten/937cd8f9-f22d-4088-83fa-f7c58c6988e0","uuid":"937cd8f9-f22d-4088-83fa-f7c58c6988e0","zaak":"http://localhost:8003/zaken/api/v1/zaken/5ee030af-870d-430a-ac7c-2a7dc47d7bce","object":"","zaakobjecttype":null,"objectType":"overige","objectTypeOverige":"building
+        in construction","objectTypeOverigeDefinitie":null,"relatieomschrijving":"","objectIdentificatie":{"overigeData":"Building:
+        Maple Avenue 3B"}}'
+    headers:
+      API-version:
+      - 1.5.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '456'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/zaken/api/v1/zaakobjecten/937cd8f9-f22d-4088-83fa-f7c58c6988e0
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: '{"zaak": "http://localhost:8003/zaken/api/v1/zaken/5ee030af-870d-430a-ac7c-2a7dc47d7bce",
+      "objectType": "overige", "objectTypeOverige": "parking in construction", "objectIdentificatie":
+      {"overige_data": "Parking: de Pijp 4199"}}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '228'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.33.0
+    method: POST
+    uri: http://localhost:8003/zaken/api/v1/zaakobjecten
+  response:
+    body:
+      string: '{"url":"http://localhost:8003/zaken/api/v1/zaakobjecten/ec446169-0ac4-43e9-9d51-1a44a87c076d","uuid":"ec446169-0ac4-43e9-9d51-1a44a87c076d","zaak":"http://localhost:8003/zaken/api/v1/zaken/5ee030af-870d-430a-ac7c-2a7dc47d7bce","object":"","zaakobjecttype":null,"objectType":"overige","objectTypeOverige":"parking
+        in construction","objectTypeOverigeDefinitie":null,"relatieomschrijving":"","objectIdentificatie":{"overigeData":"Parking:
+        de Pijp 4199"}}'
+    headers:
+      API-version:
+      - 1.5.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '451'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Location:
+      - http://localhost:8003/zaken/api/v1/zaakobjecten/ec446169-0ac4-43e9-9d51-1a44a87c076d
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 201
+      message: Created
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.33.0
+    method: GET
+    uri: http://localhost:8003/zaken/api/v1/zaakobjecten
+  response:
+    body:
+      string: '{"count":2,"next":null,"previous":null,"results":[{"url":"http://localhost:8003/zaken/api/v1/zaakobjecten/ec446169-0ac4-43e9-9d51-1a44a87c076d","uuid":"ec446169-0ac4-43e9-9d51-1a44a87c076d","zaak":"http://localhost:8003/zaken/api/v1/zaken/5ee030af-870d-430a-ac7c-2a7dc47d7bce","object":"","zaakobjecttype":null,"objectType":"overige","objectTypeOverige":"parking
+        in construction","objectTypeOverigeDefinitie":null,"relatieomschrijving":"","objectIdentificatie":{"overigeData":"Parking:
+        de Pijp 4199"}},{"url":"http://localhost:8003/zaken/api/v1/zaakobjecten/937cd8f9-f22d-4088-83fa-f7c58c6988e0","uuid":"937cd8f9-f22d-4088-83fa-f7c58c6988e0","zaak":"http://localhost:8003/zaken/api/v1/zaken/5ee030af-870d-430a-ac7c-2a7dc47d7bce","object":"","zaakobjecttype":null,"objectType":"overige","objectTypeOverige":"building
+        in construction","objectTypeOverigeDefinitie":null,"relatieomschrijving":"","objectIdentificatie":{"overigeData":"Building:
+        Maple Avenue 3B"}}]}'
+    headers:
+      API-version:
+      - 1.5.1
+      Allow:
+      - GET, POST, HEAD, OPTIONS
+      Content-Length:
+      - '960'
+      Content-Type:
+      - application/json
+      Cross-Origin-Opener-Policy:
+      - same-origin
+      Referrer-Policy:
+      - same-origin
+      Vary:
+      - Accept, origin
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - DENY
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/src/openforms/registrations/contrib/zgw_apis/typing.py
+++ b/src/openforms/registrations/contrib/zgw_apis/typing.py
@@ -31,6 +31,21 @@ class FileComponentOptions(TypedDict, total=False):
     title: str
 
 
+class ObjectOverige(TypedDict):
+    # in the ZGW API `overige_data` is of "Any" format, but we treat it as
+    # a string, since we display it as a TextArea in the UI
+    overige_data: str
+
+
+CaseObjectType = Literal["overige"]
+
+
+class CaseObject(TypedDict):
+    case_object_type: CaseObjectType
+    case_object_type_overige: str
+    case_object_identification: ObjectOverige
+
+
 class RegistrationOptions(TypedDict):
     zgw_api_group: ZGWApiGroupConfig
     catalogue: CatalogueOption
@@ -68,3 +83,4 @@ class RegistrationOptions(TypedDict):
     admin enforcing key uniqueness for *all* components in the form, which is stricter
     than vanilla Formio.
     """
+    case_objects: NotRequired[list[CaseObject]]


### PR DESCRIPTION
Closes #6343

**Changes**
* [x] Add a new tab "Case objects" in the configuration options for ZGW API 
* [x] Make some options `required`, which are necessary for requests to Open Zaak
* [x] Create configured case objects during registration step
* [x] FE tests
* [x] BE tests
* [x] update FE translations
* [x] Document new configuration options 

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
