### PR TITLE
Fix broken conditional test inside edit grids

### DIFF
--- a/src/openforms/appointments/api/serializers.py
+++ b/src/openforms/appointments/api/serializers.py
@@ -336,6 +336,7 @@ class AppointmentSerializer(serializers.HyperlinkedModelSerializer):
             context={
                 **self.context,
                 "submission": attrs["submission"],
+                "configuration": {"components": contact_details_meta},
             },
         )
         if not contact_details_serializer.is_valid():

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -1108,11 +1108,13 @@ class EditGridField(serializers.Field):
         ]
 
     def _build_child(self, **kwargs):
+        assert "context" not in kwargs
         return build_serializer(
             components=self.components,
             # XXX: check out type annotations here, there's some co/contra variance
             # in play
             register=self.registry,
+            context=self.context,
             **kwargs,
         )
 

--- a/src/openforms/formio/serializers.py
+++ b/src/openforms/formio/serializers.py
@@ -50,7 +50,11 @@ class StepDataSerializer(serializers.Serializer):
         if not hasattr(self, "initial_data"):
             return
 
-        config_wrapper = FormioConfigurationWrapper(configuration)
+        assert self.context
+        assert "configuration_wrapper" in self.context
+        config_wrapper: FormioConfigurationWrapper = self.context[
+            "configuration_wrapper"
+        ]
 
         values = FormioData(self.initial_data)
 
@@ -61,8 +65,6 @@ class StepDataSerializer(serializers.Serializer):
             if not register.holds_submission_data(component):
                 continue
 
-            # XXX: is_hidden does not understand editgrid at all yet, which
-            # is a broader issue, but also manifests here.
             is_hidden = config_wrapper.is_hidden(component["key"], values)
 
             # we don't have to do anything when the component is visible, regular
@@ -150,6 +152,12 @@ def build_serializer(
     This recursively builds up the serializer fields for each (nested) component and
     puts them into a serializer instance ready for validation.
     """
+    if context := kwargs.get("context"):
+        assert isinstance(context, dict) and "configuration" in context
+        context.setdefault(
+            "configuration_wrapper",
+            FormioConfigurationWrapper(context["configuration"]),
+        )
     fields: dict[str, FieldOrNestedFields] = {}
 
     config: FormioConfiguration = {"components": components}

--- a/src/openforms/formio/tests/test_validation.py
+++ b/src/openforms/formio/tests/test_validation.py
@@ -10,7 +10,10 @@ from ..typing import Component, RadioComponent, TextFieldComponent
 
 
 def validate_formio_data(components: list[Component], data: JSONValue) -> None:
-    context = {"submission": SubmissionFactory.build()}
+    context = {
+        "submission": SubmissionFactory.build(),
+        "configuration": {"components": components},
+    }
     serializer = build_serializer(components=components, data=data, context=context)
     serializer.is_valid(raise_exception=True)
 

--- a/src/openforms/formio/tests/validation/helpers.py
+++ b/src/openforms/formio/tests/validation/helpers.py
@@ -19,7 +19,10 @@ def validate_formio_data(
     """
     Dynamically build the serializer, validate it and return the status.
     """
-    context = {"submission": submission or SubmissionFactory.build()}
+    context = {
+        "submission": submission or SubmissionFactory.build(),
+        "configuration": {"components": [component]},
+    }
     serializer = build_serializer(components=[component], data=data, context=context)
     is_valid = serializer.is_valid(raise_exception=False)
     return is_valid, serializer.errors

--- a/src/openforms/formio/tests/validation/test_editgrid.py
+++ b/src/openforms/formio/tests/validation/test_editgrid.py
@@ -156,7 +156,10 @@ class EditGridValidationTests(SimpleTestCase):
         data: JSONObject = {
             "toplevel": [{"nested": "i am valid"}],
         }
-        context = {"submission": SubmissionFactory.build()}
+        context = {
+            "submission": SubmissionFactory.build(),
+            "configuration": {"components": [component]},
+        }
 
         serializer = build_serializer(
             components=[component], data=data, context=context
@@ -307,7 +310,10 @@ class EditGridValidationTests(SimpleTestCase):
                 {"naamWerkgever": "ABC", "nettoLoon": 5, "periodeNettoLoon": "maand"}
             ],
         }
-        context = {"submission": SubmissionFactory.build()}
+        context = {
+            "submission": SubmissionFactory.build(),
+            "configuration": {"components": components},
+        }
         serializer = build_serializer(components=components, data=data, context=context)
 
         is_valid = serializer.is_valid()
@@ -468,18 +474,35 @@ class EditGridFieldTests(SimpleTestCase):
     """
 
     def test_invalid_type_provided(self):
+        editgrid_components = [
+            {"type": "textfield", "key": "textfield", "label": "Text field"}
+        ]
+
         class Serializer(serializers.Serializer):
             editgrid = EditGridField(
                 registry=register,
-                components=[
-                    {"type": "textfield", "key": "textfield", "label": "Text field"}
-                ],
+                components=editgrid_components,
             )
 
         invalid_values = (False, {}, 123, "foo")
         for value in invalid_values:
             with self.subTest(invalid_value=value):
-                serializer = Serializer(data={"editgrid": value})
+                serializer = Serializer(
+                    data={"editgrid": value},
+                    context={
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "editgrid",
+                                    "key": "editgrid",
+                                    "label": "editgrid",
+                                    "groupLabel": "Item",
+                                    "components": editgrid_components,
+                                }
+                            ]
+                        }
+                    },
+                )
 
                 is_valid = serializer.is_valid()
 
@@ -488,16 +511,33 @@ class EditGridFieldTests(SimpleTestCase):
                 self.assertEqual(error.code, "not_a_list")
 
     def test_empty_disallowed(self):
+        editgrid_components = [
+            {"type": "textfield", "key": "textfield", "label": "Text field"}
+        ]
+
         class Serializer(serializers.Serializer):
             editgrid = EditGridField(
                 registry=register,
-                components=[
-                    {"type": "textfield", "key": "textfield", "label": "Text field"}
-                ],
+                components=editgrid_components,
                 allow_empty=False,
             )
 
-        serializer = Serializer(data={"editgrid": []})
+        serializer = Serializer(
+            data={"editgrid": []},
+            context={
+                "configuration": {
+                    "components": [
+                        {
+                            "type": "editgrid",
+                            "key": "editgrid",
+                            "label": "editgrid",
+                            "groupLabel": "Item",
+                            "components": editgrid_components,
+                        }
+                    ]
+                }
+            },
+        )
 
         is_valid = serializer.is_valid()
 
@@ -506,17 +546,34 @@ class EditGridFieldTests(SimpleTestCase):
         self.assertEqual(error.code, "empty")
 
     def test_min_length(self):
+        editgrid_components = [
+            {"type": "textfield", "key": "textfield", "label": "Text field"}
+        ]
+
         class Serializer(serializers.Serializer):
             editgrid = EditGridField(
                 registry=register,
-                components=[
-                    {"type": "textfield", "key": "textfield", "label": "Text field"}
-                ],
+                components=editgrid_components,
                 allow_empty=False,
                 min_length=3,
             )
 
-        serializer = Serializer(data={"editgrid": [{"textfield": "foo"}]})
+        serializer = Serializer(
+            data={"editgrid": [{"textfield": "foo"}]},
+            context={
+                "configuration": {
+                    "components": [
+                        {
+                            "type": "editgrid",
+                            "key": "editgrid",
+                            "label": "editgrid",
+                            "groupLabel": "Item",
+                            "components": editgrid_components,
+                        }
+                    ]
+                }
+            },
+        )
 
         is_valid = serializer.is_valid()
 
@@ -525,17 +582,34 @@ class EditGridFieldTests(SimpleTestCase):
         self.assertEqual(error.code, "min_length")
 
     def test_max_length(self):
+        editgrid_components = [
+            {"type": "textfield", "key": "textfield", "label": "Text field"}
+        ]
+
         class Serializer(serializers.Serializer):
             editgrid = EditGridField(
                 registry=register,
-                components=[
-                    {"type": "textfield", "key": "textfield", "label": "Text field"}
-                ],
+                components=editgrid_components,
                 allow_empty=False,
                 max_length=3,
             )
 
-        serializer = Serializer(data={"editgrid": [{"textfield": "foo"}] * 4})
+        serializer = Serializer(
+            data={"editgrid": [{"textfield": "foo"}] * 4},
+            context={
+                "configuration": {
+                    "components": [
+                        {
+                            "type": "editgrid",
+                            "key": "editgrid",
+                            "label": "editgrid",
+                            "groupLabel": "Item",
+                            "components": editgrid_components,
+                        }
+                    ]
+                }
+            },
+        )
 
         is_valid = serializer.is_valid()
 
@@ -544,15 +618,32 @@ class EditGridFieldTests(SimpleTestCase):
         self.assertEqual(error.code, "max_length")
 
     def test_to_representation(self):
+        editgrid_components = [{"type": "textfield", "key": "bar", "label": "Bar"}]
+
         class Serializer(serializers.Serializer):
             editgrid = EditGridField(
                 registry=register,
-                components=[{"type": "textfield", "key": "bar", "label": "Bar"}],
+                components=editgrid_components,
             )
 
         Foo = namedtuple("Foo", "bar")
         foos = [Foo(bar="first"), Foo(bar="second")]
-        serializer = Serializer(instance={"editgrid": foos})
+        serializer = Serializer(
+            instance={"editgrid": foos},
+            context={
+                "configuration": {
+                    "components": [
+                        {
+                            "type": "editgrid",
+                            "key": "editgrid",
+                            "label": "editgrid",
+                            "groupLabel": "Item",
+                            "components": editgrid_components,
+                        }
+                    ]
+                }
+            },
+        )
 
         data = serializer.data
 

--- a/src/openforms/formio/tests/validation/test_editgrid.py
+++ b/src/openforms/formio/tests/validation/test_editgrid.py
@@ -418,6 +418,49 @@ class EditGridValidationTests(SimpleTestCase):
 
             self.assertTrue(is_valid)
 
+    @tag("gh-6447")
+    def test_conditional_resolves_to_component_specific_test(self):
+        component: EditGridComponent = {
+            "type": "editgrid",
+            "key": "editgrid",
+            "label": "Edit grid with nested conditional",
+            "groupLabel": "item",
+            "components": [
+                # uses selectboxes because the value comparison is special and requires
+                # the registry to work
+                {
+                    "type": "selectboxes",
+                    "key": "selectboxes",
+                    "label": "Selectboxes 1",
+                    "values": [  # type: ignore
+                        {"value": "a", "label": "A"},
+                        {"value": "b", "label": "B"},
+                    ],
+                },
+                {
+                    "type": "textfield",
+                    "key": "textfield2",
+                    "label": "text field 2",
+                    "validate": {"required": True},
+                    "conditional": {  # type: ignore
+                        "eq": "a",
+                        "show": True,
+                        "when": "editgrid.selectboxes",
+                    },
+                },
+            ],
+        }
+
+        invalid_data: JSONValue = {
+            "editgrid": [{"selectboxes": {"a": True, "b": False}}]
+        }
+
+        is_valid, errors = validate_formio_data(component, invalid_data)
+
+        self.assertFalse(is_valid)
+        error = extract_error(errors["editgrid"][0], "textfield2")
+        self.assertEqual(error.code, "required")
+
 
 class EditGridFieldTests(SimpleTestCase):
     """

--- a/src/openforms/submissions/api/serializers.py
+++ b/src/openforms/submissions/api/serializers.py
@@ -498,7 +498,10 @@ class SubmissionStepSerializer(NestedHyperlinkedModelSerializer):
         step_data_serializer = build_serializer(
             configuration["components"],
             data=data,
-            context={"submission": submission},
+            context={
+                "submission": submission,
+                "configuration": configuration,
+            },
         )
         step_data_serializer.is_valid(raise_exception=True)
 

--- a/src/openforms/submissions/api/validation.py
+++ b/src/openforms/submissions/api/validation.py
@@ -132,7 +132,10 @@ class SubmissionCompletionSerializer(serializers.Serializer):
                 step_data_serializer = build_serializer(
                     configuration["components"],
                     data=data.data,
-                    context={"submission": submission},
+                    context={
+                        "submission": submission,
+                        "configuration": configuration,
+                    },
                 )
                 if not step_data_serializer.is_valid():
                     step_errors["data"] = (  # pyright: ignore[reportArgumentType]


### PR DESCRIPTION
Closes #6447

**Changes**

The root cause is that the component reference 'editgrid.selectboxes' is not found in the formio configuration wrapper, because a local configuration wrapper is used that's missing the context of being in an editgrid.

The visibility code then falls back to an 'unknown' component, which works for the simple direct comparison cases, but falls apart for selectboxes and file components (and any component that needs a custom 'test_conditional' implementation).

- [x] Added regression test
- [x] Implemented fix

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
