### PR TITLE
Fix dmn logic with unsaved form variables

### DIFF
--- a/bin/report_logic_with_deprecated_clear_on_hide_behavior.py
+++ b/bin/report_logic_with_deprecated_clear_on_hide_behavior.py
@@ -14,6 +14,8 @@ from json_logic.meta.expressions import destructure
 from json_logic.typing import JSON
 from tabulate import tabulate
 
+from openforms.forms.constants import LogicActionTypes
+
 SRC_DIR = Path(__file__).parent.parent / "src"
 sys.path.insert(0, str(SRC_DIR.resolve()))
 
@@ -214,28 +216,53 @@ def report_rules() -> bool:
             }
             # Steps on which the rule will be executed
             executing_steps = rule.steps
-            if not (input_steps and executing_steps):
+            if input_steps and executing_steps:
                 # Input steps and/or executing steps can be empty if we are only dealing
                 # with user-defined variables. We don't have to do anything in that
                 # case.
-                continue
 
-            # If the earliest executing step is before the last step of the input
-            # variables, the input value(s) will not be available yet -> risk of
-            # difference in behavior.
-            if (
-                min(executing_steps, key=lambda step: step.order).order
-                < max(input_steps, key=lambda step: step.order).order
-            ):
-                data.append(
-                    (
-                        form.admin_name,
-                        form.pk,
-                        rule.order,
-                        "-",
-                        "variables from future steps",
+                # If the earliest executing step is before the last step of the input
+                # variables, the input value(s) will not be available yet -> risk of
+                # difference in behavior.
+                if (
+                    min(executing_steps, key=lambda step: step.order).order
+                    < max(input_steps, key=lambda step: step.order).order
+                ):
+                    data.append(
+                        (
+                            form.admin_name,
+                            form.pk,
+                            rule.order,
+                            "-",
+                            "variables from future steps",
+                        )
                     )
-                )
+
+            ###################################
+            ### VARIABLES USED AS DMN INPUT ###
+            ###################################
+            for action in rule.actions:
+                if action["action"]["type"] != LogicActionTypes.evaluate_dmn:
+                    continue
+                # raw config lookup so that we can also run this on older versions of
+                # open forms
+                input_variable_keys = {
+                    mapping["form_variable"]
+                    for mapping in action["action"]["config"]["input_mapping"]
+                }
+                if (
+                    variable_names := components_with_affected_visibility
+                    & input_variable_keys
+                ):
+                    data.append(
+                        (
+                            form.admin_name,
+                            form.pk,
+                            rule.order,
+                            ", ".join(variable_names),
+                            "used in DMN input but may be missing",
+                        )
+                    )
 
     if data:
         click.echo(

--- a/docs/installation/upgrade-400.rst
+++ b/docs/installation/upgrade-400.rst
@@ -313,6 +313,15 @@ differently. This script is still available in 4.0, and can be executed with usi
     # in the container via ``docker exec`` or ``kubectl exec``:
     python /app/bin/report_logic_with_deprecated_clear_on_hide_behavior.py
 
+DMN evaluation logic actions
+----------------------------
+
+Logic rules with actions that evaluate DMN tables behave differently if the trigger does
+not test for the presence of the input parameters. The respective evaluation will be
+skipped entirely until all the input parameters are available.
+
+Before 4.0, these would be evaluated with their implicit empty value.
+
 Removal of legacy ZGW URLs support in registration plugins
 ==========================================================
 

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -707,6 +707,15 @@ class EvaluateDMNAction(ActionOperation):
         *,
         data_for_visible_state: FormioData,
     ) -> DataMapping | None:
+        # evaluation may be triggered/requested when not all input variables are
+        # available yet, in particular when a submission is being started. Normal
+        # (step-level) evaluation should not run into these situations, unless something
+        # is broken with the logic dependency graph building.
+        # If not all inputs are available yet, we abort early without doing anything,
+        # rather than guessing some kind of magic fallback value.
+        if any(item["form_variable"] not in context for item in self.input_mapping):
+            return None
+
         # Mapping from form variables to DMN inputs
         dmn_inputs = {
             item["dmn_variable"]: context[item["form_variable"]]

--- a/src/openforms/submissions/tests/test_start_submission.py
+++ b/src/openforms/submissions/tests/test_start_submission.py
@@ -21,11 +21,14 @@ from rest_framework.reverse import reverse, reverse_lazy
 from rest_framework.test import APITestCase
 
 from openforms.authentication.service import FORM_AUTH_SESSION_KEY, AuthAttribute
+from openforms.forms.constants import LogicActionTypes
 from openforms.forms.tests.factories import (
     FormFactory,
+    FormLogicFactory,
     FormStepFactory,
     FormVariableFactory,
 )
+from openforms.variables.constants import FormVariableDataTypes
 
 from ..constants import SUBMISSIONS_SESSION_KEY, SubmissionValueVariableSources
 from ..models import Submission, SubmissionValueVariable
@@ -272,3 +275,88 @@ class SubmissionStartTests(APITestCase):
 
         response = self.client.post(self.endpoint, body)
         self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+
+    @tag("gh-6275")
+    def test_start_submission_with_dmn_action_using_future_inputs(self):
+        """
+        Assert that DMN logic does not crash starting a submission.
+
+        Test taken from PR#6407 where the regression was observed.
+
+        At the time of response serialization, logic is being evaluated for the form,
+        which caused crashes in the DMN evaluation because it tries to read variable
+        values for variables of the first step, which of course don't exist yet at
+        this stage.
+        """
+        # no VCR here because we don't expect any calls to be made :-)
+        endpoint = reverse_lazy("api:submission-list")
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            is_single_step_form=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "invoiceAmount",
+                        "label": "Invoice Amount",
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "textField",
+                        "label": "Textfield",
+                    },
+                ]
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="test",
+            user_defined=True,
+            data_type=FormVariableDataTypes.string,
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "component": "",
+                    "action": {
+                        "type": LogicActionTypes.evaluate_dmn,
+                        "config": {
+                            "plugin_id": "camunda7",
+                            "decision_definition_id": "invoiceClassification",
+                            "decision_definition_version": "2",
+                            "input_mapping": [
+                                {
+                                    "form_variable": "invoiceAmount",
+                                    "dmn_variable": "amount",
+                                },
+                                {
+                                    "form_variable": "textField",
+                                    "dmn_variable": "invoiceCategory",
+                                },
+                            ],
+                            "output_mapping": [
+                                {
+                                    "form_variable": "test",
+                                    "dmn_variable": "invoiceClassification",
+                                }
+                            ],
+                        },
+                    },
+                }
+            ],
+        )
+        form.apply_logic_analysis()
+        form_url = reverse("api:form-detail", kwargs={"uuid_or_slug": form.uuid})
+        submission_body = {
+            "form": f"http://testserver.com{form_url}",
+            "formUrl": "http://testserver.com/my-form",
+            "anonymous": True,
+        }
+
+        response = self.client.post(
+            endpoint, submission_body, headers={"Host": "testserver.com"}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)

--- a/src/openforms/upgrades/tests/test_upgrade_paths.py
+++ b/src/openforms/upgrades/tests/test_upgrade_paths.py
@@ -2,6 +2,7 @@ from django.test import SimpleTestCase, TestCase
 
 from unittest_parametrize import ParametrizedTestCase, parametrize
 
+from openforms.forms.constants import LogicActionTypes
 from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
@@ -245,6 +246,76 @@ class ReportLogicWithDeprecatedClearOnHideBehaviorTests(ParametrizedTestCase, Te
             self.assertTrue(self.script.execute())
             self.assertIn(
                 "No logic rules with a risk of behaving differently in Open Forms 4.0",
+                stdout.getvalue(),
+            )
+
+    def test_with_dmn_action_referring_to_clear_on_hide_variables(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            is_single_step_form=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "number",
+                        "key": "invoiceAmount",
+                        "label": "Invoice Amount",
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "textField",
+                        "label": "Textfield",
+                    },
+                ]
+            },
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "action": {
+                        "type": "property",
+                        "property": {"value": "hidden", "type": "bool"},
+                        "state": True,
+                    },
+                    "component": "textField",
+                }
+            ],
+        )
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "component": "",
+                    "action": {
+                        "type": LogicActionTypes.evaluate_dmn,
+                        "config": {
+                            "plugin_id": "camunda7",
+                            "decision_definition_id": "invoiceClassification",
+                            "decision_definition_version": "2",
+                            "input_mapping": [
+                                {
+                                    "form_variable": "invoiceAmount",
+                                    "dmn_variable": "amount",
+                                },
+                                {
+                                    "form_variable": "textField",
+                                    "dmn_variable": "invoiceCategory",
+                                },
+                            ],
+                            "output_mapping": [],
+                        },
+                    },
+                }
+            ],
+        )
+
+        with capture_output() as stdout:
+            self.assertFalse(self.script.execute())
+            self.assertIn(
+                "Found logic rules with a risk of behaving differently in Open Forms "
+                "4.0",
                 stdout.getvalue(),
             )
 


### PR DESCRIPTION
Regression following #6275
Unblocks #6407 

**Changes**

* Fix crash when DMN logic uses not-yet-existing form variables as input
* Update docs & detection script to report logic rules that use possibly hidden form variables as input

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
