### PR TITLE
[#6458] Fix date/today operator in partial logic evaluation

### DIFF
--- a/src/openforms/utils/json_logic/partial_evaluation.py
+++ b/src/openforms/utils/json_logic/partial_evaluation.py
@@ -128,7 +128,7 @@ def partially_evaluate_json_logic(
             # unchanged expression, which can be evaluated at the end.
             # Mismatch between the `JSON` type of `json_logic`, and our own
             # `JSONValue`
-            return expression, True  # pyright: ignore[reportReturnType]
+            return expression, False  # pyright: ignore[reportReturnType]
         case _:
             pass
 


### PR DESCRIPTION
Closes #6458 partly

**Changes**

- Do not mark the `today` operator as evaluated in partial logic evaluation.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
