### PR TITLE
:ambulance: Disable OAS lint job due to ongoing supply chain attack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,21 +417,21 @@ jobs:
           # ensure local image gets used
           TAG: ${{ needs.setup.outputs.version }}
 
-  oas:
-    name: OAS
-    uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
-    with:
-      python-version: '3.12'
-      apt-packages: 'libxml2 libxmlsec1 libxmlsec1-openssl gdal-bin'
-      django-settings-module: openforms.conf.ci
-      oas-generate-command: ./bin/generate_oas.sh
-      schema-path: src/openapi.yaml
-      oas-artifact-name: open-forms-oas
-      node-version-file: '.nvmrc'
-      spectral-version: '^6.15.0'
-      openapi-to-postman-version: '^5.0.0'
-      postman-artifact-name: open-forms-postman-collection
-      openapi-generator-version: '^2.20.0'
+  # oas:
+  #   name: OAS
+  #   uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
+  #   with:
+  #     python-version: '3.12'
+  #     apt-packages: 'libxml2 libxmlsec1 libxmlsec1-openssl gdal-bin'
+  #     django-settings-module: openforms.conf.ci
+  #     oas-generate-command: ./bin/generate_oas.sh
+  #     schema-path: src/openapi.yaml
+  #     oas-artifact-name: open-forms-oas
+  #     node-version-file: '.nvmrc'
+  #     spectral-version: '^6.15.0'
+  #     openapi-to-postman-version: '^5.0.0'
+  #     postman-artifact-name: open-forms-postman-collection
+  #     openapi-generator-version: '^2.20.0'
 
   docker_push:
     needs:
@@ -440,7 +440,7 @@ jobs:
       - e2etests
       - setup
       - docker_build
-      - oas
+      # - oas
 
     name: Push Docker image
     runs-on: ubuntu-latest


### PR DESCRIPTION
OAS lint uses spectral under the hood, which has a loose version range in its rulesets dependency that depends on @asyncapi/specs, which itself uses @asyncapi/spec-json-schemas that has been compromised on July 14th.

Details in https://github.com/asyncapi/spec-json-schemas/issues/656 and https://github.com/stoplightio/spectral/issues/2999. This has been verified by multiple independent security researchers.

Impact on Open Forms:

* nobody has run the tool locally, so there's no secrets exfiltration
* our CI jobs run with minimal permissions thanks to our earlier zizmor-related efforts
* the job does not have any secrets injected (most interesting would be the docker hub tokens), so they could not have been exfiltrated. Out of an abundance of caution, we're rotating them anyway.

[skip: e2e]