### PR TITLE
Fix tinymce table markup rendering (explanation template, introduction page)

### DIFF
--- a/src/csp_post_processor/processor.py
+++ b/src/csp_post_processor/processor.py
@@ -48,6 +48,8 @@ wysiwyg_allowed_tags = [
     "table",
     "thead",
     "tbody",
+    "colgroup",
+    "col",
     "tr",
     "th",
     "td",
@@ -70,6 +72,10 @@ _tags_with_style = [
     "h4",
     "h5",
     "h6",
+    "table",
+    "col",
+    "td",
+    "th",
 ]
 _style_attrs = [
     "id",
@@ -95,6 +101,8 @@ wysiwyg_css_properties += [
     "padding-left",
     # TinyMCE uses list-style-type for list styling
     "list-style-type",
+    # Table styling in TinyMCE
+    "border-style",
 ]
 
 wysiwyg_svg_properties = list(css_sanitizer.ALLOWED_SVG_PROPERTIES)

--- a/src/openforms/forms/tests/test_api_forms.py
+++ b/src/openforms/forms/tests/test_api_forms.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Permission
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.urls import reverse
 from django.utils import translation
 from django.utils.translation import gettext as _
@@ -1411,6 +1411,58 @@ class FormsAPITests(APITestCase):
 
         self.assertEqual(data["backend"], "digid")
         self.assertEqual(data["options"], {"loa": DigiDAssuranceLevels.middle})
+
+    @patch("csp_post_processor.processor.get_html_id")
+    @tag("gh-5730", "gh-6113")
+    def test_table_markup_in_explanation_template_not_mangled(self, mock_get_html_id):
+        self.maxDiff = None
+        mock_get_html_id.side_effect = ("1", "2", "3", "4")
+        form = FormFactory.create(
+            # HTML input taken from database after adding a table with TinyMCE
+            explanation_template="""
+                <table style="border-collapse: collapse; width: 100%;" border="1">
+                    <colgroup>
+                        <col style="width: 25%;">
+                        <col style="width: 75%;">
+                    </colgroup>
+                    <tbody>
+                        <tr>
+                            <td>Tab</td>
+                            <td style="border-style: none;">El</td>
+                        </tr>
+                    </tbody>
+                </table>
+            """,
+            generate_minimal_setup=True,
+        )
+        url = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
+
+        response = self.client.get(url, headers={"X-CSP-Nonce": "dGVzdA=="})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertHTMLEqual(
+            response.json()["explanationTemplate"],
+            """
+            <style nonce="dGVzdA==">
+                #nonce-5fa62ae6176f3746142503a6ebe96cb3-1 { border-collapse: collapse;width: 100%; }
+                #nonce-5fa62ae6176f3746142503a6ebe96cb3-2 { width: 25%; }
+                #nonce-5fa62ae6176f3746142503a6ebe96cb3-3 { width: 75%; }
+                #nonce-5fa62ae6176f3746142503a6ebe96cb3-4 { border-style: none; }
+            </style>
+            <table id="nonce-5fa62ae6176f3746142503a6ebe96cb3-1">
+                <colgroup>
+                    <col id="nonce-5fa62ae6176f3746142503a6ebe96cb3-2">
+                    <col id="nonce-5fa62ae6176f3746142503a6ebe96cb3-3">
+                </colgroup>
+                <tbody>
+                    <tr>
+                        <td>Tab</td>
+                        <td id="nonce-5fa62ae6176f3746142503a6ebe96cb3-4">El</td>
+                    </tr>
+                </tbody>
+            </table>
+            """,
+        )
 
 
 class FormsAPITranslationTests(APITestCase):


### PR DESCRIPTION
Closes #6113
Closes #5730

**Changes**

* Allow table elements in the bleach HTML-processing
* Allow table-related styling properties

Styling is now taken into account for columns as well (width in particular):

<img width="780" height="366" alt="image" src="https://github.com/user-attachments/assets/513ea4ad-ae06-4648-8512-ade8a3d85bc5" />


[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
