### PR TITLE
Fix table styles (introduction page, explanation template) on main

### DIFF
--- a/src/csp_post_processor/processor.py
+++ b/src/csp_post_processor/processor.py
@@ -46,6 +46,8 @@ WYSIWYG_ALLOWED_TAGS: set[str] = {
     "table",
     "thead",
     "tbody",
+    "colgroup",
+    "col",
     "tr",
     "th",
     "td",
@@ -68,6 +70,10 @@ _TAGS_WITH_STYLE = [
     "h4",
     "h5",
     "h6",
+    "table",
+    "col",
+    "td",
+    "th",
 ]
 _STYLE_ATTRS: set[str] = {
     "id",
@@ -141,6 +147,8 @@ WYSIWYG_CSS_PROPERTIES: set[str] = {
     "list-style-type",
     # TinyMCE uses padding-left for indent
     "padding-left",
+    # Table styling in TinyMCE
+    "border-style",
 }
 WYSIWYG_SVG_PROPERTIES: set[str] = {
     "fill",

--- a/src/openforms/forms/tests/test_api_forms.py
+++ b/src/openforms/forms/tests/test_api_forms.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 from django.conf import settings
 from django.contrib.auth.models import AnonymousUser, Permission
-from django.test import override_settings
+from django.test import override_settings, tag
 from django.urls import reverse
 from django.utils import translation
 from django.utils.translation import gettext as _
@@ -1463,6 +1463,58 @@ class FormsAPITests(APITestCase):
         self.assertEqual(
             errors["reason"],
             _("Appointment forms require an appointment plugin to be configured."),
+        )
+
+    @patch("csp_post_processor.processor.get_html_id")
+    @tag("gh-5730", "gh-6113")
+    def test_table_markup_in_explanation_template_not_mangled(self, mock_get_html_id):
+        self.maxDiff = None
+        mock_get_html_id.side_effect = ("1", "2", "3", "4")
+        form = FormFactory.create(
+            # HTML input taken from database after adding a table with TinyMCE
+            explanation_template="""
+                <table style="border-collapse: collapse; width: 100%;" border="1">
+                    <colgroup>
+                        <col style="width: 25%;">
+                        <col style="width: 75%;">
+                    </colgroup>
+                    <tbody>
+                        <tr>
+                            <td>Tab</td>
+                            <td style="border-style: none;">El</td>
+                        </tr>
+                    </tbody>
+                </table>
+            """,
+            generate_minimal_setup=True,
+        )
+        url = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
+
+        response = self.client.get(url, headers={"X-CSP-Nonce": "dGVzdA=="})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertHTMLEqual(
+            response.json()["explanationTemplate"],
+            """
+            <style nonce="dGVzdA==">
+                #nonce-5fa62ae6176f3746142503a6ebe96cb3-1 { border-collapse: collapse;width: 100%; }
+                #nonce-5fa62ae6176f3746142503a6ebe96cb3-2 { width: 25%; }
+                #nonce-5fa62ae6176f3746142503a6ebe96cb3-3 { width: 75%; }
+                #nonce-5fa62ae6176f3746142503a6ebe96cb3-4 { border-style: none; }
+            </style>
+            <table id="nonce-5fa62ae6176f3746142503a6ebe96cb3-1">
+                <colgroup>
+                    <col id="nonce-5fa62ae6176f3746142503a6ebe96cb3-2">
+                    <col id="nonce-5fa62ae6176f3746142503a6ebe96cb3-3">
+                </colgroup>
+                <tbody>
+                    <tr>
+                        <td>Tab</td>
+                        <td id="nonce-5fa62ae6176f3746142503a6ebe96cb3-4">El</td>
+                    </tr>
+                </tbody>
+            </table>
+            """,
         )
 
 


### PR DESCRIPTION
The bugfix for #6113 / #5730 mostly applies to 3.4.x, but the investigation there revealed that the styling for tables is broken on newer versions too (3.5.x, main). The same fixes are applied to fix the styling on those versions as well.

Closes #6113
Closes #5730

#6433 is the PR to 3.4.x

[skip: e2e]

**Changes**

* Allow table elements in the bleach HTML-processing
* Allow table-related styling properties

Styling is now taken into account for columns as well (width in particular):

<img width="780" height="366" alt="image" src="https://github.com/user-attachments/assets/513ea4ad-ae06-4648-8512-ade8a3d85bc5" />

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
