### PR TITLE
Fix options with templates of select/radio/selectboxes components not requiring backend logic evaluation

### DIFF
--- a/src/openforms/formio/variables.py
+++ b/src/openforms/formio/variables.py
@@ -139,22 +139,15 @@ def extract_variables_from_template_properties(component: Component) -> set[str]
     Extract all variables used in the template expressions of the relevant properties.
 
     Relevant properties: label, groupLabel, legend, defaultValue, description, html,
-    placeholder, and tooltip.
+    placeholder, tooltip, data (select), values (radio and selectboxes).
 
     :param component: Component to extract variables from.
     :return: Set of variable names, empty if no variables were extracted.
     """
     variables: set[str] = set()
     for _property_name, property_value in iter_template_properties(component):
-        match property_value:
-            case str():
-                variables.update(extract_variables_used(property_value))
-            case [str(), *_]:
-                # Value could be a list of expressions because of
-                # `multiple: True`.
-                for v in property_value:
-                    variables.update(extract_variables_used(v))
-            case _:
-                pass
+        recursively_apply_function(
+            property_value, lambda v: variables.update(extract_variables_used(v))
+        )
 
     return variables

--- a/src/openforms/forms/tests/test_models.py
+++ b/src/openforms/forms/tests/test_models.py
@@ -665,6 +665,52 @@ class FormStepBackendLogicEvaluationRequiredTests(SimpleTestCase):
         )
         self.assertTrue(step.is_backend_logic_evaluation_required)
 
+    def test_template_expression_in_select_component_options(self):
+        step = FormStepFactory.build(
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "select",
+                        "key": "select",
+                        "label": "Select",
+                        "openForms": {"dataSrc": "manual"},
+                        "data": {
+                            "values": [
+                                {
+                                    "value": "a",
+                                    "label": "{% if someVar == 'foo' %}A{% else %}Not A{% endif %}",
+                                },
+                                {"value": "b", "label": "B"},
+                            ]
+                        },
+                    }
+                ]
+            }
+        )
+        self.assertTrue(step.is_backend_logic_evaluation_required)
+
+    def test_template_expression_in_radio_component_options(self):
+        step = FormStepFactory.build(
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "radio",
+                        "key": "radio",
+                        "label": "Radio",
+                        "openForms": {"dataSrc": "manual"},
+                        "values": [
+                            {
+                                "value": "a",
+                                "label": "{% if someVar == 'foo' %}A{% else %}Not A{% endif %}",
+                            },
+                            {"value": "b", "label": "B"},
+                        ],
+                    }
+                ]
+            }
+        )
+        self.assertTrue(step.is_backend_logic_evaluation_required)
+
 
 class FormLogicTests(TestCase):
     def test_input_and_output_variable_keys(self):


### PR DESCRIPTION
Closes #6459

[skip: e2e]

**Changes**

Recurse into component properties for template variable extraction

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
