### PR TITLE
Set a default for max celery worker tasks per child

### DIFF
--- a/bin/celery_worker.sh
+++ b/bin/celery_worker.sh
@@ -10,6 +10,7 @@ WORKER_NAME=${CELERY_WORKER_NAME:="${QUEUE}"@%n}
 
 # Set defaults for OTEL
 export OTEL_SERVICE_NAME="${OTEL_SERVICE_NAME:-openforms-worker-"${QUEUE}"}"
+export CELERY_WORKER_MAX_TASKS_PER_CHILD=${CELERY_WORKER_MAX_TASKS_PER_CHILD:-100}
 
 echo "Starting celery worker $WORKER_NAME with queue $QUEUE"
 # unset this if NOT using a process pool


### PR DESCRIPTION
In the event of memory leaks, a worker child will be respawned after processing this number of tasks, reducing the impact of memory leaks.

Keeping this an undocumented feature for now until we see some results from experimenting/tuning with some values.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
