### PR TITLE
Fix type error when session data contains `None`

### DIFF
--- a/src/openforms/submissions/utils.py
+++ b/src/openforms/submissions/utils.py
@@ -128,7 +128,7 @@ def _session_lock(session: SessionBase, key: str):
 
 def append_to_session_list(session: SessionBase, session_key: str, value: Any) -> None:
     with _session_lock(session, session_key):
-        active = session.get(session_key, [])
+        active = session.get(session_key) or []
         if value not in active:
             active.append(value)
             session[session_key] = active
@@ -138,7 +138,7 @@ def remove_from_session_list(
     session: SessionBase, session_key: str, value: Any
 ) -> None:
     with _session_lock(session, session_key):
-        active = session.get(session_key, [])
+        active = session.get(session_key) or []
         if value in active:
             active.remove(value)
             session[session_key] = active


### PR DESCRIPTION
Looks like there's a possibility that the session data actually contains null/None rather than not exist at all for a given key, which causes runtime `TypeError` when trying to modify the session key.

Seen via Sentry error monitoring, easy fix with a different default fallback mechanism.

[skip: e2e]