### PR TITLE
Implementing form export options

### DIFF
--- a/docs/manual/forms/export_import.rst
+++ b/docs/manual/forms/export_import.rst
@@ -16,7 +16,7 @@ U kunt elk formulier eenvoudig exporteren door onderstaande stappen te volgen:
 1. Navigeer naar **Formulieren** > **Formulieren**.
 2. Klik op de titel van het gewenste formulier om het formulier te openen.
 3. Klik onderaan op de knop **Exporteren**
-4. Een ZIP-bestand, met de naam van het *URL-deel* van het formulier, wordt nu 
+4. Een ZIP-bestand, met de naam van het *URL-deel* van het formulier, wordt nu
    gedownload op uw computer.
 
 U hoeft het ZIP-bestand niet uit te pakken.
@@ -25,17 +25,32 @@ U hoeft het ZIP-bestand niet uit te pakken.
 
     **Technische achtergrond**
 
-    Formulieren worden geëxporteerd als een ZIP-bestand waarin meerdere 
-    JSON-bestanden zitten. Elk JSON-bestand bevat de configuratie van het 
+    Formulieren worden geëxporteerd als een ZIP-bestand waarin meerdere
+    JSON-bestanden zitten. Elk JSON-bestand bevat de configuratie van het
     formulier zelf of een stap binnen het formulier. De JSON-structuur komt
     1-op-1 overeen met de API-specificatie waardoor het export formaat tevens
     open en transparent is.
 
+Formulier exporteer opties
+--------------------------
+
+Bij het exporteren van een formulier heb je enkele opties over hoe het
+ZIP-bestand wordt gemaakt:
+
+* **Anonimiseer formulierinstellingen**: Indien aangevinkt, dan worden de
+  formulierinstellingen automatisch geanonimiseerd. Dit verwijderd alle
+  e-mailadressen die zijn configureerd in de E-mail registratie en de interne
+  opmerkingen op het formulier. Deze optie is standaard aangevinkt.
+* **Formulierinstellingen**: Hiermee kunnen registratie backends,
+  betaalprovider, prefill en inlogmethode eenvoudig bij het exporteren
+  weggelaten worden. Standaard worden alle instellingen mee geëxporteerd.
+* **Aanvullende formulierinstellingen**: Hiermee kunnen aanvullende
+  instellingen van het formulier aan het ZIP-bestand toegevoegd worden.
 
 Formulieren importeren
 ======================
 
-Formulieren die zijn geëxporteerd met Open Formulieren kunnen ook weer 
+Formulieren die zijn geëxporteerd met Open Formulieren kunnen ook weer
 geïmporteerd worden.
 
 1. Navigeer naar **Formulieren** > **Formulieren**.
@@ -44,25 +59,25 @@ geïmporteerd worden.
 4. Klik op **Importeren**
 
 Als het goed is, is het formulier inclusief alle stappen geïmporteerd. Het
-geïmporteerde formulier is standaard niet actief en dus niet direct voor de 
+geïmporteerde formulier is standaard niet actief en dus niet direct voor de
 buitenwereld toegankelijk.
 
 Bijzonderheden
 --------------
 
-Als een formulier wordt geïmporteerd en het bevat een stap waarvan het 
+Als een formulier wordt geïmporteerd en het bevat een stap waarvan het
 *URL-deel* overeenkomt met een bestaande stap, dan controleert het import proces
-of de te importeren stap **exact hetzelfde** is als de bestaande stap. Als dat 
+of de te importeren stap **exact hetzelfde** is als de bestaande stap. Als dat
 zo is, dan wordt de bestaande stap gebruikt voor het geïmporteerde formulier. Er
 wordt dan geen nieuwe stap aangemaakt.
 
 Als de stap **niet exact hetzelfde** is, dan wordt er een nieuwe stap aangemaakt
-en wordt het *URL-deel* van de stap gewijzigd. Bijvoorbeeld van 
-``persoonsgegevens`` naar ``persoonsgegevens-2``. U krijgt hier altijd een 
+en wordt het *URL-deel* van de stap gewijzigd. Bijvoorbeeld van
+``persoonsgegevens`` naar ``persoonsgegevens-2``. U krijgt hier altijd een
 melding van.
 
-Als het *URL-deel* van een te importeren formulier zelf al bestaat, dan kan het 
-formulier niet worden geïmporteerd. U kunt dan het *URL-deel* van het 
+Als het *URL-deel* van een te importeren formulier zelf al bestaat, dan kan het
+formulier niet worden geïmporteerd. U kunt dan het *URL-deel* van het
 conflicterende formulier zelf aanpassen en het nogmaals proberen.
 
 Export en import van :ref:`logica <manual_logic>` regels die gebruik maken van

--- a/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
+++ b/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
@@ -4,8 +4,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Open Forms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-23 13:00+0200\n"
-"PO-Revision-Date: 2026-07-22 14:23+0200\n"
+"POT-Creation-Date: 2026-08-02 13:12+0200\n"
+"PO-Revision-Date: 2026-08-02 13:17+0200\n"
 "Last-Translator:   <admin@admin.com>\n"
 "Language-Team: Dutch <support@maykinmedia.nl>\n"
 "Language: nl\n"
@@ -28,12 +28,13 @@ msgid ""
 "omit this header without losing functionality. We recommend favouring the "
 "nonce mechanism though."
 msgstr ""
-"De waarde van de CSP-nonce gegenereerd door de pagina die de SDK insluit/"
-"embed. Als deze meegestuurd wordt, dan worden velden met rich tekst (uit "
-"\"WYSIWYG\" editors) verwerkt om inline-styles toe te laten met de gegeven "
-"nonce. Indien de insluitende pagina een `style-src` policy heeft die `unsafe-"
-"inline` bevat, dan kan je deze header weglaten zonder functionaliteit te "
-"verliezen. We raden echter aan om het nonce-mechanisme te gebruiken."
+"De waarde van de CSP-nonce gegenereerd door de pagina die de SDK "
+"insluit/embed. Als deze meegestuurd wordt, dan worden velden met rich tekst "
+"(uit \"WYSIWYG\" editors) verwerkt om inline-styles toe te laten met de "
+"gegeven nonce. Indien de insluitende pagina een `style-src` policy heeft die"
+" `unsafe-inline` bevat, dan kan je deze header weglaten zonder "
+"functionaliteit te verliezen. We raden echter aan om het nonce-mechanisme te"
+" gebruiken."
 
 #: openforms/accounts/admin.py:38
 msgid "Groups"
@@ -86,7 +87,7 @@ msgstr "stafstatus"
 msgid "Designates whether the user can log into this admin site."
 msgstr "Bepaalt of de gebruiker zich op deze beheerwebsite kan aanmelden."
 
-#: openforms/accounts/models.py:55 openforms/forms/models/form.py:311
+#: openforms/accounts/models.py:55 openforms/forms/models/form.py:312
 msgid "active"
 msgstr "actief"
 
@@ -114,8 +115,8 @@ msgstr ""
 "De voorkeurstaal voor de (beheer) gebruikersinterface. Wanneer geen waarde "
 "ingesteld is, worden de browserinstellingen gebruikt."
 
-#: openforms/accounts/models.py:85 openforms/forms/models/form.py:841
-#: openforms/forms/models/form_version.py:64 soap/models.py:53
+#: openforms/accounts/models.py:85 openforms/forms/models/form.py:854
+#: openforms/forms/models/form_version.py:86 soap/models.py:53
 msgid "user"
 msgstr "gebruiker"
 
@@ -161,10 +162,8 @@ msgstr ""
 "verzoekenlogging in voor meer gedetailleerde informatie."
 
 #: openforms/analytics_tools/admin.py:15
-#, fuzzy
-#| msgid "General Email settings"
 msgid "General settings"
-msgstr "Algemene e-mailinstellingen"
+msgstr "Algemene instellingen"
 
 #: openforms/analytics_tools/admin.py:25
 msgid "Analytics: Google"
@@ -227,8 +226,8 @@ msgstr "Google Analytics code"
 msgid ""
 "Typically looks like 'UA-XXXXX-Y'. Supplying this installs Google Analytics."
 msgstr ""
-"Heeft typisch het formaat 'UA-XXXXX-Y'. Schakelt Google Analytics in als een "
-"waarde ingevuld is."
+"Heeft typisch het formaat 'UA-XXXXX-Y'. Schakelt Google Analytics in als een"
+" waarde ingevuld is."
 
 #: openforms/analytics_tools/models.py:145
 msgid "enable google analytics"
@@ -245,7 +244,8 @@ msgstr "Matomo server-URL"
 #: openforms/analytics_tools/models.py:156
 msgid "The base URL of your Matomo server, e.g. 'https://matomo.example.com'."
 msgstr ""
-"De basis-URL van uw Matomo server, bijvoorbeeld 'https://matomo.example.com'."
+"De basis-URL van uw Matomo server, bijvoorbeeld "
+"'https://matomo.example.com'."
 
 #: openforms/analytics_tools/models.py:160
 msgid "Matomo site ID"
@@ -306,8 +306,8 @@ msgstr "Piwik PRO site-ID"
 
 #: openforms/analytics_tools/models.py:206
 msgid ""
-"The 'idsite' of the website you're tracking in Piwik PRO. https://"
-"help.piwik.pro/support/questions/find-website-id/"
+"The 'idsite' of the website you're tracking in Piwik PRO. "
+"https://help.piwik.pro/support/questions/find-website-id/"
 msgstr ""
 "De 'idsite'-waarde van de website die je analyseert met Piwik PRO. Zie ook "
 "https://help.piwik.pro/support/questions/find-website-id/"
@@ -335,12 +335,12 @@ msgstr "SiteImprove ID"
 #: openforms/analytics_tools/models.py:226
 msgid ""
 "Your SiteImprove ID - you can find this from the embed snippet example, "
-"which should contain a URL like '//siteimproveanalytics.com/js/"
-"siteanalyze_XXXXX.js'. The XXXXX is your ID."
+"which should contain a URL like "
+"'//siteimproveanalytics.com/js/siteanalyze_XXXXX.js'. The XXXXX is your ID."
 msgstr ""
 "Uw SiteImprove ID - deze waarde kan je terugvinden in het embed-voorbeeld. "
-"Deze bevat normaal een URL zoals '//siteimproveanalytics.com/js/"
-"siteanalyze_XXXXX.js'. De XXXXX is uw ID."
+"Deze bevat normaal een URL zoals "
+"'//siteimproveanalytics.com/js/siteanalyze_XXXXX.js'. De XXXXX is uw ID."
 
 #: openforms/analytics_tools/models.py:232
 msgid "enable siteImprove analytics"
@@ -398,8 +398,8 @@ msgstr "GovMetric secure GUID (inzending voltooid)"
 
 #: openforms/analytics_tools/models.py:269
 msgid ""
-"Your GovMetric secure GUID for when a form is finished - This is an optional "
-"value. It is created by KLANTINFOCUS when a list  of questions is created. "
+"Your GovMetric secure GUID for when a form is finished - This is an optional"
+" value. It is created by KLANTINFOCUS when a list  of questions is created. "
 "It is a string that is unique per set of questions."
 msgstr ""
 "Het GovMetric secure GUID voor voltooide inzendingen. Deze waarde is niet "
@@ -428,8 +428,8 @@ msgid ""
 "The name of your organization as registered in Expoints. This is used to "
 "construct the URL to communicate with Expoints."
 msgstr ""
-"De naam/het label van de organisatie zoals deze bij Expoints bekend is. Deze "
-"waarde wordt gebruikt om de URL op te bouwen om met Expoints te verbinden."
+"De naam/het label van de organisatie zoals deze bij Expoints bekend is. Deze"
+" waarde wordt gebruikt om de URL op te bouwen om met Expoints te verbinden."
 
 #: openforms/analytics_tools/models.py:293
 msgid "Expoints configuration identifier"
@@ -440,8 +440,8 @@ msgid ""
 "The UUID used to retrieve the configuration from Expoints to initialize the "
 "client satisfaction survey."
 msgstr ""
-"Het UUID van de configuratie in Expoints om het tevredenheidsonderzoek op te "
-"halen."
+"Het UUID van de configuratie in Expoints om het tevredenheidsonderzoek op te"
+" halen."
 
 #: openforms/analytics_tools/models.py:301
 msgid "use Expoints test mode"
@@ -449,8 +449,8 @@ msgstr "gebruik Expoints testmode"
 
 #: openforms/analytics_tools/models.py:304
 msgid ""
-"Indicates whether or not the test mode should be enabled. If enabled, filled "
-"out surveys won't actually be sent, to avoid cluttering Expoints while "
+"Indicates whether or not the test mode should be enabled. If enabled, filled"
+" out surveys won't actually be sent, to avoid cluttering Expoints while "
 "testing."
 msgstr ""
 "Indien aangevinkt, dan wordt de testmode van Expoints ingeschakeld. "
@@ -495,8 +495,8 @@ msgstr ""
 #: openforms/analytics_tools/models.py:339
 msgid ""
 "Force the tag manager scripts to run, even if no cookie consent is given or "
-"individual tools are not enabled. You typically need this when you are using "
-"an external Consent Management Platform (CMP) through a tag manager. Be "
+"individual tools are not enabled. You typically need this when you are using"
+" an external Consent Management Platform (CMP) through a tag manager. Be "
 "careful when you enable this, as incorrect configuration may have privacy "
 "and/or legal implications."
 msgstr ""
@@ -525,8 +525,8 @@ msgstr ""
 
 #: openforms/analytics_tools/models.py:495
 msgid ""
-"If you enable GovMetric, you need to provide the source ID for all languages "
-"(the same one can be reused)."
+"If you enable GovMetric, you need to provide the source ID for all languages"
+" (the same one can be reused)."
 msgstr ""
 "Wanneer je GovMetric inschakelt, dan moet je een source ID ingegeven voor "
 "elke taaloptie. Je kan hetzelfde ID hergebruiken voor meerdere talen."
@@ -561,8 +561,8 @@ msgid ""
 "has passed, the session is expired and the user is 'logged out'. Note that "
 "every subsequent API call resets the expiry."
 msgstr ""
-"Aantal seconden waarna een sessie verloopt. Na het verlopen van de sessie is "
-"de gebruiker uitgelogd en kan zijn huidige inzending niet meer afmaken. "
+"Aantal seconden waarna een sessie verloopt. Na het verlopen van de sessie is"
+" de gebruiker uitgelogd en kan zijn huidige inzending niet meer afmaken. "
 "Opmerking: Bij elke interactie met de API wordt de sessie verlengd."
 
 #: openforms/api/drf_spectacular/hooks.py:29
@@ -574,8 +574,8 @@ msgid ""
 "If true, the user is allowed to navigate between submission steps even if "
 "previous submission steps have not been completed yet."
 msgstr ""
-"Indien waar, dan mag de gebruiker vrij binnen de formulierstappen navigeren, "
-"ook als de vorige stappen nog niet voltooid zijn."
+"Indien waar, dan mag de gebruiker vrij binnen de formulierstappen navigeren,"
+" ook als de vorige stappen nog niet voltooid zijn."
 
 #: openforms/api/drf_spectacular/hooks.py:45
 msgid "Language code of the currently activated language."
@@ -686,12 +686,12 @@ msgstr "Ping de API"
 
 #: openforms/api/views/views.py:60
 msgid ""
-"Pinging the API extends the user session. Note that you must be a staff user "
-"or have active submission(s) in your session."
+"Pinging the API extends the user session. Note that you must be a staff user"
+" or have active submission(s) in your session."
 msgstr ""
-"Door de API te pingen wordt de sessie van de gebruiker verlengd. Merk op dat "
-"je een actieve inzending in je sessie dient te hebben of ingelogd moet zijn "
-"in de beheerinterface."
+"Door de API te pingen wordt de sessie van de gebruiker verlengd. Merk op dat"
+" je een actieve inzending in je sessie dient te hebben of ingelogd moet zijn"
+" in de beheerinterface."
 
 #: openforms/appointments/admin.py:43
 msgid "Please configure the plugin first"
@@ -741,10 +741,10 @@ msgstr "Productcode"
 
 #: openforms/appointments/api/serializers.py:49
 #: openforms/appointments/api/serializers.py:84
+#: openforms/config/models/csp.py:76 openforms/config/models/map.py:18
 #: openforms/contrib/customer_interactions/models.py:19
 #: openforms/contrib/objects_api/models.py:21
 #: openforms/registrations/contrib/zgw_apis/models.py:29
-#: openforms/config/models/csp.py:76 openforms/config/models/map.py:18
 msgid "identifier"
 msgstr "Unieke identificatie"
 
@@ -754,17 +754,17 @@ msgstr "Unieke sleutel van het product"
 
 #: openforms/appointments/api/serializers.py:51
 #: openforms/appointments/api/serializers.py:86
+#: openforms/config/models/map.py:70 openforms/config/models/theme.py:21
 #: openforms/contrib/customer_interactions/models.py:14
 #: openforms/contrib/objects_api/models.py:16
-#: openforms/dmn/api/serializers.py:76 openforms/forms/admin/form.py:268
+#: openforms/dmn/api/serializers.py:76 openforms/forms/admin/form.py:271
 #: openforms/forms/admin/form_definition.py:69
-#: openforms/forms/models/category.py:13 openforms/forms/models/form.py:80
+#: openforms/forms/models/category.py:13 openforms/forms/models/form.py:81
 #: openforms/forms/models/form_definition.py:40
 #: openforms/forms/models/form_registration_backend.py:23
 #: openforms/forms/models/form_variable.py:265
 #: openforms/multidomain/models.py:7 openforms/products/models/product.py:24
 #: openforms/registrations/contrib/zgw_apis/models.py:24
-#: openforms/config/models/map.py:70 openforms/config/models/theme.py:21
 msgid "name"
 msgstr "naam"
 
@@ -791,11 +791,12 @@ msgstr "Limiet aantal afspraakaanvragen"
 
 #: openforms/appointments/api/serializers.py:63
 msgid ""
-"The maximum number of times a user can request this appointment. Defaults to "
-"0 (unlimited) if the plugin does not specify this."
+"The maximum number of times a user can request this appointment. Defaults to"
+" 0 (unlimited) if the plugin does not specify this."
 msgstr ""
 "Het maximale aantal keren dat een gebruiker deze afspraak kan aanvragen. De "
-"standaardwaarde 0 (onbeperkt) wordt gebruikt als de plugin dit niet aangeeft."
+"standaardwaarde 0 (onbeperkt) wordt gebruikt als de plugin dit niet "
+"aangeeft."
 
 #: openforms/appointments/api/serializers.py:75
 msgid ""
@@ -972,7 +973,8 @@ msgstr "Het geselecteerde tijdstip is niet (langer) beschikbaar."
 msgid "ID of the product, repeat for multiple products."
 msgstr "Product-ID, herhaal deze parameter voor meerdere producten."
 
-#: openforms/appointments/api/views.py:77 openforms/products/api/viewsets.py:12
+#: openforms/appointments/api/views.py:77
+#: openforms/products/api/viewsets.py:12
 msgid "List available products"
 msgstr "Producten weergeven"
 
@@ -1050,8 +1052,9 @@ msgid "Submission does not contain all the info needed to make an appointment"
 msgstr ""
 "Er ontbreken gegevens in de inzending om een afspraak te kunnen registreren."
 
-#: openforms/appointments/constants.py:11 openforms/submissions/constants.py:15
-#: openforms/submissions/constants.py:68 openforms/translations/constants.py:9
+#: openforms/appointments/constants.py:11
+#: openforms/submissions/constants.py:15 openforms/submissions/constants.py:68
+#: openforms/translations/constants.py:9
 msgid "Failed"
 msgstr "Mislukt"
 
@@ -1110,7 +1113,7 @@ msgid "Hidden"
 msgstr "Verborgen"
 
 #: openforms/appointments/contrib/jcc_rest/constants.py:16
-#: openforms/forms/constants.py:62
+#: openforms/forms/constants.py:60
 msgid "Required"
 msgstr "Verplicht"
 
@@ -1245,6 +1248,10 @@ msgstr "Ongeldige pluginconfiguratie: {exc}"
 
 #: openforms/appointments/contrib/jcc_rest/plugin.py:564
 #: openforms/appointments/contrib/qmatic/plugin.py:408
+#: openforms/config/templates/admin/config/overview.html:4
+#: openforms/config/templates/admin/config/overview.html:9
+#: openforms/config/templates/admin/config/overview.html:15
+#: openforms/config/views.py:49 openforms/config/views.py:65
 #: openforms/contrib/brk/checks.py:42
 #: openforms/contrib/kadaster/config_check.py:30
 #: openforms/contrib/kadaster/config_check.py:61
@@ -1259,10 +1266,6 @@ msgstr "Ongeldige pluginconfiguratie: {exc}"
 #: openforms/registrations/contrib/microsoft_graph/plugin.py:130
 #: openforms/registrations/contrib/stuf_zds/plugin.py:681
 #: openforms/submissions/api/serializers.py:313
-#: openforms/config/templates/admin/config/overview.html:4
-#: openforms/config/templates/admin/config/overview.html:9
-#: openforms/config/templates/admin/config/overview.html:15
-#: openforms/config/views.py:49 openforms/config/views.py:65
 msgid "Configuration"
 msgstr "Configuratie"
 
@@ -1395,7 +1398,7 @@ msgid "The submission that made the appointment"
 msgstr "De inzending bij deze afspraak"
 
 #: openforms/appointments/models.py:68
-#: openforms/forms/models/form_version.py:56
+#: openforms/forms/models/form_version.py:78
 msgid "created"
 msgstr "aangemaakt"
 
@@ -1546,7 +1549,8 @@ msgid "The authentication attribute provided by this plugin."
 msgstr "Het authenticatie attribuut geleverd door deze plugin."
 
 #: openforms/authentication/api/serializers.py:28
-#: openforms/forms/api/viewsets.py:637 openforms/payments/api/serializers.py:18
+#: openforms/forms/api/viewsets.py:660
+#: openforms/payments/api/serializers.py:18
 #: openforms/registrations/api/serializers.py:13
 msgid "JSON schema"
 msgstr "JSON-schema"
@@ -1597,7 +1601,8 @@ msgid "..."
 msgstr "..."
 
 #: openforms/authentication/api/serializers.py:60
-#: openforms/dmn/api/serializers.py:17 openforms/payments/api/serializers.py:25
+#: openforms/dmn/api/serializers.py:17
+#: openforms/payments/api/serializers.py:25
 msgid "Identifier"
 msgstr "Unieke identificatie"
 
@@ -1777,8 +1782,9 @@ msgstr "Claim pad"
 #: openforms/authentication/contrib/yivi_oidc/oidc_plugins/schemas.py:21
 #: openforms/authentication/contrib/yivi_oidc/oidc_plugins/schemas.py:53
 msgid ""
-"Path to the claim value holding the level of assurance. If left empty, it is "
-"assumed there is no LOA claim and the configured fallback value will be used."
+"Path to the claim value holding the level of assurance. If left empty, it is"
+" assumed there is no LOA claim and the configured fallback value will be "
+"used."
 msgstr ""
 "Naam van de claim die het betrouwbaardheidsniveau bevat. Als er geen waarde "
 "wordt opgegeven, wordt verondersteld dat er geen LOA-claim aanwezig is en "
@@ -1793,7 +1799,8 @@ msgstr "Standaardwaarden"
 #: openforms/authentication/contrib/digid_eherkenning_oidc/oidc_plugins/schemas.py:144
 #: openforms/authentication/contrib/yivi_oidc/oidc_plugins/schemas.py:33
 #: openforms/authentication/contrib/yivi_oidc/oidc_plugins/schemas.py:65
-msgid "Fallback level of assurance, in case no claim value could be extracted."
+msgid ""
+"Fallback level of assurance, in case no claim value could be extracted."
 msgstr ""
 "Standaardwaarde voor het betrouwbaarheidsniveau. Wordt gebruikt wanneer er "
 "geen claimwaarde kan worden verkregen."
@@ -1811,7 +1818,8 @@ msgstr "eIDAS identity instellingen."
 
 #: openforms/authentication/contrib/digid_eherkenning_oidc/oidc_plugins/schemas.py:60
 msgid ""
-"Path to the claim value holding the bsn identifier of the authenticated user."
+"Path to the claim value holding the bsn identifier of the authenticated "
+"user."
 msgstr "Naam van de claim die het BSN bevat van de geauthoriseerde gebruiker."
 
 #: openforms/authentication/contrib/digid_eherkenning_oidc/oidc_plugins/schemas.py:69
@@ -1831,8 +1839,8 @@ msgstr "voornaamclaim van de wettelijke vertegenwoordiger"
 
 #: openforms/authentication/contrib/digid_eherkenning_oidc/oidc_plugins/schemas.py:82
 msgid ""
-"Path to the claim value that holds the legal first name of the authenticated "
-"user."
+"Path to the claim value that holds the legal first name of the authenticated"
+" user."
 msgstr ""
 "Claim die de wettelijke achternaam van de geauthenticeerde gebruiker bevat"
 
@@ -1857,7 +1865,8 @@ msgid ""
 "Path to the claim value that holds the legal birthdate of the authenticated "
 "user."
 msgstr ""
-"Claim die de wettelijke geboortedatum van de geauthenticeerde gebruiker bevat"
+"Claim die de wettelijke geboortedatum van de geauthenticeerde gebruiker "
+"bevat"
 
 #: openforms/authentication/contrib/digid_eherkenning_oidc/oidc_plugins/schemas.py:120
 msgid "OIDC eIDAS company configuration options."
@@ -1920,8 +1929,10 @@ msgstr "geboortedatumclaim van de handelende persoon"
 
 #: openforms/authentication/contrib/digid_eherkenning_oidc/oidc_plugins/schemas.py:241
 msgid ""
-"Path to the claim value that holds the legal birthdate of the acting subject."
-msgstr "Claim die de wettelijke geboortedatum van de handelende persoon bevat."
+"Path to the claim value that holds the legal birthdate of the acting "
+"subject."
+msgstr ""
+"Claim die de wettelijke geboortedatum van de handelende persoon bevat."
 
 #: openforms/authentication/contrib/digid_eherkenning_oidc/oidc_plugins/schemas.py:250
 msgid "Mandate service id claim path"
@@ -1981,8 +1992,8 @@ msgstr "eIDAS"
 
 #: openforms/authentication/contrib/eherkenning/views.py:44
 msgid ""
-"Login failed due to no KvK number/Pseudo ID being returned by eHerkenning/"
-"eIDAS."
+"Login failed due to no KvK number/Pseudo ID being returned by "
+"eHerkenning/eIDAS."
 msgstr ""
 "Inloggen mislukt omdat er geen geldig KvK-nummer/Pseudo-ID terugkwam uit "
 "eHerkenning."
@@ -2087,18 +2098,19 @@ msgstr ""
 "formulierconfiguratie."
 
 #: openforms/authentication/contrib/yivi_oidc/models.py:20
+#: openforms/config/models/map.py:64 openforms/config/models/theme.py:26
 #: openforms/forms/api/serializers/logic/action_serializers.py:214
-#: openforms/forms/models/category.py:10 openforms/forms/models/form.py:79
-#: openforms/forms/models/form.py:828
+#: openforms/forms/models/category.py:10 openforms/forms/models/form.py:80
+#: openforms/forms/models/form.py:841
 #: openforms/forms/models/form_definition.py:39
 #: openforms/forms/models/form_step.py:27
-#: openforms/forms/models/form_version.py:44 openforms/forms/models/logic.py:22
-#: openforms/payments/models.py:99 openforms/products/models/product.py:19
+#: openforms/forms/models/form_version.py:66
+#: openforms/forms/models/logic.py:22 openforms/payments/models.py:99
+#: openforms/products/models/product.py:19
 #: openforms/submissions/models/submission.py:134
 #: openforms/submissions/models/submission_files.py:51
 #: openforms/submissions/models/submission_files.py:200
 #: openforms/submissions/models/submission_step.py:102
-#: openforms/config/models/map.py:64 openforms/config/models/theme.py:26
 msgid "UUID"
 msgstr "UUID"
 
@@ -2108,8 +2120,8 @@ msgstr "groepsbeschrijving"
 
 #: openforms/authentication/contrib/yivi_oidc/models.py:25
 msgid ""
-"A longer human-readable description for the group of attributes, used in the "
-"form configuration."
+"A longer human-readable description for the group of attributes, used in the"
+" form configuration."
 msgstr ""
 "Een beschrijving van de attributengroep die wordt gebruikt in de "
 "formulierconfiguratie."
@@ -2125,8 +2137,8 @@ msgstr "attributen"
 
 #: openforms/authentication/contrib/yivi_oidc/models.py:41
 msgid ""
-"List of attributes that will be requested from the user. The user can choose "
-"whether to grant access to all these attributes, or none. If you want "
+"List of attributes that will be requested from the user. The user can choose"
+" whether to grant access to all these attributes, or none. If you want "
 "individually optional attributes, you should define them as separate "
 "attribute groups."
 msgstr ""
@@ -2171,9 +2183,9 @@ msgid ""
 "claim are proprietary, so you can translate them into their standardized "
 "identifiers."
 msgstr ""
-"Claim-waardekoppeling voor betrouwbaarheidsniveaus. Dit is nuttig wanneer de "
-"waarden in de LOA-claim eigen of niet-standaard zijn, zodat ze kunnen worden "
-"omgezet naar gestandaardiseerde identificaties."
+"Claim-waardekoppeling voor betrouwbaarheidsniveaus. Dit is nuttig wanneer de"
+" waarden in de LOA-claim eigen of niet-standaard zijn, zodat ze kunnen "
+"worden omgezet naar gestandaardiseerde identificaties."
 
 #: openforms/authentication/contrib/yivi_oidc/oidc_plugins/schemas.py:51
 msgid "KvK loa claim path"
@@ -2274,9 +2286,9 @@ msgstr "Unieke identificatie van de authenticatieplugin"
 msgid "Name of the attribute returned by the authentication plugin."
 msgstr "Naam van het attribuut voorzien door de authenticatieplugin"
 
-#: openforms/authentication/models.py:49
-#: openforms/submissions/models/submission_value_variable.py:458
-#: openforms/validations/api/views.py:72 openforms/config/models/csp.py:70
+#: openforms/authentication/models.py:49 openforms/config/models/csp.py:70
+#: openforms/submissions/models/submission_value_variable.py:453
+#: openforms/validations/api/views.py:72
 msgid "value"
 msgstr "waarde"
 
@@ -2317,7 +2329,8 @@ msgstr "Betrouwbaarheidsniveau"
 
 #: openforms/authentication/models.py:167
 msgid ""
-"How certain is the identity provider that this identity belongs to this user."
+"How certain is the identity provider that this identity belongs to this "
+"user."
 msgstr ""
 "Indicatie van de mate van zekerheid over de identiteit van de gebruiker, "
 "afgegeven door de identity provider."
@@ -2414,8 +2427,8 @@ msgstr "Inzending registrator: {plugin}::{attr}"
 msgid "You must be logged in to start this form."
 msgstr "Je moet ingelogd zijn om dit formulier te starten."
 
-#: openforms/authentication/signals.py:93 openforms/authentication/views.py:202
-#: openforms/authentication/views.py:369
+#: openforms/authentication/signals.py:93
+#: openforms/authentication/views.py:202 openforms/authentication/views.py:369
 msgid "Demo plugins require an active admin session."
 msgstr "Om demo-plugins te gebruiken moet je als beheerder ingelogd zijn."
 
@@ -2489,7 +2502,8 @@ msgid "Authentication context data: branch number"
 msgstr "Authenticatiecontext: vestigingsnummer"
 
 #: openforms/authentication/static_variables/static_variables.py:375
-msgid "Authentication context data: authorizee, acting subject identifier type"
+msgid ""
+"Authentication context data: authorizee, acting subject identifier type"
 msgstr ""
 "Authenticatiecontext: gemachtigde, identificatiesoort van de handelende "
 "persoon"
@@ -2513,8 +2527,8 @@ msgid ""
 "When filling out a form for a client or company please enter additional "
 "information."
 msgstr ""
-"Wanneer je een formulier invult voor een klant (burger of bedrijf), geef dan "
-"extra informatie op."
+"Wanneer je een formulier invult voor een klant (burger of bedrijf), geef dan"
+" extra informatie op."
 
 #: openforms/authentication/templates/of_authentication/registrator_subject_info.html:35
 #: openforms/authentication/templates/of_authentication/registrator_subject_info.html:49
@@ -2529,8 +2543,7 @@ msgstr "Start het authenticatie proces"
 msgid ""
 "This endpoint is the internal redirect target to start external login flow.\n"
 "\n"
-"Note that this is NOT a JSON 'endpoint', but rather the browser should be "
-"redirected to this URL and will in turn receive another redirect.\n"
+"Note that this is NOT a JSON 'endpoint', but rather the browser should be redirected to this URL and will in turn receive another redirect.\n"
 "\n"
 "Various validations are performed:\n"
 "* the form must be live\n"
@@ -2539,11 +2552,9 @@ msgid ""
 "* the `next` parameter must be present\n"
 "* the `next` parameter must match the CORS policy"
 msgstr ""
-"Dit endpoint is het doel van de interne redirect om het externe login proces "
-"te starten.\n"
+"Dit endpoint is het doel van de interne redirect om het externe login proces te starten.\n"
 "\n"
-"Merk op dat dit GEEN typische JSON-endpoint betreft maar een endpoint "
-"waarnaar toe geredirect wordt en zelf ook een redirect teruggeeft.\n"
+"Merk op dat dit GEEN typische JSON-endpoint betreft maar een endpoint waarnaar toe geredirect wordt en zelf ook een redirect teruggeeft.\n"
 "\n"
 "Diverse validaties worden uitgevoerd:\n"
 "* het formulier is actief\n"
@@ -2558,8 +2569,8 @@ msgstr "URL-deel dat het formulier identificeert."
 
 #: openforms/authentication/views.py:114
 msgid ""
-"Identifier of the authentication plugin. Note that this is validated against "
-"the configured available plugins for this particular form."
+"Identifier of the authentication plugin. Note that this is validated against"
+" the configured available plugins for this particular form."
 msgstr ""
 "Unieke identificatie van de authenticatieplugin. Merk op dat deze waarde "
 "gevalideerd wordt met de beschikbare plugins voor dit formulier."
@@ -2585,8 +2596,8 @@ msgid ""
 "URL of the external authentication service where the end-user will be "
 "redirected to. The value is specific to the selected authentication plugin."
 msgstr ""
-"URL van de externe authenticatie service waar de gebruiker naar toe verwezen "
-"wordt. Deze waarde is specifiek voor de geselecteerde authenticatieplugin"
+"URL van de externe authenticatie service waar de gebruiker naar toe verwezen"
+" wordt. Deze waarde is specifiek voor de geselecteerde authenticatieplugin"
 
 #: openforms/authentication/views.py:155
 msgid "OK. A login page is rendered."
@@ -2607,8 +2618,8 @@ msgid ""
 "Method not allowed. The authentication plugin requires `POST` or `GET`, and "
 "the wrong method was used."
 msgstr ""
-"Methode niet toegestaan. De authenticatieplugin moet worden benaderd middels "
-"een `POST` of `GET`."
+"Methode niet toegestaan. De authenticatieplugin moet worden benaderd middels"
+" een `POST` of `GET`."
 
 #: openforms/authentication/views.py:270
 msgid "Return from external login flow"
@@ -2616,12 +2627,9 @@ msgstr "Aanroeppunt van het externe login proces"
 
 #: openforms/authentication/views.py:272
 msgid ""
-"Authentication plugins call this endpoint in the return step of the "
-"authentication flow. Depending on the plugin, either `GET` or `POST` is "
-"allowed as HTTP method.\n"
+"Authentication plugins call this endpoint in the return step of the authentication flow. Depending on the plugin, either `GET` or `POST` is allowed as HTTP method.\n"
 "\n"
-"Typically authentication plugins will redirect again to the URL where the "
-"SDK is embedded.\n"
+"Typically authentication plugins will redirect again to the URL where the SDK is embedded.\n"
 "\n"
 "Various validations are performed:\n"
 "* the form must be live\n"
@@ -2629,9 +2637,7 @@ msgid ""
 "* logging in is required on the form\n"
 "* the redirect target must match the CORS policy"
 msgstr ""
-"Authenticatieplugins roepen dit endpoint aan zodra het externe login proces "
-"is afgerond. Afhankelijk van de plugin, een `POST` of `GET` is toegestaan "
-"als HTTP-methode.\n"
+"Authenticatieplugins roepen dit endpoint aan zodra het externe login proces is afgerond. Afhankelijk van de plugin, een `POST` of `GET` is toegestaan als HTTP-methode.\n"
 "\n"
 "Authenticatieplugins zullen typisch een redirect uitvoeren naar de SDK.\n"
 "\n"
@@ -2653,6 +2659,1436 @@ msgstr "Toegestaande HTTP methoden voor deze plugin."
 #: openforms/authentication/views.py:459
 msgid "OK. Possibly a form with validation errors is rendered."
 msgstr "OK. Er kan een formulier met validatie fouten worden getoond."
+
+#: openforms/config/admin.py:29
+msgid "Email security configuration"
+msgstr "E-mail beveiligingsconfiguratie"
+
+#: openforms/config/admin.py:35 openforms/submissions/admin.py:80
+msgid "Submissions"
+msgstr "Inzendingen"
+
+#: openforms/config/admin.py:46
+msgid "Confirmation Email"
+msgstr "Bevestigingse-mail"
+
+#: openforms/config/admin.py:52
+msgid "Save Form Email"
+msgstr "Sjabloon \"pauzeer\"-email"
+
+#: openforms/config/admin.py:61
+msgid "Submissions with cosigning"
+msgstr "Formulieren met mede-ondertekenen"
+
+#: openforms/config/admin.py:70
+msgid "Co-sign emails"
+msgstr "Mede-ondertekenen e-mails"
+
+#: openforms/config/admin.py:80
+msgid "Email address verification emails"
+msgstr "E-mails voor e-mailadresbevestiging"
+
+#: openforms/config/admin.py:88
+msgid "General Email settings"
+msgstr "Algemene e-mailinstellingen"
+
+#: openforms/config/admin.py:90
+msgid "Button labels"
+msgstr "Knop labels"
+
+#: openforms/config/admin.py:104
+msgid "General form options"
+msgstr "Standaardformulieropties"
+
+#: openforms/config/admin.py:120
+msgid "Help callout page options"
+msgstr ""
+
+#: openforms/config/admin.py:124 openforms/config/admin.py:315
+msgid "Organization configuration"
+msgstr "Organisatie configuratie"
+
+#: openforms/config/admin.py:136
+msgid "Statement of truth"
+msgstr "Verklaring van waarheid"
+
+#: openforms/config/admin.py:145
+msgid "Privacy"
+msgstr "Privacy"
+
+#: openforms/config/admin.py:155
+msgid "Sessions"
+msgstr "Sessies"
+
+#: openforms/config/admin.py:164
+msgid "Data removal"
+msgstr "Gegevens schonen"
+
+#: openforms/config/admin.py:177
+msgid "Search engines"
+msgstr "Zoekmachines"
+
+#: openforms/config/admin.py:179
+msgid "Plugin configuration"
+msgstr "Pluginconfiguratie"
+
+#: openforms/config/admin.py:190 openforms/emails/constants.py:10
+#: openforms/submissions/admin.py:260
+#: openforms/submissions/rendering/constants.py:11
+msgid "Registration"
+msgstr "Registratie"
+
+#: openforms/config/admin.py:200
+msgid "Virus scan"
+msgstr "Virusscan"
+
+#: openforms/config/admin.py:211
+msgid "Payments"
+msgstr "Betalingen"
+
+#: openforms/config/admin.py:217
+msgid "Feature flags & fields for testing"
+msgstr "Feature flags, test- en ontwikkelinstellingen"
+
+#: openforms/config/admin.py:227
+msgid "feature flags"
+msgstr "feature flags"
+
+#: openforms/config/admin.py:232
+msgid "Manage"
+msgstr "Beheren"
+
+#: openforms/config/admin.py:303
+msgid "Content type"
+msgstr "inhoudstype"
+
+#: openforms/config/admin.py:318
+#: openforms/submissions/templates/report/submission_report.html:36
+msgid "Logo"
+msgstr "Logo"
+
+#: openforms/config/admin.py:320
+msgid "Appearance"
+msgstr "Weergave"
+
+#: openforms/config/admin.py:343
+#: openforms/config/templates/admin/config/theme/preview.html:33
+msgid "Preview"
+msgstr "Voorvertoning"
+
+#: openforms/config/admin.py:346
+msgid "Show preview"
+msgstr "Toon voorvertoning"
+
+#: openforms/config/api/constants.py:11
+msgid "Statement checkbox"
+msgstr "Verklaringselectievakje"
+
+#: openforms/config/api/constants.py:13
+msgid ""
+"A single Form.io checkbox component for the statements that a user may have "
+"to accept before submitting a form."
+msgstr ""
+"Eén enkel Form.io selectievakjecomponent voor de verklaring die een "
+"gebruiker mogelijks moet accepteren voor het formulier ingestuurd kan "
+"worden."
+
+#: openforms/config/api/constants.py:19
+msgid "Component type (checkbox)"
+msgstr "Componenttype (selectievakje)"
+
+#: openforms/config/api/constants.py:23
+msgid "Key of the statement field"
+msgstr "Sleutel van het verklaringsveld"
+
+#: openforms/config/api/constants.py:27
+msgid "Text of the statement"
+msgstr "Tekst van de verklaring"
+
+#: openforms/config/api/constants.py:34
+msgid "Whether accepting this statement is required or not."
+msgstr "Indicatie of de verklaring verplicht is."
+
+#: openforms/config/api/serializers.py:21
+msgid ""
+"Whether the user must agree to the privacy policy before submitting a form."
+msgstr ""
+"Of de gebruiker akkoord moet gaan met het privacybeleid voordat hij een "
+"formulier indient."
+
+#: openforms/config/api/serializers.py:26
+msgid ""
+"The formatted label to use next to the checkbox when asking the user to "
+"agree to the privacy policy."
+msgstr ""
+"Het opgemaakte label dat naast het selectievakje moet worden getoond wanneer"
+" de gebruiker wordt gevraagd akkoord te gaan met het privacybeleid."
+
+#: openforms/config/api/viewsets.py:11
+msgid "List available themes"
+msgstr "Lijst van beschikbare stijlen"
+
+#: openforms/config/api/viewsets.py:12
+msgid "Retrieve theme details"
+msgstr "Stijldetails weergeven"
+
+#: openforms/config/checks.py:57
+msgid "Address lookup plugins"
+msgstr "Adresopzoekplugins"
+
+#: openforms/config/checks.py:70
+msgid "Validator plugins"
+msgstr "Validatieplugins"
+
+#: openforms/config/checks.py:81
+msgid "Appointment plugins"
+msgstr "Afspraakplugins"
+
+#: openforms/config/checks.py:82
+msgid "Registration plugins"
+msgstr "Registratieplugins"
+
+#: openforms/config/checks.py:83
+#: openforms/emails/templates/emails/admin_digest.html:46
+msgid "Prefill plugins"
+msgstr "Prefillplugins"
+
+#: openforms/config/checks.py:84
+msgid "Payment plugins"
+msgstr "Betaalproviderplugins"
+
+#: openforms/config/checks.py:85
+msgid "DMN plugins"
+msgstr "DMN plugins"
+
+#: openforms/config/checks.py:131
+#, python-brace-format
+msgid "Internal error: {exception}"
+msgstr "Interne fout: {exception}"
+
+#: openforms/config/constants.py:63
+msgid "any filetype"
+msgstr "elk bestandstype"
+
+#: openforms/config/constants.py:65
+msgid ".png"
+msgstr ".png"
+
+#: openforms/config/constants.py:66
+msgid ".jpg"
+msgstr ".jpg"
+
+#: openforms/config/constants.py:67
+msgid ".pdf"
+msgstr ".pdf"
+
+#: openforms/config/constants.py:68
+msgid ".xls"
+msgstr ".xls"
+
+#: openforms/config/constants.py:71
+msgid ".xlsx"
+msgstr ".xlsx"
+
+#: openforms/config/constants.py:73
+msgid ".csv"
+msgstr ".csv"
+
+#: openforms/config/constants.py:75
+msgid ".doc"
+msgstr ".doc"
+
+#: openforms/config/constants.py:78
+msgid ".docx"
+msgstr ".docx"
+
+#: openforms/config/constants.py:82
+msgid "Open Office"
+msgstr "Open Office"
+
+#: openforms/config/constants.py:86
+msgid ".zip"
+msgstr ".zip"
+
+#: openforms/config/constants.py:88
+msgid ".rar"
+msgstr ".rar"
+
+#: openforms/config/constants.py:89
+msgid ".tar"
+msgstr ".tar"
+
+#: openforms/config/constants.py:90
+msgid ".msg"
+msgstr ".msg"
+
+#: openforms/config/constants.py:94
+msgid ".dwg"
+msgstr ".dwg"
+
+#: openforms/config/constants.py:99
+msgid "Haal Centraal"
+msgstr "Haal Centraal"
+
+#: openforms/config/constants.py:100
+msgid "StufBg"
+msgstr "StUF-BG"
+
+#: openforms/config/forms.py:69
+msgid "Form for preview"
+msgstr "Formulier voor voorvertoning"
+
+#: openforms/config/forms.py:71
+msgid "Pick a form to preview the theme with."
+msgstr "Kies een formulier om de stijl in voor te vertonen."
+
+#: openforms/config/models/color.py:10
+msgid "color"
+msgstr "kleur"
+
+#: openforms/config/models/color.py:12
+msgid "Color in RGB hex format (#RRGGBB)"
+msgstr "Kleur in RGB hex-formaat (#RRGGBB)"
+
+#: openforms/config/models/color.py:15 openforms/config/models/map.py:36
+#: openforms/contrib/microsoft/models.py:11
+#: openforms/contrib/zgw/api/serializers.py:23
+#: openforms/dmn/api/serializers.py:53 openforms/dmn/api/serializers.py:73
+#: soap/models.py:21
+msgid "label"
+msgstr "label"
+
+#: openforms/config/models/color.py:17
+msgid "Human readable label for reference"
+msgstr "Label ter referentie"
+
+#: openforms/config/models/color.py:21
+msgid "text editor color preset"
+msgstr "WYSIWYG-editor tekstkleur"
+
+#: openforms/config/models/color.py:22
+msgid "text editor color presets"
+msgstr "WYSIWYG-editor tekstkleuren"
+
+#: openforms/config/models/color.py:34
+msgid "Example"
+msgstr "Voorbeeld"
+
+#: openforms/config/models/config.py:52
+msgid "allowed email (sub)domain names"
+msgstr "toegestane e-mail(sub)domeinen"
+
+#: openforms/config/models/config.py:54
+msgid ""
+"Provide a list of allowed (sub)domains (without 'https://www').Hyperlinks in"
+" a (confirmation) email are removed, unless the (sub)domain is provided "
+"here."
+msgstr ""
+"Geef een lijst van toegelaten (sub)domeinen op (zonder 'https://www.'). "
+"Hyperlinks in (bevestigings)e-mails worden verwijderd, tenzij het "
+"(sub)domein hier opgegeven is."
+
+#: openforms/config/models/config.py:64
+msgid "submission confirmation title"
+msgstr "Paginatitel inzendingsbevestiging"
+
+#: openforms/config/models/config.py:67
+msgid ""
+"The content of the confirmation page title. You can (and should) include the"
+" 'public_reference' variable (using expression '{{ public_reference }}') so "
+"the users have a reference in case they need to contact the customer "
+"service."
+msgstr ""
+"De inhoud van de bevestigingspaginatitel. De 'public_reference' "
+"sjablooninstructie is beschikbaar (gebruik de expressie '{{ public_reference"
+" }}') en we adviseren om deze weer te geven zodat gebruikers een referentie "
+"hebben als ze de klantenservice moeten contacteren."
+
+#: openforms/config/models/config.py:72
+msgid "Confirmation: {{ public_reference }}"
+msgstr "Bevestiging: {{ public_reference }}"
+
+#: openforms/config/models/config.py:76 openforms/forms/models/form.py:171
+msgid "submission confirmation template"
+msgstr "Bevestigingspagina tekst"
+
+#: openforms/config/models/config.py:78
+msgid ""
+"The content of the submission confirmation page. It can contain variables "
+"that will be templated from the submitted form data."
+msgstr ""
+"De inhoud van bevestigingspagina kan variabelen bevatten die op basis van de"
+" ingediende formuliergegevens worden weergegeven. "
+
+#: openforms/config/models/config.py:81
+msgid "Thank you for submitting this form."
+msgstr "Wij hebben uw inzending ontvangen. "
+
+#: openforms/config/models/config.py:85
+msgid "submission report download link title"
+msgstr "titel downloadlink inzendings-PDF"
+
+#: openforms/config/models/config.py:87
+msgid "The title of the link to download the report of a submission."
+msgstr ""
+"Titel/tekst van de downloadlink om de inzending als PDF te downloaden."
+
+#: openforms/config/models/config.py:88
+msgid "Download PDF"
+msgstr "Download het document."
+
+#: openforms/config/models/config.py:91
+msgid "cosign submission confirmation title"
+msgstr "Titel mede-ondertekenenbevestigingspagina"
+
+#: openforms/config/models/config.py:94
+msgid ""
+"The content of the confirmation page title for submissions requiring "
+"cosigning."
+msgstr ""
+"De inhoud van de bevestigingspaginatitel wanneer de inzending mede-"
+"ondertekend moet worden."
+
+#: openforms/config/models/config.py:97
+msgid "Request not complete yet"
+msgstr "Aanvraag niet compleet"
+
+#: openforms/config/models/config.py:101
+msgid "cosign submission confirmation template"
+msgstr "Mede-ondertekenenbevestigingspagina tekst"
+
+#: openforms/config/models/config.py:103
+msgid ""
+"The content of the submission confirmation page for submissions requiring "
+"cosigning. The variables 'public_reference' and 'cosigner_email' are "
+"available (using expressions '{{ public_reference }}' and '{{ cosigner_email"
+" }}', respectively). We strongly advise you to include the "
+"'public_reference' in case users need to contact the customer service."
+msgstr ""
+"De inhoud van de bevestigingspagina wanneer de inzending mede-ondertekend "
+"moet worden. Je kan de variabelen 'public_reference' en 'cosigner_email' "
+"gebruiken (gebruik de expressies '{{ public_reference }}' en '{{ "
+"cosigner_email }}'). We raden sterk aan om de publieke referentie weer te "
+"geven zodat gebruikers hiernaar kunnen verwijzen als ze de klantenservice "
+"moeten contacteren."
+
+#: openforms/config/models/config.py:120 openforms/config/models/config.py:146
+#: openforms/config/models/config.py:204 openforms/emails/models.py:43
+#: openforms/registrations/contrib/email/models.py:54
+msgid "subject"
+msgstr "onderwerp"
+
+#: openforms/config/models/config.py:123
+msgid ""
+"Subject of the confirmation email message. Can be overridden on the form "
+"level"
+msgstr ""
+"Onderwerp van de bevestigingsmail. Bij het formulier kan een afwijkend "
+"onderwerp worden opgegeven."
+
+#: openforms/config/models/config.py:129 openforms/config/models/config.py:153
+#: openforms/config/models/config.py:211 openforms/emails/models.py:50
+#: openforms/submissions/models/submission_files.py:59
+#: openforms/submissions/models/submission_files.py:258
+#: openforms/submissions/models/submission_report.py:21
+msgid "content"
+msgstr "inhoud"
+
+#: openforms/config/models/config.py:131
+msgid ""
+"Content of the confirmation email message. Can be overridden on the form "
+"level"
+msgstr ""
+"Inhoud van de bevestigingsmail. Bij het formulier kan een afwijkende inhoud "
+"worden opgegeven."
+
+#: openforms/config/models/config.py:148
+msgid "Subject of the save form email message."
+msgstr "Onderwerp van de \"pauzeer\"-email"
+
+#: openforms/config/models/config.py:154
+msgid "Content of the save form email message."
+msgstr "Inhoud van de \"pauzeer\"-email"
+
+#: openforms/config/models/config.py:163
+msgid "co-sign request template"
+msgstr "mede-ondertekenenverzoeksjabloon"
+
+#: openforms/config/models/config.py:165
+msgid ""
+"Content of the co-sign request email. The available template variables are: "
+"'form_name', 'submission_date', 'form_url' and 'code'."
+msgstr ""
+"De inhoud van de e-mail voor het mede-ondertekenenverzoek. De beschikbare "
+"sjabloonvariabelen zijn: 'form_name', 'submission_date', 'form_url' en "
+"'code'."
+
+#: openforms/config/models/config.py:175 openforms/emails/models.py:68
+msgid "cosign subject"
+msgstr "onderwerp bevestigingsmail met mede-ondertekenen"
+
+#: openforms/config/models/config.py:178
+msgid ""
+"Subject of the confirmation email message when the form requires cosigning. "
+"Can be overridden on the form level."
+msgstr ""
+"Onderwerp van de bevestigingsmail voor formulieren met mede-ondertekenen. "
+"Bij het formulier kan een afwijkend onderwerp worden opgegeven."
+
+#: openforms/config/models/config.py:185 openforms/emails/models.py:75
+msgid "cosign content"
+msgstr "inhoud bevestigingsmail met mede-ondertekenen"
+
+#: openforms/config/models/config.py:187
+msgid ""
+"Content of the confirmation email message when the form requires cosigning. "
+"Can be overridden on the form level."
+msgstr ""
+"Inhoud van de bevestigingsmail voor formulieren met mede-ondertekenen. Bij "
+"het formulier kan een afwijkende inhoud worden opgegeven."
+
+#: openforms/config/models/config.py:206
+msgid "Subject of the email verification email."
+msgstr "Onderwerp van de \"e-mailverificatie\"-email."
+
+#: openforms/config/models/config.py:212
+msgid "Content of the email verification email message."
+msgstr "Inhoud van de \"e-mailverificatie\"-email."
+
+#: openforms/config/models/config.py:221
+msgid "allow empty initiator"
+msgstr "Lege initiator toestaan"
+
+#: openforms/config/models/config.py:224
+msgid ""
+"When enabled and the submitter is not authenticated, a case is created "
+"without any initiator. Otherwise, a fake initiator is added with BSN "
+"111222333."
+msgstr ""
+"Indien aangevinkt en de inzender is niet geauthenticeerd, dan wordt een zaak"
+" aangemaakt zonder initiator. Indien uitgevinkt, dan zal een nep-initiator "
+"worden toegevoegd met BSN 111222333."
+
+#: openforms/config/models/config.py:231
+msgid "back to form text"
+msgstr "\"terug naar formulier\"-tekst"
+
+#: openforms/config/models/config.py:233 openforms/config/models/config.py:270
+msgid "Previous page"
+msgstr "Vorige stap"
+
+#: openforms/config/models/config.py:235
+msgid ""
+"The text that will be displayed in the overview page to go to the previous "
+"step"
+msgstr ""
+"Het label van de knop op de overzichtspagina om naar de vorige stap te gaan."
+
+#: openforms/config/models/config.py:240 openforms/forms/models/form.py:272
+msgid "change text"
+msgstr "Stap wijzigen-label"
+
+#: openforms/config/models/config.py:242
+msgid "Change"
+msgstr "Wijzigen"
+
+#: openforms/config/models/config.py:244
+msgid ""
+"The text that will be displayed in the overview page to change a certain "
+"step"
+msgstr ""
+"Het label de link op de overzichtspagina om een bepaalde stap te wijzigen"
+
+#: openforms/config/models/config.py:249 openforms/forms/models/form.py:282
+msgid "confirm text"
+msgstr "Formulier verzenden-label"
+
+#: openforms/config/models/config.py:251
+#: openforms/forms/templates/admin/forms/form/migrate-payment-backend.html:69
+msgid "Confirm"
+msgstr "Verzenden"
+
+#: openforms/config/models/config.py:253
+msgid ""
+"The text that will be displayed in the overview page to confirm the form is "
+"filled in correctly"
+msgstr ""
+"Het label van de knop op de overzichtspagina om het formulier in te dienen"
+
+#: openforms/config/models/config.py:258 openforms/forms/models/form.py:252
+msgid "begin text"
+msgstr "Formulier starten-label"
+
+#: openforms/config/models/config.py:260
+msgid "Begin form"
+msgstr "Formulier starten"
+
+#: openforms/config/models/config.py:262
+msgid ""
+"The text that will be displayed at the start of the form to indicate the "
+"user can begin to fill in the form"
+msgstr "Het label van de knop om het formulier te starten."
+
+#: openforms/config/models/config.py:268
+msgid "previous step text"
+msgstr "\"vorige stap\"-tekst"
+
+#: openforms/config/models/config.py:272
+msgid ""
+"The text that will be displayed in the form step to go to the previous step"
+msgstr ""
+"Het label van de knop om naar de vorige stap binnen het formulier te gaan"
+
+#: openforms/config/models/config.py:276
+#: openforms/forms/models/form_step.py:51
+msgid "step save text"
+msgstr "Opslaan-label"
+
+#: openforms/config/models/config.py:278
+msgid "Save current information"
+msgstr "Tussentijds opslaan"
+
+#: openforms/config/models/config.py:280
+msgid ""
+"The text that will be displayed in the form step to save the current "
+"information"
+msgstr "Het label van de knop om het formulier tussentijds op te slaan"
+
+#: openforms/config/models/config.py:284
+#: openforms/forms/models/form_step.py:60
+msgid "step next text"
+msgstr "Volgende stap-label"
+
+#: openforms/config/models/config.py:286
+msgid "Next"
+msgstr "Volgende"
+
+#: openforms/config/models/config.py:288
+msgid ""
+"The text that will be displayed in the form step to go to the next step"
+msgstr ""
+"Het label van de knop om naar de volgende stap binnen het formulier te gaan"
+
+#: openforms/config/models/config.py:292
+msgid "Mark form fields 'required' by default"
+msgstr "Formulierenvelden zijn standaard 'verplicht'"
+
+#: openforms/config/models/config.py:295
+msgid ""
+"Whether the checkbox 'required' on form fields should be checked by default."
+msgstr ""
+"Configureer of formuliervelden standaard 'verplicht' moeten zijn bij het "
+"ontwerpen van een formulier."
+
+#: openforms/config/models/config.py:299
+msgid "Mark required fields with asterisks"
+msgstr "Markeer verplichte velden met een asterisk"
+
+#: openforms/config/models/config.py:302
+msgid ""
+"If checked, required fields are marked with an asterisk and optional fields "
+"are unmarked. If unchecked, optional fields will be marked with '(optional)'"
+" and required fields are unmarked."
+msgstr ""
+"Indien aangevinkt, dan zijn verplichte velden gemarkeerd met een asterisk en"
+" optionele velden niet gemarkeerd. Indien uitgevinkt, dan zijn optionele "
+"velden gemarkeerd met '(niet verplicht)' en verplichte velden ongemarkeerd."
+
+#: openforms/config/models/config.py:309
+msgid "Default allowed file upload types"
+msgstr "Standaard-toegestane upload-bestandstypen"
+
+#: openforms/config/models/config.py:311
+msgid ""
+"Provide a list of default allowed file upload types. If empty, all "
+"extensions are allowed."
+msgstr ""
+"Geef aan welke bestandstypen standaard toegestaan zijn. Indien deze waarde "
+"leeg is, dan zijn alle bestandstypen toegelaten."
+
+#: openforms/config/models/config.py:317
+msgid "Hide non-applicable form steps"
+msgstr "Verberg formulierstappen die niet van toepassing zijn"
+
+#: openforms/config/models/config.py:320
+msgid ""
+"If checked, form steps that become non-applicable as a result of user input "
+"are hidden from the progress indicator display (by default, they are "
+"displayed but marked as non-applicable.)"
+msgstr ""
+"Indien aangevinkt, dan worden stappen die (via logicaregels) niet van "
+"toepassing zijn verborgen. Standaard zijn deze zichtbaar maar gemarkeerd als"
+" n.v.t."
+
+#: openforms/config/models/config.py:326
+msgid "The default zoom level for the leaflet map."
+msgstr "Standaard zoomniveau voor kaartmateriaal."
+
+#: openforms/config/models/config.py:331
+msgid "The default latitude for the leaflet map."
+msgstr ""
+"Standaard latitude voor kaartmateriaal (in coördinatenstelsel EPSG:4326/WGS "
+"84)."
+
+#: openforms/config/models/config.py:339
+msgid "The default longitude for the leaflet map."
+msgstr ""
+"Standaard longitude voor kaartmateriaal (in coördinatenstelsel EPSG:4326/WGS"
+" 84)."
+
+#: openforms/config/models/config.py:352
+msgid "default theme"
+msgstr "Standaardstijl"
+
+#: openforms/config/models/config.py:354
+msgid ""
+"If no explicit theme is configured, the configured default theme will be "
+"used as a fallback."
+msgstr ""
+"Indien geen expliciete stijl ingesteld is, dan wordt de standaardstijl "
+"gebruikt."
+
+#: openforms/config/models/config.py:360 openforms/config/models/theme.py:51
+msgid "favicon"
+msgstr "favicon"
+
+#: openforms/config/models/config.py:364
+msgid ""
+"Allow the uploading of a favicon, .png .jpg .svg and .ico are compatible."
+msgstr ""
+"Upload het favicon voor de applicatie. Enkel .png, .jpg, .svg en .ico "
+"bestanden zijn toegestaan."
+
+#: openforms/config/models/config.py:368 openforms/config/models/theme.py:42
+msgid "main website link"
+msgstr "hoofdsite link"
+
+#: openforms/config/models/config.py:371
+msgid ""
+"URL to the main website. Used for the 'back to municipality website' link."
+msgstr ""
+"URL naar de hoofdsite van de organisatie. Wordt gebruikt voor 'terug naar de"
+" gemeentewebsite' link."
+
+#: openforms/config/models/config.py:375 openforms/config/models/theme.py:32
+msgid "organization name"
+msgstr "organisatienaam"
+
+#: openforms/config/models/config.py:379
+msgid ""
+"The name of your organization that will be used as label for elements like "
+"the logo."
+msgstr ""
+"De naam van de organisatie/gemeente - dit wordt gebruikt in label bij "
+"elementen zoals het logo en de link terug naar de website."
+
+#: openforms/config/models/config.py:386
+msgid "organization OIN"
+msgstr "organisatie-OIN"
+
+#: openforms/config/models/config.py:389
+msgid "The OIN of the organization."
+msgstr "Het (door Logius toegekende) organisatie-identificatienummer (OIN)."
+
+#: openforms/config/models/config.py:395
+msgid "admin session timeout"
+msgstr "beheersessie time-out"
+
+#: openforms/config/models/config.py:399
+msgid ""
+"Amount of time in minutes the admin can be inactive for before being logged "
+"out"
+msgstr "Tijd in minuten voordat de sessie van een beheerder verloopt."
+
+#: openforms/config/models/config.py:403
+msgid "form session timeout"
+msgstr "formuliersessie time-out"
+
+#: openforms/config/models/config.py:410
+#, python-format
+msgid ""
+"Due to DigiD requirements this value has to be less than or equal to "
+"%(limit_value)s minutes."
+msgstr ""
+"Om veiligheidsredenen mag de waarde niet groter zijn %(limit_value)s "
+"minuten."
+
+#: openforms/config/models/config.py:415
+msgid ""
+"Amount of time in minutes a user filling in a form can be inactive for "
+"before being logged out"
+msgstr "Tijd in minuten voordat de sessie van een gebruiker verloopt."
+
+#: openforms/config/models/config.py:421
+msgid "Payment Order ID template"
+msgstr "Betaling: bestellingsnummersjabloon"
+
+#: openforms/config/models/config.py:426
+#, python-brace-format
+msgid ""
+"Template to use when generating payment order IDs. It should be alpha-"
+"numerical and can contain the '/._-' characters. You can use the placeholder"
+" tokens: {year}, {public_reference}, {uid}."
+msgstr ""
+"Sjabloon voor de generatie van unieke betalingsreferenties. Het sjabloon "
+"moet alfanumeriek zijn en mag de karakters '/._-' bevatten. De placeholder "
+"tokens {year}, {public_reference} en {uid} zijn beschikbaar. Het sjabloon "
+"moet de placeholder {uid} bevatten."
+
+#: openforms/config/models/config.py:434 openforms/forms/models/form.py:231
+msgid "ask privacy consent"
+msgstr "vraag toestemming om gegevens te verwerken"
+
+#: openforms/config/models/config.py:437 openforms/forms/models/form.py:236
+msgid ""
+"If enabled, the user will have to agree to the privacy policy before "
+"submitting a form."
+msgstr ""
+"Indien ingeschakeld, moet de gebruiker akkoord gaan met het privacybeleid "
+"voordat hij een formulier indient."
+
+#: openforms/config/models/config.py:441
+msgid "privacy policy URL"
+msgstr "Privacybeleid URL"
+
+#: openforms/config/models/config.py:441
+msgid "URL to the privacy policy"
+msgstr "URL naar het privacybeleid op uw eigen website"
+
+#: openforms/config/models/config.py:444
+msgid "privacy policy label"
+msgstr "Privacybeleid label"
+
+#: openforms/config/models/config.py:447
+msgid ""
+"The label of the checkbox that prompts the user to agree to the privacy "
+"policy."
+msgstr ""
+"Het label van het selectievakje dat de gebruiker vraagt om akkoord te gaan "
+"met het privacybeleid. "
+
+#: openforms/config/models/config.py:451
+msgid ""
+"Yes, I have read the {% privacy_policy %} and explicitly agree to the "
+"processing of my submitted information."
+msgstr ""
+"Ja, ik heb kennis genomen van het {% privacy_policy %} en geef uitdrukkelijk"
+" toestemming voor het verwerken van de door mij opgegeven gegevens."
+
+#: openforms/config/models/config.py:467 openforms/forms/models/form.py:240
+msgid "ask statement of truth"
+msgstr "vraag waarheidsverklaring"
+
+#: openforms/config/models/config.py:470 openforms/forms/models/form.py:245
+msgid ""
+"If enabled, the user will have to agree that they filled out the form "
+"truthfully before submitting it."
+msgstr ""
+"Indien verplicht dient de gebruiker de verklaring naar waarheid te "
+"accepteren voor die het formulier indient."
+
+#: openforms/config/models/config.py:475
+msgid "statement of truth label"
+msgstr "waarheidsverklaringtekst"
+
+#: openforms/config/models/config.py:478
+msgid ""
+"The label of the checkbox that prompts the user to agree that they filled "
+"out the form truthfully. Note that this field does not have templating "
+"support."
+msgstr ""
+"Het label van het selectievakje dat de gebruiker vraagt om akkoord te gaan "
+"met de waarheidsverklaring. Merk op dat dit veld geen sjablonen ondersteunt."
+
+#: openforms/config/models/config.py:484
+msgid ""
+"I declare that I have filled out the form truthfully and have not omitted "
+"any information."
+msgstr ""
+"Ik verklaar dat ik deze aanvraag naar waarheid heb ingevuld en geen "
+"informatie heb verzwegen."
+
+#: openforms/config/models/config.py:492 openforms/forms/models/form.py:336
+msgid "successful submission removal limit"
+msgstr "bewaartermijn voor voltooide inzendingen."
+
+#: openforms/config/models/config.py:496
+msgid "Amount of days successful submissions will remain before being removed"
+msgstr "Aantal dagen dat een voltooide inzending bewaard blijft."
+
+#: openforms/config/models/config.py:500 openforms/forms/models/form.py:346
+msgid "successful submissions removal method"
+msgstr "opschoonmethode voor voltooide inzendingen"
+
+#: openforms/config/models/config.py:504
+msgid "How successful submissions will be removed after the limit"
+msgstr ""
+"Geeft aan hoe voltooide inzendingen worden opgeschoond na de bewaartermijn."
+
+#: openforms/config/models/config.py:507 openforms/forms/models/form.py:356
+msgid "incomplete submission removal limit"
+msgstr "bewaartermijn voor sessies"
+
+#: openforms/config/models/config.py:511
+msgid "Amount of days incomplete submissions will remain before being removed"
+msgstr "Aantal dagen dat een sessie bewaard blijft."
+
+#: openforms/config/models/config.py:515 openforms/forms/models/form.py:366
+msgid "incomplete submissions removal method"
+msgstr "opschoonmethode voor sessies."
+
+#: openforms/config/models/config.py:519
+msgid "How incomplete submissions will be removed after the limit"
+msgstr "Geeft aan hoe sessies worden opgeschoond na de bewaartermijn."
+
+#: openforms/config/models/config.py:522 openforms/forms/models/form.py:376
+#: openforms/forms/models/form.py:386
+msgid "errored submission removal limit"
+msgstr "bewaartermijn voor niet voltooide inzendingen"
+
+#: openforms/config/models/config.py:526
+msgid "Amount of days errored submissions will remain before being removed"
+msgstr ""
+"Aantal dagen dat een niet voltooide inzendingen (door fouten in de "
+"afhandeling) bewaard blijft."
+
+#: openforms/config/models/config.py:530
+msgid "errored submissions removal method"
+msgstr "opschoonmethode voor niet voltooide inzendingen"
+
+#: openforms/config/models/config.py:534
+msgid "How errored submissions will be removed after the"
+msgstr ""
+"Geeft aan hoe niet voltooide inzendingen (door fouten in de afhandeling) "
+"worden opgeschoond na de bewaartermijn."
+
+#: openforms/config/models/config.py:537 openforms/forms/models/form.py:396
+msgid "all submissions removal limit"
+msgstr "bewaartermijn van inzendingen"
+
+#: openforms/config/models/config.py:540
+msgid "Amount of days when all submissions will be permanently deleted"
+msgstr ""
+"Aantal dagen dat een inzending bewaard blijft voordat deze definitief "
+"verwijderd wordt."
+
+#: openforms/config/models/config.py:544
+msgid "default registration backend attempt limit"
+msgstr "limiet aantal registratiepogingen"
+
+#: openforms/config/models/config.py:548
+msgid ""
+"How often we attempt to register the submission at the registration backend "
+"before giving up"
+msgstr ""
+"Stel in hoe vaak het systeem een inzending probeert af te leveren bij de "
+"registratie-backend voor er opgegeven wordt."
+
+#: openforms/config/models/config.py:553
+msgid "plugin configuration"
+msgstr "pluginconfiguratie"
+
+#: openforms/config/models/config.py:557
+msgid ""
+"Configuration of plugins for authentication, payments, prefill, "
+"registrations and validation"
+msgstr ""
+"Configuratie van plugins voor authenticatie, betaalproviders, prefill, "
+"registraties en validaties."
+
+#: openforms/config/models/config.py:564
+msgid "reference lists services"
+msgstr "referentielijstenservices"
+
+#: openforms/config/models/config.py:566
+msgid ""
+"List of services that are instances of the Referentielijsten API. The "
+"selected services will be shown as options when configuring select or "
+"selectboxes components to be populated from Referentielijsten."
+msgstr ""
+"Selecteer de services die referentielijsten ontsluiten. Je kan vervolgens in"
+" de formuliercomponenten uit deze lijst van services een optie selecteren om"
+" de keuzeopties uit de referentielijsten op te halen."
+
+#: openforms/config/models/config.py:573
+msgid "family members data api"
+msgstr "familieledengegevens-API"
+
+#: openforms/config/models/config.py:574
+msgid "Which API to use to retrieve the data of the family members."
+msgstr "Welke API gebruikt wordt om familiegegevens op te halen."
+
+#: openforms/config/models/config.py:580
+msgid "communication preferences portal url"
+msgstr "url naar communicatievoorkeurenportaal"
+
+#: openforms/config/models/config.py:583
+msgid ""
+"Url to the online portal where users can update their communication "
+"preferences. This is used by the profile component."
+msgstr ""
+"URL naar het portaal/de Mijn-omgeving waar gebruikers hun "
+"communicatievoorkeuren kunnen inzien en beheren. Dit wordt gebruikt in het "
+"Profiel-component."
+
+#: openforms/config/models/config.py:590
+msgid "Allow form page indexing"
+msgstr "Laat indexeren van formulierpagina's toe"
+
+#: openforms/config/models/config.py:593
+msgid ""
+"Whether form detail pages may be indexed and displayed in search engine "
+"result lists. Disable this to prevent listing."
+msgstr ""
+"Geeft aan of formulierpagina's geïndexeerd én getoond mogen worden in de "
+"resultaten van zoekmachines. Schakel dit uit om weergave te voorkomen."
+
+#: openforms/config/models/config.py:599
+msgid "Enable virus scan"
+msgstr "Virusscan inschakelen"
+
+#: openforms/config/models/config.py:602
+msgid ""
+"Whether the files uploaded by the users should be scanned by ClamAV virus "
+"scanner.In case a file is found to be infected, the file is deleted."
+msgstr ""
+"Indien aangevinkt, dan worden uploads van eindgebruikers op virussen "
+"gescand. Geïnfecteerde bestanden worden meteen verwijdered en geblokkeerd."
+
+#: openforms/config/models/config.py:607
+msgid "ClamAV server hostname"
+msgstr "ClamAV server hostname"
+
+#: openforms/config/models/config.py:609
+msgid "Hostname or IP address where ClamAV is running."
+msgstr "Hostname of IP-adres waarop de ClamAV service bereikbaar is."
+
+#: openforms/config/models/config.py:614
+msgid "ClamAV port number"
+msgstr "ClamAV poortnummer"
+
+#: openforms/config/models/config.py:615
+msgid "The TCP port on which ClamAV is listening."
+msgstr "Poortnummer (TCP) waarop de ClamAV service luistert."
+
+#: openforms/config/models/config.py:623
+msgid "ClamAV socket timeout"
+msgstr "ClamAV-connectie timeout"
+
+#: openforms/config/models/config.py:624
+msgid "ClamAV socket timeout expressed in seconds (optional)."
+msgstr "ClamAV socket timeout, in seconden."
+
+#: openforms/config/models/config.py:632
+msgid "recipients email digest"
+msgstr "ontvangers (probleem)rapportage"
+
+#: openforms/config/models/config.py:634
+msgid ""
+"The email addresses that should receive a daily report of items requiring "
+"attention."
+msgstr ""
+"Geef de e-mailaddressen op van beheerders die een dagelijkse rapportage "
+"dienen te ontvangen van eventuele problemen die actie vereisen."
+
+#: openforms/config/models/config.py:640
+msgid "wait for payment to register"
+msgstr "wacht tot betalingen voltooid zijn om inzendingen te verwerken"
+
+#: openforms/config/models/config.py:642
+msgid ""
+"Should a submission be processed (sent to the registration backend) only "
+"after payment has been received?"
+msgstr "Mag een inzending pas verwerkt worden nadat de betaling ontvangen is?"
+
+#: openforms/config/models/config.py:648
+msgid "Public reference template"
+msgstr "Publiek referentiesjabloon"
+
+#: openforms/config/models/config.py:652
+#, python-brace-format
+msgid ""
+"Template to use when generating public reference of the submission. It "
+"should be alpha-numerical and can contain the '/._-' characters. You can use"
+" the placeholder tokens: {year}, {uid}."
+msgstr ""
+"Sjabloon voor de generatie van de publieke referentie voor een inzending. "
+"Het sjabloon moet alfanumeriek zijn en mag de karakters '/._-' bevatten. De "
+"placeholder tokens {year} en {uid} zijn beschikbaar. Het sjabloon moet de "
+"placeholder {uid} bevatten."
+
+#: openforms/config/models/config.py:661
+msgid "Public reference alphabet"
+msgstr "Publiek referentie-alfabet"
+
+#: openforms/config/models/config.py:665
+#, python-brace-format
+msgid ""
+"Alphabet used to generate the {uid} part of the public reference of the "
+"submission. The sequence is shuffled in the unique way for each instance of "
+"Open Forms "
+msgstr ""
+"Alfabet dat wordt gebruikt om het {uid}-gedeelte van de publieke referentie "
+"van de inzending te genereren. Elke Open Formulieren-instantie heeft een "
+"unieke volgorde van het alfabet."
+
+#: openforms/config/models/config.py:673
+#| msgid "export content"
+msgid "help callout page content"
+msgstr ""
+
+#: openforms/config/models/config.py:675
+msgid "The content shown on the help callout page."
+msgstr ""
+
+#: openforms/config/models/config.py:679
+msgid "help callout page image"
+msgstr ""
+
+#: openforms/config/models/config.py:680
+msgid "The image shown on the help callout page."
+msgstr ""
+
+#: openforms/config/models/config.py:688
+msgid "General configuration"
+msgstr "Algemene configuratie"
+
+#: openforms/config/models/config.py:714
+msgid "ClamAV host and port need to be configured if virus scan is enabled."
+msgstr ""
+"De ClamAV host en poortnummer moeten ingesteld zijn om virusscannen in te "
+"schakelen."
+
+#: openforms/config/models/config.py:725
+#, python-brace-format
+msgid "Cannot connect to ClamAV: {error}"
+msgstr "Kon niet verbinden met de antivirus-service: {error}"
+
+#: openforms/config/models/csp.py:64
+msgid "directive"
+msgstr "directive"
+
+#: openforms/config/models/csp.py:67
+msgid "CSP header directive."
+msgstr "CSP header directive."
+
+#: openforms/config/models/csp.py:72
+msgid "CSP header value."
+msgstr "CSP header waarde."
+
+#: openforms/config/models/csp.py:79
+msgid "An extra tag for this CSP entry, to identify the exact source."
+msgstr ""
+"Een extra label voor de CSP-configuratie zodat de precieze bron bepaald kan "
+"worden."
+
+#: openforms/config/models/csp.py:85
+#: openforms/submissions/models/submission_files.py:64
+#: openforms/submissions/models/submission_files.py:268
+msgid "content type"
+msgstr "content type"
+
+#: openforms/config/models/csp.py:91
+msgid "object id"
+msgstr "object-ID"
+
+#: openforms/config/models/map.py:23
+msgid "A unique identifier for the tile layer."
+msgstr "Unieke identificatie voor de achtergrondlaag."
+
+#: openforms/config/models/map.py:26 openforms/config/models/map.py:77
+msgid "tile layer url"
+msgstr "achtergrondlaag-URL"
+
+#: openforms/config/models/map.py:29
+#, python-brace-format
+msgid ""
+"URL to the tile layer image, used to define the map component background. To"
+" ensure correct functionality of the map, EPSG 28992 projection should be "
+"used. Example value: "
+"https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png"
+msgstr ""
+"URL naar de tegels van de achtergrondlaag van de kaart. Om de juiste werking"
+" te garanderen moet de laag de EPSG:28992-projectie gebruiken. Bijvoorbeeld:"
+" "
+"https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png"
+
+#: openforms/config/models/map.py:39
+msgid "An easily recognizable name for the tile layer, used to identify it."
+msgstr ""
+"Een herkenbare naam voor de achtergrondlaag zodat je deze kan selecteren in "
+"keuzemenu's."
+
+#: openforms/config/models/map.py:46
+msgid "map tile layer"
+msgstr "kaartachtergrondlaag"
+
+#: openforms/config/models/map.py:47
+msgid "map tile layers"
+msgstr "kaartachtergrondlagen"
+
+#: openforms/config/models/map.py:73
+msgid ""
+"An easily recognizable name for the WMS tile layer, used to identify it."
+msgstr ""
+"Een herkenbare naam voor de WMS-kaartlaag zodat je deze kan selecteren in "
+"keuzemenu's."
+
+#: openforms/config/models/map.py:80
+msgid ""
+"URL to collect the WMS tile layer capabilities. To ensure correct "
+"functionality of the map, EPSG 28992 projection should be available on the "
+"WMS tile layer. Example value: "
+"https://service.pdok.nl/lv/bag/wms/v2_0?request=getCapabilities&service=WMS"
+msgstr ""
+"URL naar de tegels van de WMS-kaartlaag. Om de juiste werking te garanderen "
+"moet de laag de EPSG:28992-projectie gebruiken. Bijvoorbeeld: "
+"https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png"
+
+#: openforms/config/models/map.py:91
+msgid "WMS layer"
+msgstr "WMS-kaartlaag"
+
+#: openforms/config/models/map.py:92
+msgid "WMS layers"
+msgstr "WMS-kaartlagen"
+
+#: openforms/config/models/theme.py:23
+msgid "An easily recognizable name for the theme, used to identify it."
+msgstr "Een herkenbare naam om deze stijl te identificeren."
+
+#: openforms/config/models/theme.py:36
+msgid ""
+"The name of your organization that will be used as label for elements like "
+"the logo. If left blank, the matching configuration option from the global "
+"configuration is used."
+msgstr ""
+"De naam van de organisatie/gemeente - dit wordt gebruikt in label bij "
+"elementen zoals het logo en de link terug naar de website. Als je dit "
+"leeglaat, dan wordt de algemene instelling gebruikt."
+
+#: openforms/config/models/theme.py:45
+msgid ""
+"URL to the main website. Used for the 'back to municipality website' link. "
+"If left blank, the matching configuration option from the global "
+"configuration is used."
+msgstr ""
+"URL naar de hoofdsite van de organisatie. Wordt gebruikt voor de 'terug naar"
+" de gemeentewebsite' link. Als je dit leeglaat, dan wordt de algemene "
+"instelling gebruikt."
+
+#: openforms/config/models/theme.py:55
+msgid ""
+"Allow the uploading of a favicon, .png .jpg .svg and .ico are compatible. If"
+" left blank, the matching configuration option from the global configuration"
+" is used."
+msgstr ""
+"Upload het favicon voor de applicatie. Enkel .png, .jpg, .svg en .ico "
+"bestanden zijn toegestaan. Als je dit leeglaat, dan wordt de algemene "
+"instelling gebruikt."
+
+#: openforms/config/models/theme.py:71
+msgid "theme logo"
+msgstr "logo"
+
+#: openforms/config/models/theme.py:75
+msgid ""
+"Upload the theme/organization logo, visible to users filling out forms. We "
+"advise dimensions around 150px by 75px. SVG's are permitted."
+msgstr ""
+"Upload het logo van de gemeente dat zichtbaar is op de formulierwebsite. We "
+"adviseren de dimensies van 150 x 75 pixels. SVG-bestanden zijn toegestaan."
+
+#: openforms/config/models/theme.py:80
+msgid "email logo"
+msgstr "emaillogo"
+
+#: openforms/config/models/theme.py:84
+msgid ""
+"Upload the email logo, visible to users who receive an email. We advise "
+"dimensions around 150px by 75px. SVG's are not permitted."
+msgstr ""
+"Upload het logo van de gemeente dat zichtbaar is in e-mails. We adviseren de"
+" dimensies van 150 x 75 pixels. SVG-bestanden zijn niet toegestaan."
+
+#: openforms/config/models/theme.py:93
+msgid "theme CSS class name"
+msgstr "Thema CSS class name"
+
+#: openforms/config/models/theme.py:95
+msgid "If provided, this class name will be set on the <html> element."
+msgstr ""
+"Indien ingevuld, dan wordt deze class name aan het <html> element "
+"toegevoegd."
+
+#: openforms/config/models/theme.py:98
+msgid "theme stylesheet URL"
+msgstr "Stylesheet-URL thema"
+
+#: openforms/config/models/theme.py:104
+msgid "The URL must point to a CSS resource (.css extension)."
+msgstr "De URL moet naar een CSS bestand wijzen (.css extensie)."
+
+#: openforms/config/models/theme.py:108
+msgid ""
+"The URL stylesheet with theme-specific rules for your organization. This "
+"will be included as final stylesheet, overriding previously defined styles. "
+"Note that you also have to include the host to the `style-src` CSP "
+"directive. Example value: https://unpkg.com/@utrecht/design-"
+"tokens@1.0.0-alpha.20/dist/index.css."
+msgstr ""
+"URL naar de stylesheet met thema-specifieke regels voor uw organisatie. Deze"
+" stylesheet wordt als laatste ingeladen, waarbij eerdere stijlregels dus "
+"overschreven worden. Vergeet niet dat u ook de host van deze URL aan de "
+"`style-src` CSP configuratie moet toevoegen. Voorbeeldwaarde: "
+"https://unpkg.com/@utrecht/design-tokens@1.0.0-alpha.20/dist/index.css."
+
+#: openforms/config/models/theme.py:115
+msgid "theme stylesheet"
+msgstr "Stylesheet thema"
+
+#: openforms/config/models/theme.py:120
+msgid ""
+"A stylesheet with theme-specific rules for your organization. This will be "
+"included as final stylesheet, overriding previously defined styles. If both "
+"a URL to a stylesheet and a stylesheet file have been configured, the "
+"uploaded file is included after the stylesheet URL."
+msgstr ""
+"Een stylesheet met thema-specifieke regels voor uw organisatie. Deze "
+"stylesheet wordt als laatste ingeladen. Indien je tegelijkertijd een "
+"stylesheet-URL en -bestand opgeeft, dan wordt het bestand na de URL "
+"ingeladen."
+
+#: openforms/config/models/theme.py:144
+msgid "design token values"
+msgstr "design token waarden"
+
+#: openforms/config/models/theme.py:148
+msgid ""
+"Values of various style parameters, such as border radii, background "
+"colors... Note that this is advanced usage. Any available but un-specified "
+"values will use fallback default values. See https://open-"
+"forms.readthedocs.io/en/latest/installation/form_hosting.html#run-time-"
+"configuration for documentation."
+msgstr ""
+"Waarden met diverse stijl parameters, zoals randen, achtergrondkleuren, etc."
+" Dit is voor geavanceerde gebruikers. Attributen die niet zijn opgegeven "
+"vallen terug op standaardwaarden. Zie https://open-"
+"forms.readthedocs.io/en/latest/installation/form_hosting.html#run-time-"
+"configuration voor documentatie."
+
+#: openforms/config/models/theme.py:156
+#: openforms/forms/api/serializers/form.py:211
+msgid "theme"
+msgstr "stijl"
+
+#: openforms/config/models/theme.py:157
+msgid "themes"
+msgstr "stijlen"
+
+#: openforms/config/templates/admin/config/overview.html:8
+#: openforms/config/templates/admin/config/theme/preview.html:13
+#: openforms/forms/templates/admin/forms/form/export.html:13
+#: openforms/forms/templates/admin/forms/form/import_form.html:13
+#: openforms/forms/templates/admin/forms/form/migrate-payment-backend.html:18
+#: openforms/forms/templates/admin/forms/formsubmissionstatistics/export_form.html:19
+msgid "Home"
+msgstr "Thuis"
+
+#: openforms/config/templates/admin/config/overview.html:10
+msgid "Overview"
+msgstr "Overzicht"
+
+#: openforms/config/templates/admin/config/overview.html:23
+msgid "Name"
+msgstr "Naam"
+
+#: openforms/config/templates/admin/config/overview.html:24
+msgid "Status"
+msgstr "Status"
+
+#: openforms/config/templates/admin/config/overview.html:25
+#: openforms/forms/admin/category.py:37 openforms/forms/admin/form.py:264
+#: openforms/forms/api/serializers/logic/form_logic.py:132
+#: openforms/submissions/api/serializers.py:244
+msgid "Actions"
+msgstr "Acties"
+
+#: openforms/config/templates/admin/config/overview.html:35
+msgid "Failed to validate the configuration."
+msgstr "Kon de configuratie niet valideren"
+
+#: openforms/config/templates/admin/config/overview.html:37
+msgid "Skipped"
+msgstr "Overgeslagen"
+
+#: openforms/config/templates/admin/config/theme/preview.html:9
+#: openforms/config/templates/admin/config/theme/preview.html:15
+#, python-format
+msgid "Preview theme '%(theme)s'"
+msgstr "Bekijk stijl '%(theme)s'"
+
+#: openforms/config/templates/admin/config/theme/preview.html:14
+msgid "Themes"
+msgstr "Stijlen"
+
+#: openforms/config/templates/admin/config/theme/preview.html:20
+msgid "Preview a theme"
+msgstr "Bekijk een stijl"
+
+#: openforms/config/templates/config/default_cosign_submission_confirmation.html:6
+msgid "Your request is not yet complete."
+msgstr "Je aanvraag is nog niet compleet."
+
+#: openforms/config/templates/config/default_cosign_submission_confirmation.html:7
+msgid "Cosigning required"
+msgstr "Medeondertekening nodig"
+
+#: openforms/config/templates/config/default_cosign_submission_confirmation.html:8
+msgid ""
+"You can start the cosigning process immediately by clicking the button "
+"below."
+msgstr ""
+"Je kan het mede-ondertekenen meteen starten door de onderstaande knop aan te"
+" klikken."
+
+#: openforms/config/templates/config/default_cosign_submission_confirmation.html:9
+#: openforms/submissions/templatetags/cosign.py:17
+msgid "Cosign now"
+msgstr "Nu mede-ondertekenen"
+
+#: openforms/config/templates/config/default_cosign_submission_confirmation.html:11
+msgid "Alternative instructions"
+msgstr "Alternatieve instructies"
+
+#: openforms/config/templates/config/default_cosign_submission_confirmation.html:12
+#, python-format
+msgid ""
+"We've sent an email with a cosign request to <a "
+"href=\"mailto:%(tt_openvariable)s cosigner_email "
+"%(tt_closevariable)s\">%(tt_openvariable)s cosigner_email "
+"%(tt_closevariable)s</a>. Once the submission has been cosigned we will "
+"start processing your request."
+msgstr ""
+"Wij hebben een e-mail gestuurd voor medeondertekening naar <a "
+"href=\"mailto:%(tt_openvariable)s cosigner_email "
+"%(tt_closevariable)s\">%(tt_openvariable)s cosigner_email "
+"%(tt_closevariable)s</a>. Als deze ondertekend is, nemen wij je aanvraag in "
+"behandeling."
+
+#: openforms/config/templates/config/default_cosign_submission_confirmation.html:17
+#, python-format
+msgid ""
+"If you need to contact us about this submission, you can use the reference "
+"<strong>%(tt_openvariable)s public_reference %(tt_closevariable)s</strong>"
+msgstr ""
+"Als je contact moet opnemen over deze aanvraag, dan kan je de referentie "
+"<strong>%(tt_openvariable)s public_reference %(tt_closevariable)s</strong> "
+"gebruiken."
+
+#: openforms/config/templatetags/privacy_policy.py:19
+msgid "privacy policy"
+msgstr "privacybeleid"
 
 #: openforms/contrib/auth_oidc/admin.py:52
 #, python-brace-format
@@ -2789,8 +4225,8 @@ msgstr "standaardwaarde BRP Personen doelbinding-header"
 #: openforms/contrib/haal_centraal/models.py:50
 msgid ""
 "The default purpose limitation (\"doelbinding\") for queries to the BRP "
-"Persoon API. If a more specific value is configured on a form, that value is "
-"used instead."
+"Persoon API. If a more specific value is configured on a form, that value is"
+" used instead."
 msgstr ""
 "De standaard \"doelbinding\" voor BRP Personen bevragingen. Mogelijke "
 "waarden hiervoor zijn afhankelijk van je gateway-leverancier en/of eigen "
@@ -2804,12 +4240,13 @@ msgstr "standaardwaarde BRP Personen verwerking-header"
 #: openforms/contrib/haal_centraal/models.py:60
 msgid ""
 "The default processing (\"verwerking\") for queries to the BRP Persoon API. "
-"If a more specific value is configured on a form, that value is used instead."
+"If a more specific value is configured on a form, that value is used "
+"instead."
 msgstr ""
-"De standaard \"verwerking\" voor BRP Personen bevragingen. Mogelijke waarden "
-"hiervoor zijn afhankelijk van je gateway-leverancier. Je kan deze ook op "
-"formulierniveau opgeven en dan overschrijft de formulierspecifieke waarde de "
-"standaardwaarde."
+"De standaard \"verwerking\" voor BRP Personen bevragingen. Mogelijke waarden"
+" hiervoor zijn afhankelijk van je gateway-leverancier. Je kan deze ook op "
+"formulierniveau opgeven en dan overschrijft de formulierspecifieke waarde de"
+" standaardwaarde."
 
 #: openforms/contrib/haal_centraal/models.py:65
 msgid "header name for OIN value"
@@ -2835,8 +4272,8 @@ msgstr "BRP Personen doelbinding-header"
 msgid ""
 "The purpose limitation (\"doelbinding\") for queries to the BRP Persoon API."
 msgstr ""
-"De \"doelbinding\" voor BRP Personen bevragingen. Mogelijke waarden hiervoor "
-"zijn afhankelijk van je gateway-leverancier en/of eigen organisatie-"
+"De \"doelbinding\" voor BRP Personen bevragingen. Mogelijke waarden hiervoor"
+" zijn afhankelijk van je gateway-leverancier en/of eigen organisatie-"
 "instellingen."
 
 #: openforms/contrib/haal_centraal/models.py:102
@@ -2931,11 +4368,13 @@ msgstr "Rijksdriehoekcoördinaten"
 
 #: openforms/contrib/kadaster/api/serializers.py:48
 msgid ""
-"X and Y coordinates in the [Rijkdsdriehoek](https://nl.wikipedia.org/wiki/"
-"Rijksdriehoeksco%C3%B6rdinaten) coordinate system."
+"X and Y coordinates in the "
+"[Rijkdsdriehoek](https://nl.wikipedia.org/wiki/Rijksdriehoeksco%C3%B6rdinaten)"
+" coordinate system."
 msgstr ""
-"X- en Y-coördinaten in de [Rijkdsdriehoek](https://nl.wikipedia.org/wiki/"
-"Rijksdriehoeksco%C3%B6rdinaten) coordinate system."
+"X- en Y-coördinaten in de "
+"[Rijkdsdriehoek](https://nl.wikipedia.org/wiki/Rijksdriehoeksco%C3%B6rdinaten)"
+" coordinate system."
 
 #: openforms/contrib/kadaster/api/serializers.py:59
 msgid "Latitude, in decimal degrees."
@@ -2971,7 +4410,8 @@ msgid "Get an adress based on coordinates"
 msgstr "Zoek adres op basis van coördinaten"
 
 #: openforms/contrib/kadaster/api/views.py:94
-msgid "Get the closest address name based on the given longitude and latitude."
+msgid ""
+"Get the closest address name based on the given longitude and latitude."
 msgstr ""
 "Haal de omschrijving op van het dichtsbijzijndste adres voor de opgegeven "
 "longitude en latitude."
@@ -2990,18 +4430,13 @@ msgstr "Geef lijst van adressuggesties met coördinaten."
 
 #: openforms/contrib/kadaster/api/views.py:147
 msgid ""
-"Get a list of addresses, ordered by relevance/match score of the input "
-"query. Note that only results having latitude/longitude data are returned.\n"
+"Get a list of addresses, ordered by relevance/match score of the input query. Note that only results having latitude/longitude data are returned.\n"
 "\n"
-"The results are retrieved from the configured geo search service, defaulting "
-"to the Kadaster location server."
+"The results are retrieved from the configured geo search service, defaulting to the Kadaster location server."
 msgstr ""
-"Haal een lijst op van adressen, gesorteerd op relevantie/match score van de "
-"zoekopdracht. Merk op dat enkel resultaten voorzien van latitude/longitude "
-"teruggegeven worden.\n"
+"Haal een lijst op van adressen, gesorteerd op relevantie/match score van de zoekopdracht. Merk op dat enkel resultaten voorzien van latitude/longitude teruggegeven worden.\n"
 "\n"
-"Deze resultaten worden opgehaald uit de ingestelde geo-zoekservice. "
-"Standaard is dit de Locatieserver van het Kadaster."
+"Deze resultaten worden opgehaald uit de ingestelde geo-zoekservice. Standaard is dit de Locatieserver van het Kadaster."
 
 #: openforms/contrib/kadaster/api/views.py:158
 msgid ""
@@ -3125,14 +4560,6 @@ msgstr "KvK vestigingsnummer"
 msgid "Microsoft code & configuration"
 msgstr "Microsof code en configuratie"
 
-#: openforms/contrib/microsoft/models.py:11
-#: openforms/contrib/zgw/api/serializers.py:23
-#: openforms/dmn/api/serializers.py:53 openforms/dmn/api/serializers.py:73
-#: soap/models.py:21 openforms/config/models/color.py:15
-#: openforms/config/models/map.py:36
-msgid "label"
-msgstr "label"
-
 #: openforms/contrib/microsoft/models.py:13 soap/models.py:23
 msgid "Human readable label to identify services"
 msgstr "Eenvoudige naam om services te identificeren"
@@ -3206,11 +4633,11 @@ msgstr "De gewenste Objecten API-groep."
 
 #: openforms/contrib/objects_api/api/serializers.py:23
 msgid ""
-"URL reference to this object. This is the unique identification and location "
-"of this object."
+"URL reference to this object. This is the unique identification and location"
+" of this object."
 msgstr ""
-"URL-referentie naar dit object. Dit is de unieke identificatie en vindplaats "
-"van het object."
+"URL-referentie naar dit object. Dit is de unieke identificatie en vindplaats"
+" van het object."
 
 #: openforms/contrib/objects_api/api/serializers.py:26
 msgid "Unique identifier (UUID4)."
@@ -3266,10 +4693,11 @@ msgstr ""
 #: openforms/contrib/objects_api/checks.py:36
 #, python-brace-format
 msgid ""
-"Missing Objecttypes API credentials for Objects API group {objects_api_group}"
-msgstr ""
-"Ontbrekende Objecttypen API authenticatiegegevens voor de Objecten API-groep "
+"Missing Objecttypes API credentials for Objects API group "
 "{objects_api_group}"
+msgstr ""
+"Ontbrekende Objecttypen API authenticatiegegevens voor de Objecten API-groep"
+" {objects_api_group}"
 
 #: openforms/contrib/objects_api/checks.py:70
 #, python-brace-format
@@ -3344,8 +4772,8 @@ msgid ""
 msgstr ""
 "Omschrijving van het documenttype in de Catalogi API (het "
 "INFORMATIEOBJECTTYPE.omschrijving attribuut) voor het PDF-document met "
-"inzendingsgegevens. De juiste versie wordt automatisch geselecteerd op basis "
-"van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
+"inzendingsgegevens. De juiste versie wordt automatisch geselecteerd op basis"
+" van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
 
 #: openforms/contrib/objects_api/models.py:119
 #: openforms/registrations/contrib/objects_api/config.py:194
@@ -3361,8 +4789,8 @@ msgid ""
 msgstr ""
 "Omschrijving van het documenttype in de Catalogi API (het "
 "INFORMATIEOBJECTTYPE.omschrijving attribuut) voor het CSV-document met "
-"inzendingsgegevens. De juiste versie wordt automatisch geselecteerd op basis "
-"van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
+"inzendingsgegevens. De juiste versie wordt automatisch geselecteerd op basis"
+" van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
 
 #: openforms/contrib/objects_api/models.py:134
 #: openforms/registrations/contrib/objects_api/config.py:207
@@ -3378,8 +4806,8 @@ msgid ""
 msgstr ""
 "Omschrijving van het documenttype in de Catalogi API (het "
 "INFORMATIEOBJECTTYPE.omschrijving attribuut) voor inzendingsbijlagen. De "
-"juiste versie wordt automatisch geselecteerd op basis van de inzendingsdatum "
-"en geldigheidsdatums van de documenttypeversies."
+"juiste versie wordt automatisch geselecteerd op basis van de inzendingsdatum"
+" en geldigheidsdatums van de documenttypeversies."
 
 #: openforms/contrib/objects_api/models.py:150
 msgid "submission report informatieobjecttype"
@@ -3423,7 +4851,8 @@ msgstr "Objecten API-groepen"
 
 #: openforms/contrib/objects_api/models.py:185
 #: openforms/registrations/contrib/zgw_apis/models.py:157
-msgid "You must specify both domain and RSIN to uniquely identify a catalogue."
+msgid ""
+"You must specify both domain and RSIN to uniquely identify a catalogue."
 msgstr ""
 "Je moet het domein én RSIN beide opgeven om een catalogus uniek te "
 "identificeren."
@@ -3504,8 +4933,8 @@ msgid ""
 "same case type with the same identification exist. The filter returns a "
 "document type if it occurs within any version of the specified case type."
 msgstr ""
-"Filter documenttypen voor een gegeven zaaktype. De zaaktype-identificatie is "
-"uniek binnen een catalogus. Merk op dat meerdere versies van hetzelfde "
+"Filter documenttypen voor een gegeven zaaktype. De zaaktype-identificatie is"
+" uniek binnen een catalogus. Merk op dat meerdere versies van hetzelfde "
 "zaaktype met dezelfde identificatie kunnen bestaan. De filter geeft een "
 "documenttype terug zodra deze binnen één versie van een zaaktype voorkomt."
 
@@ -3681,7 +5110,8 @@ msgstr "Versie-identificatie"
 
 #: openforms/dmn/api/serializers.py:32
 msgid ""
-"The (unique) identifier pointing to a particular decision definition version."
+"The (unique) identifier pointing to a particular decision definition "
+"version."
 msgstr "De (unieke) identifier voor een beslisdefinitieversie."
 
 #: openforms/dmn/api/serializers.py:37
@@ -3853,16 +5283,11 @@ msgstr ""
 "Testbericht is succesvol verzonden naar %(recipients)s. Controleer uw inbox."
 
 #: openforms/emails/connection_check.py:93
-msgid "If the message doesn't arrive check the Django-yubin queue and cronjob."
+msgid ""
+"If the message doesn't arrive check the Django-yubin queue and cronjob."
 msgstr ""
 "Indien het bericht niet aankomt, controleer de Django-yubin wachtrij en "
 "periodieke acties."
-
-#: openforms/emails/constants.py:10 openforms/submissions/admin.py:260
-#: openforms/submissions/rendering/constants.py:11
-#: openforms/config/admin.py:186
-msgid "Registration"
-msgstr "Registratie"
 
 #: openforms/emails/constants.py:11
 msgid "Confirmation"
@@ -3931,7 +5356,8 @@ msgstr "ONBEKEND"
 
 #: openforms/emails/digest.py:640
 #, python-brace-format
-msgid "Service reference '{slug}' could not be resolved (used in form {form})."
+msgid ""
+"Service reference '{slug}' could not be resolved (used in form {form})."
 msgstr ""
 "Servicereferentie '{slug}' kon niet worden opgehaald (gebruikt in formulier "
 "{form})."
@@ -3963,25 +5389,9 @@ msgstr ""
 "De component is ingesteld om gegevens bij te werken in de klantinteracties-"
 "API, maar de gekoppelde prefill-variable ontbreekt."
 
-#: openforms/emails/models.py:43
-#: openforms/registrations/contrib/email/models.py:54
-#: openforms/config/models/config.py:120 openforms/config/models/config.py:146
-#: openforms/config/models/config.py:204
-msgid "subject"
-msgstr "onderwerp"
-
 #: openforms/emails/models.py:46
 msgid "Subject of the email message"
 msgstr "Onderwerp van het e-mailbericht"
-
-#: openforms/emails/models.py:50
-#: openforms/submissions/models/submission_files.py:59
-#: openforms/submissions/models/submission_files.py:258
-#: openforms/submissions/models/submission_report.py:21
-#: openforms/config/models/config.py:129 openforms/config/models/config.py:153
-#: openforms/config/models/config.py:211
-msgid "content"
-msgstr "inhoud"
 
 #: openforms/emails/models.py:53
 msgid ""
@@ -3991,18 +5401,10 @@ msgstr ""
 "De inhoud van het e-mailbericht kan variabelen bevatten die op basis van de "
 "ingediende formuliergegevens worden weergegeven. "
 
-#: openforms/emails/models.py:68 openforms/config/models/config.py:175
-msgid "cosign subject"
-msgstr "onderwerp bevestigingsmail met mede-ondertekenen"
-
 #: openforms/emails/models.py:71
 msgid "Subject of the email message when the form requires cosigning."
 msgstr ""
 "Onderwerp van de bevestigingsmail voor formulieren met mede-ondertekenen."
-
-#: openforms/emails/models.py:75 openforms/config/models/config.py:185
-msgid "cosign content"
-msgstr "inhoud bevestigingsmail met mede-ondertekenen"
 
 #: openforms/emails/models.py:78
 msgid ""
@@ -4015,13 +5417,13 @@ msgstr ""
 "De inhoud van de e-mail wanneer mede-ondertekenen nodig is. Je moet de "
 "speciale instructies '{% payment_information %}' en '{% cosign_information "
 "%}' opnemen. Daarnaast kan je de '{% confirmation_summary %}'-instructie "
-"gebruiken en zijn nog een aantal variabelen beschikbaar- zie de documentatie "
-"voor meer informatie."
+"gebruiken en zijn nog een aantal variabelen beschikbaar- zie de documentatie"
+" voor meer informatie."
 
 #: openforms/emails/models.py:97 openforms/forms/admin/form_logic.py:28
-#: openforms/forms/models/form.py:437
+#: openforms/forms/models/form.py:450
 #: openforms/forms/models/form_variable.py:249
-#: openforms/forms/models/form_version.py:46
+#: openforms/forms/models/form_version.py:68
 msgid "form"
 msgstr "formulier"
 
@@ -4057,8 +5459,8 @@ msgid ""
 "Use this form to send a test email to the supplied recipient and test the "
 "email backend configuration."
 msgstr ""
-"Gebruik dit formulier om een testbericht te versturen naar een opgegeven e-"
-"mailadres."
+"Gebruik dit formulier om een testbericht te versturen naar een opgegeven "
+"e-mailadres."
 
 #: openforms/emails/templates/admin/emails/connection_check.html:20
 msgid "Send test email"
@@ -4092,8 +5494,8 @@ msgstr "Registraties"
 #: openforms/emails/templates/emails/admin_digest.html:26
 #, python-format
 msgid ""
-"Form '%(form_name)s' failed %(counter)s time(s) between %(first_failure_at)s "
-"and %(last_failure_at)s.<br>"
+"Form '%(form_name)s' failed %(counter)s time(s) between %(first_failure_at)s"
+" and %(last_failure_at)s.<br>"
 msgstr ""
 "Formulier '%(form_name)s' faalde %(counter)s keer tussen "
 "%(first_failure_at)s en %(last_failure_at)s.</br>"
@@ -4116,11 +5518,6 @@ msgid ""
 msgstr ""
 "Tip: schakel uitgaande verzoekenlogging in om inzicht te krijgen in het "
 "netwerkverkeer."
-
-#: openforms/emails/templates/emails/admin_digest.html:46
-#: openforms/config/checks.py:83
-msgid "Prefill plugins"
-msgstr "Prefillplugins"
 
 #: openforms/emails/templates/emails/admin_digest.html:52
 #, python-format
@@ -4209,8 +5606,8 @@ msgid ""
 "We couldn't process logic rule %(index)s for '%(form_name)s' because it "
 "appears to be invalid. <br>"
 msgstr ""
-"Logicaregel %(index)s in formulier '%(form_name)s' lijkt ongeldig te zijn en "
-"kon daarom niet gecontroleerd worden. <br>"
+"Logicaregel %(index)s in formulier '%(form_name)s' lijkt ongeldig te zijn en"
+" kon daarom niet gecontroleerd worden. <br>"
 
 #: openforms/emails/templates/emails/admin_digest.html:145
 #, python-format
@@ -4241,10 +5638,8 @@ msgstr ""
 msgid ""
 "\n"
 "                        <p>\n"
-"                            Something went wrong while trying to retrieve "
-"data from service: %(service_label)s.\n"
-"                            This will probably affect the active forms which "
-"make use of this service and the user's experience.\n"
+"                            Something went wrong while trying to retrieve data from service: %(service_label)s.\n"
+"                            This will probably affect the active forms which make use of this service and the user's experience.\n"
 "                            See the error below:\n"
 "                        </p>\n"
 "                        <i>%(exc_message)s</i>\n"
@@ -4252,10 +5647,8 @@ msgid ""
 msgstr ""
 "\n"
 "<p>\n"
-"Er is iets foutgegaan bij het ophalen van de gegevens uit de servce:   "
-"%(service_label)s.\n"
-"Dit heeft waarschijnlijk invloed op de actieve formulieren die van deze "
-"service gebruikmaken en op de gebruikerservaring.\n"
+"Er is iets foutgegaan bij het ophalen van de gegevens uit de servce:   %(service_label)s.\n"
+"Dit heeft waarschijnlijk invloed op de actieve formulieren die van deze service gebruikmaken en op de gebruikerservaring.\n"
 "Zie de volgende foutmelding:\n"
 "</p>\n"
 "<i>%(exc_message)s</i>"
@@ -4317,8 +5710,8 @@ msgstr "Ongeldige componentinstellingen"
 #: openforms/emails/templates/emails/admin_digest.html:255
 #, python-format
 msgid ""
-"The configuration of %(component_type)s component '%(component_key)s' of the "
-"form '%(form_name)s' is invalid.<br> (%(message)s)<br>"
+"The configuration of %(component_type)s component '%(component_key)s' of the"
+" form '%(form_name)s' is invalid.<br> (%(message)s)<br>"
 msgstr ""
 "De instellingen van de \"%(component_type)s\"-component '%(component_key)s' "
 "in het formulier '%(form_name)s' zijn ongeldig.<br> (%(message)s)<br>"
@@ -4358,25 +5751,20 @@ msgid ""
 "<p>Dear reader,</p>\n"
 "\n"
 "<p>\n"
-"Someone submitted the form \"%(tt_openvariable)s form_name "
-"%(tt_closevariable)s\"\n"
-"via the website on %(tt_openvariable)s submission_date %(tt_closevariable)s. "
-"This\n"
+"Someone submitted the form \"%(tt_openvariable)s form_name %(tt_closevariable)s\"\n"
+"via the website on %(tt_openvariable)s submission_date %(tt_closevariable)s. This\n"
 "submission is not complete yet without your signature.\n"
 "</p>\n"
 "\n"
 "<h2>Cosigning required</h2>\n"
 "\n"
 "<p>\n"
-"With the link below you can log in and sign the form submission. Then, we "
-"will\n"
+"With the link below you can log in and sign the form submission. Then, we will\n"
 "process the request.\n"
 "</p>\n"
 "\n"
 "<p>\n"
-"<a href=\"%(tt_openvariable)s form_url "
-"%(tt_closevariable)s\">%(tt_openvariable)s form_url %(tt_closevariable)s</"
-"a>\n"
+"<a href=\"%(tt_openvariable)s form_url %(tt_closevariable)s\">%(tt_openvariable)s form_url %(tt_closevariable)s</a>\n"
 "</p>\n"
 "\n"
 "<p>Kind regards,</p>\n"
@@ -4387,25 +5775,20 @@ msgstr ""
 "<p>Beste lezer,</p>\n"
 "\n"
 "<p>\n"
-"Via de website heeft iemand het formulier \"%(tt_openvariable)s form_name "
-"%(tt_closevariable)s\"\n"
-"op %(tt_openvariable)s submission_date %(tt_closevariable)s ingediend. Deze "
-"is nog\n"
+"Via de website heeft iemand het formulier \"%(tt_openvariable)s form_name %(tt_closevariable)s\"\n"
+"op %(tt_openvariable)s submission_date %(tt_closevariable)s ingediend. Deze is nog\n"
 "niet compleet zonder je handtekening.\n"
 "</p>\n"
 "\n"
 "<h2>Medeondertekening nodig</h2>\n"
 "\n"
 "<p>\n"
-"Via deze link kun je inloggen om het formulier te ondertekenen. Daarna nemen "
-"wij de aanvraag \n"
+"Via deze link kun je inloggen om het formulier te ondertekenen. Daarna nemen wij de aanvraag \n"
 "in behandeling.\n"
 "</p>\n"
 "\n"
 "<p>\n"
-"<a href=\"%(tt_openvariable)s form_url "
-"%(tt_closevariable)s\">%(tt_openvariable)s form_url %(tt_closevariable)s</"
-"a>\n"
+"<a href=\"%(tt_openvariable)s form_url %(tt_closevariable)s\">%(tt_openvariable)s form_url %(tt_closevariable)s</a>\n"
 "</p>\n"
 "\n"
 "<p>Met vriendelijke groet,</p>\n"
@@ -4418,12 +5801,9 @@ msgid ""
 "\n"
 "Dear Sir, Madam,<br>\n"
 "<br>\n"
-"You have submitted the form \"%(tt_openvariable)s form_name "
-"%(tt_closevariable)s\" on %(tt_openvariable)s submission_date "
-"%(tt_closevariable)s.<br>\n"
+"You have submitted the form \"%(tt_openvariable)s form_name %(tt_closevariable)s\" on %(tt_openvariable)s submission_date %(tt_closevariable)s.<br>\n"
 "<br>\n"
-"Your reference is: %(tt_openvariable)s public_reference "
-"%(tt_closevariable)s<br>\n"
+"Your reference is: %(tt_openvariable)s public_reference %(tt_closevariable)s<br>\n"
 "<br>\n"
 "\n"
 "%(tt_openblock)s confirmation_summary %(tt_closeblock)s<br>\n"
@@ -4438,12 +5818,9 @@ msgstr ""
 "\n"
 "Geachte heer/mevrouw,<br>\n"
 "<br>\n"
-"U heeft via de website het formulier \\\"%(tt_openvariable)s form_name "
-"%(tt_closevariable)s\\\" verzonden op %(tt_openvariable)s submission_date "
-"%(tt_closevariable)s.<br>\n"
+"U heeft via de website het formulier \\\"%(tt_openvariable)s form_name %(tt_closevariable)s\\\" verzonden op %(tt_openvariable)s submission_date %(tt_closevariable)s.<br>\n"
 "<br>\n"
-"Uw referentienummer is: %(tt_openvariable)s public_reference "
-"%(tt_closevariable)s<br>\n"
+"Uw referentienummer is: %(tt_openvariable)s public_reference %(tt_closevariable)s<br>\n"
 "<br>\n"
 "\n"
 "%(tt_openblock)s confirmation_summary %(tt_closeblock)s<br>\n"
@@ -4461,10 +5838,8 @@ msgid ""
 "\n"
 "Dear reader,<br>\n"
 "<br>\n"
-"You submitted the form \"%(tt_openvariable)s form_name "
-"%(tt_closevariable)s\"\n"
-"via the website on %(tt_openvariable)s submission_date %(tt_closevariable)s."
-"<br>\n"
+"You submitted the form \"%(tt_openvariable)s form_name %(tt_closevariable)s\"\n"
+"via the website on %(tt_openvariable)s submission_date %(tt_closevariable)s.<br>\n"
 "<br>\n"
 "\n"
 "%(tt_openblock)s if registration_completed %(tt_closeblock)s<br>\n"
@@ -4479,8 +5854,7 @@ msgid ""
 "    %(tt_openblock)s endif %(tt_closeblock)s<br>\n"
 "%(tt_openblock)s endif %(tt_closeblock)s<br>\n"
 "\n"
-"Your reference is: %(tt_openvariable)s public_reference "
-"%(tt_closevariable)s<br>\n"
+"Your reference is: %(tt_openvariable)s public_reference %(tt_closevariable)s<br>\n"
 "<br>\n"
 "\n"
 "%(tt_openblock)s confirmation_summary %(tt_closeblock)s<br>\n"
@@ -4494,9 +5868,7 @@ msgstr ""
 "\n"
 "Beste lezer,<br>\n"
 "<br>\n"
-"U heeft via de website het formulier \"%(tt_openvariable)s form_name "
-"%(tt_closevariable)s\" verzonden op %(tt_openvariable)s submission_date "
-"%(tt_closevariable)s.<br>\n"
+"U heeft via de website het formulier \"%(tt_openvariable)s form_name %(tt_closevariable)s\" verzonden op %(tt_openvariable)s submission_date %(tt_closevariable)s.<br>\n"
 "<br>\n"
 "\n"
 "%(tt_openblock)s if registration_completed %(tt_closeblock)s<br>\n"
@@ -4511,8 +5883,7 @@ msgstr ""
 "%(tt_openblock)s endif %(tt_closeblock)s<br>\n"
 "%(tt_openblock)s endif %(tt_closeblock)s<br>\n"
 "\n"
-"Uw referentienummer is: %(tt_openvariable)s public_reference "
-"%(tt_closevariable)s<br>\n"
+"Uw referentienummer is: %(tt_openvariable)s public_reference %(tt_closevariable)s<br>\n"
 "<br>\n"
 "\n"
 "%(tt_openblock)s confirmation_summary %(tt_closeblock)s<br>\n"
@@ -4538,26 +5909,22 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"<p>This email address requires verification for the \"%(tt_openvariable)s "
-"form_name %(tt_closevariable)s\" form.</p>\n"
+"<p>This email address requires verification for the \"%(tt_openvariable)s form_name %(tt_closevariable)s\" form.</p>\n"
 "\n"
 "<p>Enter the code below to confirm your email address:</p>\n"
 "\n"
 "<p><strong>%(tt_openvariable)s code %(tt_closevariable)s</strong></p>\n"
 "\n"
-"<p>If you did not request this verification, you can safely ignore this "
-"email.</p>\n"
+"<p>If you did not request this verification, you can safely ignore this email.</p>\n"
 msgstr ""
 "\n"
-"<p>Dit e-mailadres moet gecontroleerd worden voor het \"%(tt_openvariable)s "
-"form_name %(tt_closevariable)s\"-formulier.</p>\n"
+"<p>Dit e-mailadres moet gecontroleerd worden voor het \"%(tt_openvariable)s form_name %(tt_closevariable)s\"-formulier.</p>\n"
 "\n"
 "<p>Voer de code die hieronder staat in om je e-mailadres te bevestigen:</p>\n"
 "\n"
 "<p><strong>%(tt_openvariable)s code %(tt_closevariable)s</strong></p>\n"
 "\n"
-"<p>Als je niet zelf deze controle gestart bent, dan kan je deze e-mail "
-"negeren.</p>\n"
+"<p>Als je niet zelf deze controle gestart bent, dan kan je deze e-mail negeren.</p>\n"
 
 #: openforms/emails/templates/emails/email_verification/subject.txt:1
 #, python-format
@@ -4575,15 +5942,11 @@ msgid ""
 "\n"
 "Dear Sir or Madam,<br>\n"
 "<br>\n"
-"You have stored the form \"%(tt_openvariable)s form_name "
-"%(tt_closevariable)s\" via the website on %(tt_openvariable)s save_date "
-"%(tt_closevariable)s.\n"
+"You have stored the form \"%(tt_openvariable)s form_name %(tt_closevariable)s\" via the website on %(tt_openvariable)s save_date %(tt_closevariable)s.\n"
 "You can resume this form at a later time by clicking the link below.<br>\n"
-"The link is valid up to and including %(tt_openvariable)s expiration_date "
-"%(tt_closevariable)s.<br>\n"
+"The link is valid up to and including %(tt_openvariable)s expiration_date %(tt_closevariable)s.<br>\n"
 "<br>\n"
-"<a href=\"%(tt_openvariable)s continue_url %(tt_closevariable)s\">Resume "
-"form \"%(tt_openvariable)s form_name %(tt_closevariable)s\".</a><br>\n"
+"<a href=\"%(tt_openvariable)s continue_url %(tt_closevariable)s\">Resume form \"%(tt_openvariable)s form_name %(tt_closevariable)s\".</a><br>\n"
 "<br>\n"
 "Kind regards,<br>\n"
 "<br>\n"
@@ -4591,24 +5954,14 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"Geachte heer/mevrouw,<br><br>U heeft via de website het formulier "
-"\"%(tt_openvariable)s form_name %(tt_closevariable)s\" tussentijds "
-"opgeslagen op %(tt_openvariable)s save_date %(tt_closevariable)s. U kunt dit "
-"formulier op een later moment hervatten door op onderstaande link te klikken."
-"<br>Onderstaande link is geldig tot en met %(tt_openvariable)s "
-"expiration_date %(tt_closevariable)s.<br><br><a href=\"%(tt_openvariable)s "
-"continue_url %(tt_closevariable)s\">Verder gaan met formulier "
-"\"%(tt_openvariable)s form_name %(tt_closevariable)s\".</a><br><br>Met "
-"vriendelijke groet,<br><br>Open Formulieren\n"
+"Geachte heer/mevrouw,<br><br>U heeft via de website het formulier \"%(tt_openvariable)s form_name %(tt_closevariable)s\" tussentijds opgeslagen op %(tt_openvariable)s save_date %(tt_closevariable)s. U kunt dit formulier op een later moment hervatten door op onderstaande link te klikken.<br>Onderstaande link is geldig tot en met %(tt_openvariable)s expiration_date %(tt_closevariable)s.<br><br><a href=\"%(tt_openvariable)s continue_url %(tt_closevariable)s\">Verder gaan met formulier \"%(tt_openvariable)s form_name %(tt_closevariable)s\".</a><br><br>Met vriendelijke groet,<br><br>Open Formulieren\n"
 
 #: openforms/emails/templates/emails/save_form/save_form.txt:1
 #, python-format
 msgid ""
 "Dear Sir or Madam,\n"
 "\n"
-"You have stored the form \"%(form_name)s\" via the website on "
-"%(formatted_save_date)s. You can resume this form at a later time by "
-"clicking the link below.\n"
+"You have stored the form \"%(form_name)s\" via the website on %(formatted_save_date)s. You can resume this form at a later time by clicking the link below.\n"
 "The link is valid up to and including %(formatted_expiration_date)s.\n"
 "\n"
 "Resume form: %(continue_url)s\n"
@@ -4619,10 +5972,7 @@ msgid ""
 msgstr ""
 "Geachte heer/mevrouw,\n"
 "\n"
-"U heeft via de website het formulier \"%(form_name)s\" tussentijds "
-"opgeslagen op %(formatted_save_date)s. U kunt dit formulier op een later "
-"moment hervatten door op onderstaande link te klikken.Onderstaande link is "
-"geldig tot en met %(formatted_expiration_date)s.\n"
+"U heeft via de website het formulier \"%(form_name)s\" tussentijds opgeslagen op %(formatted_save_date)s. U kunt dit formulier op een later moment hervatten door op onderstaande link te klikken.Onderstaande link is geldig tot en met %(formatted_expiration_date)s.\n"
 "\n"
 "Verder gaan met formulier: %(continue_url)s\n"
 "\n"
@@ -4645,8 +5995,8 @@ msgid ""
 "If you wish to change your appointment, please cancel it using the link "
 "below and create a new one."
 msgstr ""
-"Indien je jouw afspraak wenst te wijzingen, dan kan je deze annuleren en een "
-"nieuwe aanmaken."
+"Indien je jouw afspraak wenst te wijzingen, dan kan je deze annuleren en een"
+" nieuwe aanmaken."
 
 #: openforms/emails/templates/emails/templatetags/appointment_information.html:62
 #: openforms/emails/templates/emails/templatetags/appointment_information.txt:25
@@ -4731,8 +6081,8 @@ msgid ""
 "Payment of &euro; %(payment_price)s is required. You can pay using the link "
 "below."
 msgstr ""
-"Betaling van &euro;%(payment_price)s vereist. U kunt het bedrag betalen door "
-"op onderstaande link te klikken."
+"Betaling van &euro;%(payment_price)s vereist. U kunt het bedrag betalen door"
+" op onderstaande link te klikken."
 
 #: openforms/emails/templates/emails/templatetags/payment_information.html:15
 #: openforms/emails/templates/emails/templatetags/payment_information.txt:8
@@ -4818,7 +6168,8 @@ msgid "The provided file is not a {file_type}."
 msgstr "Het bestand is geen {file_type}."
 
 #: openforms/formio/api/validators.py:174
-msgid "The virus scan could not be performed at this time. Please retry later."
+msgid ""
+"The virus scan could not be performed at this time. Please retry later."
 msgstr ""
 "Het is momenteel niet mogelijk om bestanden te scannen op virussen. Probeer "
 "het later opnieuw."
@@ -4846,29 +6197,19 @@ msgstr "Maak tijdelijk bestand aan"
 msgid ""
 "File upload handler for the Form.io file upload \"url\" storage type.\n"
 "\n"
-"The uploads are stored temporarily and have to be claimed by the form "
-"submission using the returned JSON data. \n"
+"The uploads are stored temporarily and have to be claimed by the form submission using the returned JSON data. \n"
 "\n"
-"Access to this view requires an active form submission. Unclaimed temporary "
-"files automatically expire after {expire_days} day(s). \n"
+"Access to this view requires an active form submission. Unclaimed temporary files automatically expire after {expire_days} day(s). \n"
 "\n"
-"The maximum upload size for this instance is `{max_upload_size}`. Note that "
-"this includes the multipart metadata and boundaries, so the actual maximum "
-"file upload size is slightly smaller."
+"The maximum upload size for this instance is `{max_upload_size}`. Note that this includes the multipart metadata and boundaries, so the actual maximum file upload size is slightly smaller."
 msgstr ""
 "Bestandsuploadhandler voor het Form.io bestandsupload opslagtype 'url'.\n"
 "\n"
-"Bestandsuploads worden tijdelijke opgeslagen en moeten gekoppeld worden aan "
-"een inzending.\n"
+"Bestandsuploads worden tijdelijke opgeslagen en moeten gekoppeld worden aan een inzending.\n"
 "\n"
-"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet "
-"gekoppelde bestanden worden automatisch verwijderd na {expire_days} "
-"dag(en).\n"
+"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en).\n"
 "\n"
-"De maximale toegestane upload-bestandsgrootte is `{max_upload_size}` voor "
-"deze instantie. Merk op dat dit inclusief multipart-metadata en boundaries "
-"is. De daadwerkelijke maximale bestandsgrootte is dus iets lager dan deze "
-"waarde."
+"De maximale toegestane upload-bestandsgrootte is `{max_upload_size}` voor deze instantie. Merk op dat dit inclusief multipart-metadata en boundaries is. De daadwerkelijke maximale bestandsgrootte is dus iets lager dan deze waarde."
 
 #: openforms/formio/apps.py:7
 msgid "Formio integration"
@@ -4977,7 +6318,8 @@ msgid "selected"
 msgstr "geselecteerd"
 
 #: openforms/formio/components/custom.py:913
-msgid "Whether the child is selected by the user or not for further processing"
+msgid ""
+"Whether the child is selected by the user or not for further processing"
 msgstr ""
 "Ongeacht of het kind is geselecteerd door de gebruiker voor verdere "
 "behandeling"
@@ -4989,7 +6331,8 @@ msgstr "Incorrecte data."
 #: openforms/formio/components/custom.py:1197
 #, python-brace-format
 msgid "You cannot submit multiple digital addresses for the type '{type}'."
-msgstr "Je kan niet meerdere digitale adressen van het type '{type}' insturen."
+msgstr ""
+"Je kan niet meerdere digitale adressen van het type '{type}' insturen."
 
 #: openforms/formio/components/custom.py:1208
 msgid "The digital address value."
@@ -5037,10 +6380,11 @@ msgstr "De waarde ligt niet tussen de minimale en maximale tijd."
 
 #: openforms/formio/components/vanilla.py:439
 #, python-brace-format
-msgid "The value of {root_key} must match the value of {nested_key} in 'data'."
+msgid ""
+"The value of {root_key} must match the value of {nested_key} in 'data'."
 msgstr ""
-"De waarde van {root_key} moet overeenkomen met de waarde van {nested_key} in "
-"'data'."
+"De waarde van {root_key} moet overeenkomen met de waarde van {nested_key} in"
+" 'data'."
 
 #: openforms/formio/components/vanilla.py:448
 #: openforms/formio/components/vanilla.py:461
@@ -5114,8 +6458,8 @@ msgid ""
 "The dynamic options obtained with expression {items_expression} contain non-"
 "primitive types."
 msgstr ""
-"De dynamische keuzelijstopties verkregen met de expressie {items_expression} "
-"bevatten niet-primitieve typen (zoals objecten of arrays)."
+"De dynamische keuzelijstopties verkregen met de expressie {items_expression}"
+" bevatten niet-primitieve typen (zoals objecten of arrays)."
 
 #: openforms/formio/dynamic_config/dynamic_options.py:115
 msgid "Could not retrieve options from Referentielijsten API."
@@ -5125,14 +6469,14 @@ msgstr "Kon geen beschikbare opties ophalen van Referentielijsten API."
 msgid ""
 "Cannot fetch from ReferenceLists API, because no `service` is configured."
 msgstr ""
-"Kan geen gegevens ophalen van referentielijsten-API, omdat er geen `service` "
-"is geconfigureerd."
+"Kan geen gegevens ophalen van referentielijsten-API, omdat er geen `service`"
+" is geconfigureerd."
 
 #: openforms/formio/dynamic_config/reference_lists.py:37
 msgid "Cannot fetch from ReferenceLists API, because no `code` is configured."
 msgstr ""
-"Kan geen gegevens ophalen van referentielijsten-API, omdat er geen `code` is "
-"geconfigureerd."
+"Kan geen gegevens ophalen van referentielijsten-API, omdat er geen `code` is"
+" geconfigureerd."
 
 #: openforms/formio/dynamic_config/reference_lists.py:48
 #, python-brace-format
@@ -5145,7 +6489,8 @@ msgstr ""
 
 #: openforms/formio/dynamic_config/reference_lists.py:68
 #, python-brace-format
-msgid "Exception occurred while fetching from ReferenceLists API: {exception}."
+msgid ""
+"Exception occurred while fetching from ReferenceLists API: {exception}."
 msgstr ""
 "Er deed zich een fout voor tijdens het ophalen van gegevens uit de "
 "referentielijsten-API: {exception}."
@@ -5238,112 +6583,105 @@ msgstr "De waarde van 'components' moet een lijst van componenten zijn."
 msgid "form count"
 msgstr "aantal formulieren"
 
-#: openforms/forms/admin/category.py:37 openforms/forms/admin/form.py:261
-#: openforms/forms/api/serializers/logic/form_logic.py:132
-#: openforms/submissions/api/serializers.py:244
-#: openforms/config/templates/admin/config/overview.html:25
-msgid "Actions"
-msgstr "Acties"
-
 #: openforms/forms/admin/category.py:41
 msgid "Show forms"
 msgstr "Toon formulieren"
 
-#: openforms/forms/admin/form.py:51
+#: openforms/forms/admin/form.py:54
 msgid "has reached submission limit"
 msgstr "status inzendingslimiet"
 
-#: openforms/forms/admin/form.py:56
+#: openforms/forms/admin/form.py:59
 msgid "Available for submission"
 msgstr "Accepteert nieuwe inzendingen"
 
-#: openforms/forms/admin/form.py:57
+#: openforms/forms/admin/form.py:60
 msgid "Unavailable for submission"
 msgstr "Limiet bereikt"
 
-#: openforms/forms/admin/form.py:75
+#: openforms/forms/admin/form.py:78
 msgid "is deleted"
 msgstr "is verwijderd"
 
-#: openforms/forms/admin/form.py:103
+#: openforms/forms/admin/form.py:106
 msgid "Available forms"
 msgstr "Beschikbare formulieren"
 
-#: openforms/forms/admin/form.py:110
+#: openforms/forms/admin/form.py:113
 msgid "Deleted forms"
 msgstr "Verwijderde formulieren"
 
-#: openforms/forms/admin/form.py:265
+#: openforms/forms/admin/form.py:268
 msgid "Show form"
 msgstr "Toon formulier"
 
-#: openforms/forms/admin/form.py:272
+#: openforms/forms/admin/form.py:275
 msgid "Live"
 msgstr "Live"
 
-#: openforms/forms/admin/form.py:296
+#: openforms/forms/admin/form.py:299
 #, python-brace-format
 msgid "{} {} was successfully copied"
 msgstr "{} {} is met succes gekopieerd"
 
-#: openforms/forms/admin/form.py:315
+#: openforms/forms/admin/form.py:334
 #, python-brace-format
 msgid "{} {} was successfully exported"
 msgstr "{} {} is met succes geëxporteerd"
 
-#: openforms/forms/admin/form.py:338
+#: openforms/forms/admin/form.py:357
 #: openforms/forms/admin/form_definition.py:82
 #, python-format
 msgid "Copy selected %(verbose_name_plural)s"
 msgstr "Kopieer geselecteerde %(verbose_name_plural)s"
 
-#: openforms/forms/admin/form.py:346
+#: openforms/forms/admin/form.py:365
 #, python-brace-format
 msgid "Copied {count} {verbose_name} object."
 msgid_plural "Copied {count} {verbose_name} objects."
 msgstr[0] "{count} {verbose_name} object gekopieerd"
 msgstr[1] "{count} {verbose_name}objecten gekopieerd"
 
-#: openforms/forms/admin/form.py:356
+#: openforms/forms/admin/form.py:375
 #, python-format
 msgid "Set selected %(verbose_name_plural)s to maintenance mode"
 msgstr ""
 "Schakel de onderhoudsmodus in voor geselecteerde %(verbose_name_plural)s"
 
-#: openforms/forms/admin/form.py:363
+#: openforms/forms/admin/form.py:382
 #, python-brace-format
 msgid "Set {count} {verbose_name} object to maintenance mode"
 msgid_plural "Set {count} {verbose_name} objects to maintenance mode"
 msgstr[0] "Onderhoudsmodus aangezet voor {count} {verbose_name} object "
 msgstr[1] "Onderhoudsmodus aangezet voor {count} {verbose_name} objecten"
 
-#: openforms/forms/admin/form.py:372
+#: openforms/forms/admin/form.py:391
 #, python-format
 msgid "Remove %(verbose_name_plural)s from maintenance mode"
 msgstr ""
 "Schakel de onderhoudsmodus uit voor geselecteerde %(verbose_name_plural)s."
 
-#: openforms/forms/admin/form.py:378
+#: openforms/forms/admin/form.py:397
 #, python-brace-format
 msgid "Removed {count} {verbose_name} object from maintenance mode"
 msgid_plural "Removed {count} {verbose_name} objects from maintenance mode"
 msgstr[0] "Onderhoudsmodus uitgezet voor {count} {verbose_name} object"
 msgstr[1] "Onderhoudsmodus uitgezet voor {count} {verbose_name} objecten"
 
-#: openforms/forms/admin/form.py:427
-#: openforms/forms/templates/admin/forms/form/export.html:14
-#: openforms/forms/templates/admin/forms/form/export.html:18
-#: openforms/forms/templates/admin/forms/form/export.html:21
+#: openforms/forms/admin/form.py:446
+#: openforms/forms/templates/admin/forms/form/export.html:15
+#: openforms/forms/templates/admin/forms/form/export.html:19
+#: openforms/forms/templates/admin/forms/form/export.html:22
 msgid "Export forms"
 msgstr "Formulieren exporteren"
 
-#: openforms/forms/admin/form.py:433
+#: openforms/forms/admin/form.py:452
 msgid ""
 "Please configure your email address in your admin profile before requesting "
 "a bulk export"
 msgstr ""
-"Gelieve eerst uw e-mailadres in te stellen in uw gebruikersaccount voordat u "
-"een bulk-export doet."
+"Gelieve eerst uw e-mailadres in te stellen in uw gebruikersaccount voordat u"
+" een bulk-export doet."
 
 #: openforms/forms/admin/form_definition.py:25
 #, python-brace-format
@@ -5369,28 +6707,61 @@ msgstr "ingezonden tussen"
 msgid "Red"
 msgstr "Rood"
 
-#: openforms/forms/admin/tasks.py:70
+#: openforms/forms/admin/tasks.py:78
 msgid "Forms export ready"
 msgstr "Export formulieren gereed"
 
-#: openforms/forms/admin/views.py:39
+#: openforms/forms/admin/views.py:41
+msgid "Anonymize form configuration"
+msgstr "Formulierinstellingen anonimiseren"
+
+#: openforms/forms/admin/views.py:45
+#: openforms/forms/api/serializers/form.py:701
+msgid ""
+"Whether sensative form configuration should be anonymized during exporting."
+msgstr "Anonimiseer gevoelige formulierinstellingen bij het exporteren."
+
+#: openforms/forms/admin/views.py:49
+msgid "Form configuration"
+msgstr "Formulierinstellingen"
+
+#: openforms/forms/admin/views.py:60
+#: openforms/forms/api/serializers/form.py:708
+msgid ""
+"Which form configuration should be included in the export file content."
+msgstr "Welke formulierinstellingen meegenomen worden bij het exporteren."
+
+#: openforms/forms/admin/views.py:64
+msgid "Additional form configuration"
+msgstr "Aanvullende formulierinstellingen"
+
+#: openforms/forms/admin/views.py:69
+#: openforms/forms/api/serializers/form.py:715
+msgid ""
+"Which additional form configuration should be included in the export file "
+"content."
+msgstr ""
+"Welke aanvullende formulierinstellingen meegenomen worden bij het "
+"exporteren."
+
+#: openforms/forms/admin/views.py:75
 msgid "Invalid form uuids."
 msgstr "Ongeldige formulier-IDs."
 
-#: openforms/forms/admin/views.py:52
+#: openforms/forms/admin/views.py:88
 msgid "Success! You will receive an email when your export is ready."
 msgstr "Gelukt! U ontvangt een e-mail zodra de export gereed is."
 
-#: openforms/forms/admin/views.py:98
+#: openforms/forms/admin/views.py:143
 #, python-brace-format
 msgid "Something went wrong while importing form: {}"
 msgstr "Er is iets foutgegaan bij het importeren van formulier: {}"
 
-#: openforms/forms/admin/views.py:111
+#: openforms/forms/admin/views.py:156
 msgid "Form successfully imported!"
 msgstr "Formulier is succesvol geïmporteerd"
 
-#: openforms/forms/admin/views.py:113
+#: openforms/forms/admin/views.py:158
 msgid ""
 "The bulk import is being processed! The imported forms will soon be "
 "available."
@@ -5403,7 +6774,7 @@ msgid "UUID of the form the definition is used in."
 msgstr "UUID van het formulier waarin de definitie gebruikt wordt."
 
 #: openforms/forms/api/public_api/views.py:17
-#: openforms/forms/api/viewsets.py:228
+#: openforms/forms/api/viewsets.py:231
 msgid "List forms"
 msgstr "Formulieren weergeven"
 
@@ -5416,21 +6787,49 @@ msgstr ""
 "informatie. Formulieren die als \"verwijderd\" gemarkeerd zijn, komen niet "
 "terug."
 
-#: openforms/forms/api/serializers/form.py:70
+#: openforms/forms/api/serializers/form.py:78
 #: openforms/forms/models/form_authentication_backend.py:21
 msgid "authentication backend options"
 msgstr "authenticatie-backend-instellingen"
 
-#: openforms/forms/api/serializers/form.py:95
+#: openforms/forms/api/serializers/form.py:103
 #: openforms/forms/models/form_registration_backend.py:29
 msgid "registration backend options"
 msgstr "registratie backend opties"
 
+#: openforms/forms/api/serializers/form.py:146
+msgid "Help callout page display"
+msgstr ""
+
+#: openforms/forms/api/serializers/form.py:147
+#| msgid "The display label of the catalogue"
+msgid "When to display the help callout page."
+msgstr ""
+
 #: openforms/forms/api/serializers/form.py:152
+#| msgid "export content"
+msgid "Help callout page content"
+msgstr ""
+
+#: openforms/forms/api/serializers/form.py:154
+msgid ""
+"Content for the help callout page, fetched from the global configuration."
+msgstr ""
+
+#: openforms/forms/api/serializers/form.py:160
+msgid "Help callout page image"
+msgstr ""
+
+#: openforms/forms/api/serializers/form.py:162
+msgid ""
+"Image for the help callout page, fetched from the global configuration."
+msgstr ""
+
+#: openforms/forms/api/serializers/form.py:185
 msgid "cosign request has links in email"
 msgstr "mede-ondertekenenverzoek-e-mail bevat links"
 
-#: openforms/forms/api/serializers/form.py:154
+#: openforms/forms/api/serializers/form.py:187
 msgid ""
 "Indicates whether deep links are included in the cosign request emails or "
 "not."
@@ -5438,7 +6837,7 @@ msgstr ""
 "Geeft aan of er links gebruikt worden in de e-mail voor mede-"
 "ondertekenverzoek."
 
-#: openforms/forms/api/serializers/form.py:162
+#: openforms/forms/api/serializers/form.py:195
 msgid ""
 "The authentication backend to which the user will be automatically "
 "redirected upon starting the form. The chosen backend must be present in "
@@ -5448,100 +6847,95 @@ msgstr ""
 "bij het starten van het formulier. De gekozen plugin moet aanwezig zijn in "
 "`auth_backends`"
 
-#: openforms/forms/api/serializers/form.py:169
+#: openforms/forms/api/serializers/form.py:202
 #: openforms/forms/models/category.py:19
 msgid "category"
 msgstr "categorie"
 
-#: openforms/forms/api/serializers/form.py:175
+#: openforms/forms/api/serializers/form.py:208
 msgid "URL to the category in the Open Forms API"
 msgstr "URL naar de formuliercategorie in de Open Forms API"
 
-#: openforms/forms/api/serializers/form.py:178
-#: openforms/config/models/theme.py:156
-msgid "theme"
-msgstr "stijl"
-
-#: openforms/forms/api/serializers/form.py:184
+#: openforms/forms/api/serializers/form.py:217
 msgid "URL to the theme in the Open Forms API"
 msgstr "URL naar de stijl in de Open Forms API"
 
-#: openforms/forms/api/serializers/form.py:187
+#: openforms/forms/api/serializers/form.py:220
 msgid "product"
 msgstr "product"
 
-#: openforms/forms/api/serializers/form.py:193
+#: openforms/forms/api/serializers/form.py:226
 msgid "URL to the product in the Open Forms API"
 msgstr "URL van het product in de Open Formulieren API"
 
-#: openforms/forms/api/serializers/form.py:201
-#: openforms/forms/models/form.py:133
+#: openforms/forms/api/serializers/form.py:234
+#: openforms/forms/models/form.py:134
 msgid "payment backend options"
 msgstr "betaalprovider backend opties"
 
-#: openforms/forms/api/serializers/form.py:223
+#: openforms/forms/api/serializers/form.py:256
 msgid "Resume link lifetime"
 msgstr "Geldigheidsduur \"formulier hervatten\"-link"
 
-#: openforms/forms/api/serializers/form.py:225
+#: openforms/forms/api/serializers/form.py:258
 msgid "The number of days that the resume link is valid for."
 msgstr "Het aantal dagen dat de link geldig blijft."
 
-#: openforms/forms/api/serializers/form.py:233
+#: openforms/forms/api/serializers/form.py:266
 msgid "submission statements configuration"
 msgstr "Verklaringenconfiguratie voor inzending"
 
-#: openforms/forms/api/serializers/form.py:235
+#: openforms/forms/api/serializers/form.py:268
 msgid ""
 "A list of statements that need to be accepted by the user before they can "
 "submit a form. Returns a list of formio component definitions, all of type "
 "'checkbox'."
 msgstr ""
-"Een lijst van verklaringen die de gebruiker moet accepteren om het formulier "
-"te kunnen inzenden. Deze worden teruggegeven als lijst van Form.io-"
+"Een lijst van verklaringen die de gebruiker moet accepteren om het formulier"
+" te kunnen inzenden. Deze worden teruggegeven als lijst van Form.io-"
 "componentdefinities, allemaal van het type 'checkbox'."
 
-#: openforms/forms/api/serializers/form.py:570
+#: openforms/forms/api/serializers/form.py:609
 msgid ""
-"The `auto_login_authentication_backend` must be one of the selected backends "
-"from `auth_backends`"
+"The `auto_login_authentication_backend` must be one of the selected backends"
+" from `auth_backends`"
 msgstr ""
 "De `auto_login_authentication_backend` moet één van de backends uit "
 "`auth_backends` zijn."
 
-#: openforms/forms/api/serializers/form.py:671
+#: openforms/forms/api/serializers/form.py:722
 msgid "The file that contains the form, form definitions and form steps."
 msgstr ""
-"Het bestand dat het formulier, de formulierdefinities en de formulierstappen "
-"bevat."
+"Het bestand dat het formulier, de formulierdefinities en de formulierstappen"
+" bevat."
 
-#: openforms/forms/api/serializers/form.py:676
+#: openforms/forms/api/serializers/form.py:727
 msgid "The uuid of the imported form."
 msgstr "ID van het geïmporteerde formulier."
 
-#: openforms/forms/api/serializers/form.py:681
+#: openforms/forms/api/serializers/form.py:732
 msgid "Registration backend key"
 msgstr "Registratiebackend-sleutel"
 
-#: openforms/forms/api/serializers/form.py:683
+#: openforms/forms/api/serializers/form.py:734
 msgid "The registration backend key for which to generate the schema."
 msgstr ""
 "De registratiebackend-sleutel waarvoor het schema moet worden gegenereerd."
 
-#: openforms/forms/api/serializers/form.py:688
+#: openforms/forms/api/serializers/form.py:739
 msgid "Registration backend identifier"
 msgstr "Registratiebackend-identificatie"
 
-#: openforms/forms/api/serializers/form.py:693
+#: openforms/forms/api/serializers/form.py:744
 msgid "Registration backend options"
 msgstr "Registratiebackend-instellingen"
 
-#: openforms/forms/api/serializers/form.py:705
+#: openforms/forms/api/serializers/form.py:756
 #, python-brace-format
 msgid "Backend with key '{key}' does not exist for form '{form}'"
 msgstr "Backend met sleutel '{key}' bestaat niet voor formulier '{form}'"
 
-#: openforms/forms/api/serializers/form.py:722
+#: openforms/forms/api/serializers/form.py:773
 #, python-brace-format
 msgid "Backend with id '{backend}' does not allow JSON schema generation"
 msgstr ""
@@ -5587,23 +6981,23 @@ msgstr "admin URL"
 msgid "Link to the change/view page in the admin interface"
 msgstr "Link naar de wijzigen/weergave pagina in de beheeromgeving"
 
-#: openforms/forms/api/serializers/form_definition.py:71
+#: openforms/forms/api/serializers/form_definition.py:72
 #: openforms/forms/api/v3/serializers/form_definition.py:29
 #: openforms/forms/models/form_definition.py:49
 msgid "Form.io configuration"
 msgstr "Form.io configuratie"
 
-#: openforms/forms/api/serializers/form_definition.py:72
+#: openforms/forms/api/serializers/form_definition.py:73
 #: openforms/forms/api/v3/serializers/form_definition.py:30
 #: openforms/forms/models/form_definition.py:50
 msgid "The form definition as Form.io JSON schema"
 msgstr "De formulierdefinitie als Form.io JSON schema"
 
-#: openforms/forms/api/serializers/form_definition.py:163
+#: openforms/forms/api/serializers/form_definition.py:162
 msgid "Used in forms"
 msgstr "Gebruikt in formulieren"
 
-#: openforms/forms/api/serializers/form_definition.py:165
+#: openforms/forms/api/serializers/form_definition.py:164
 msgid ""
 "The collection of forms making use of this definition. This includes both "
 "active and inactive forms."
@@ -5625,7 +7019,7 @@ msgstr ""
 "{static_data}."
 
 #: openforms/forms/api/serializers/form_variable.py:117
-#: openforms/forms/api/v3/serializers/form.py:443
+#: openforms/forms/api/v3/serializers/form.py:449
 msgid ""
 "This profile form variable is already used in another communication "
 "preferences prefill plugin."
@@ -5648,7 +7042,7 @@ msgstr ""
 "sleutel in de formulierdefinitie."
 
 #: openforms/forms/api/serializers/form_variable.py:252
-#: openforms/forms/api/v3/serializers/form.py:462
+#: openforms/forms/api/v3/serializers/form.py:468
 msgid ""
 "Prefill plugin, attribute and options can not be specified at the same time."
 msgstr ""
@@ -5662,7 +7056,7 @@ msgstr ""
 "afgeleid zijn."
 
 #: openforms/forms/api/serializers/form_variable.py:272
-#: openforms/forms/api/v3/serializers/form.py:473
+#: openforms/forms/api/v3/serializers/form.py:479
 msgid ""
 "Prefill plugin must be specified with either prefill attribute or prefill "
 "options."
@@ -5690,8 +7084,8 @@ msgstr "waarde van het attribuut"
 
 #: openforms/forms/api/serializers/logic/action_serializers.py:49
 msgid ""
-"Valid JSON determining the new value of the specified property. For example: "
-"`true` or `false`."
+"Valid JSON determining the new value of the specified property. For example:"
+" `true` or `false`."
 msgstr ""
 "De JSON die de nieuwe waarde van het gespecificeerde attribuut bepaald. "
 "Bijvoorbeeld: `true` of `false`."
@@ -5703,8 +7097,8 @@ msgstr "Waarde"
 
 #: openforms/forms/api/serializers/logic/action_serializers.py:66
 msgid ""
-"A valid JsonLogic expression describing the value. This may refer to (other) "
-"Form.io components."
+"A valid JsonLogic expression describing the value. This may refer to (other)"
+" Form.io components."
 msgstr ""
 "Een JSON-logic expressie die de waarde beschrijft. Deze mag naar (andere) "
 "Form.io componenten verwijzen."
@@ -5794,8 +7188,8 @@ msgid ""
 "Key of the Form.io component that the action applies to. This field is "
 "required for the action types {action_types} - otherwise it's optional."
 msgstr ""
-"Sleutel van de Form.io-component waarop de actie van toepassing is. Dit veld "
-"is verplicht voor de actietypes {action_types} - anders is het optioneel. "
+"Sleutel van de Form.io-component waarop de actie van toepassing is. Dit veld"
+" is verplicht voor de actietypes {action_types} - anders is het optioneel. "
 
 #: openforms/forms/api/serializers/logic/action_serializers.py:230
 msgid "Key of the target variable"
@@ -5818,8 +7212,8 @@ msgstr "formulierstap"
 #: openforms/forms/api/serializers/logic/action_serializers.py:243
 #, python-brace-format
 msgid ""
-"The UUID of the form step that will be affected by the action. This field is "
-"required for action types {action_types} - otherwise it's optional."
+"The UUID of the form step that will be affected by the action. This field is"
+" required for action types {action_types} - otherwise it's optional."
 msgstr ""
 "De UUID van de formulierstap waarop de actie van invloed is. Dit veld is "
 "verplicht voor actietypen {action_types} - anders is het optioneel."
@@ -5860,8 +7254,8 @@ msgstr ""
 #: openforms/submissions/api/serializers.py:246
 msgid "Actions triggered when the trigger expression evaluates to 'truthy'."
 msgstr ""
-"Acties die worden geactiveerd wanneer de trigger-expressie wordt geëvalueerd "
-"als 'truthy'."
+"Acties die worden geactiveerd wanneer de trigger-expressie wordt geëvalueerd"
+" als 'truthy'."
 
 #: openforms/forms/api/serializers/logic/form_logic.py:143
 #: openforms/forms/models/form_step.py:85 openforms/forms/models/logic.py:36
@@ -5896,45 +7290,45 @@ msgstr ""
 "volgorde uitgevoerd. Merk op dat het zetten van een volgnummer ervoor zorgt "
 "dat het volgnummer van regels voor/na deze regel opnieuw berekend wordt."
 
-#: openforms/forms/api/v3/serializers/form.py:345
+#: openforms/forms/api/v3/serializers/form.py:351
 msgid "Non-unique form step - form definition duplicate(s) detected."
 msgstr ""
 "Niet-unieke formulierstap – er zijn dubbele formulierdefinities gevonden."
 
-#: openforms/forms/api/v3/serializers/form.py:365
+#: openforms/forms/api/v3/serializers/form.py:371
 #, python-brace-format
 msgid "Duplicate component key detected in form definition {form_definition}."
 msgstr ""
 "Er is een dubbele componentsleutel gedetecteerd in de formulierdefinitie "
 "{form_definition}."
 
-#: openforms/forms/api/v3/serializers/form.py:385
+#: openforms/forms/api/v3/serializers/form.py:391
 #: openforms/forms/validators.py:91 openforms/forms/validators.py:160
 #, python-brace-format
 msgid "\"{duplicate_key}\" (in {paths})"
 msgstr "\"{duplicate_key}\" (in {paths})"
 
-#: openforms/forms/api/v3/serializers/form.py:392
+#: openforms/forms/api/v3/serializers/form.py:398
 #: openforms/forms/validators.py:99 openforms/forms/validators.py:167
 #, python-brace-format
 msgid "Detected duplicate keys in configuration: {errors}"
 msgstr "Er zijn dubbele sleutels gedetecteerd in de configuratie: {errors}."
 
-#: openforms/forms/api/v3/serializers/form.py:428
+#: openforms/forms/api/v3/serializers/form.py:434
 #: openforms/prefill/contrib/customer_interactions/config.py:57
 msgid ""
 "Only variables of 'profile' components are allowed as profile form variable."
 msgstr "Je kan enkel variabelen gebruiken die bij profielcomponenten horen."
 
-#: openforms/forms/api/v3/serializers/form.py:546
+#: openforms/forms/api/v3/serializers/form.py:552
 msgid "At least one form step is required in a regular form."
 msgstr "Ten minste één formulierstap is verplicht in een standaardformulier."
 
-#: openforms/forms/api/v3/serializers/form.py:551
+#: openforms/forms/api/v3/serializers/form.py:557
 msgid "Form steps are not allowed in an appointment form."
 msgstr "Formulierstappen zijn niet toegestaan in afspraakformulieren."
 
-#: openforms/forms/api/v3/serializers/form.py:556
+#: openforms/forms/api/v3/serializers/form.py:562
 msgid "Exactly one form step is required in a single step form."
 msgstr "Precies één formulierstap is verplicht in een formulier met één stap."
 
@@ -5961,8 +7355,7 @@ msgstr "Alle gegevens van een formulier aanmaken of bijwerken"
 
 #: openforms/forms/api/validators.py:31
 msgid "The first operand must be a `{\"var\": \"<componentKey>\"}` expression."
-msgstr ""
-"De eerste operand moet een `{\"var\": \"<componentKey>\"}` expressie zijn."
+msgstr "De eerste operand moet een `{\"var\": \"<componentKey>\"}` expressie zijn."
 
 #: openforms/forms/api/validators.py:124
 msgid "The variable cannot be empty."
@@ -5990,208 +7383,170 @@ msgstr ", op locatie \"{location}\""
 #, python-brace-format
 msgid ""
 "The component \"{label}\" (with key \"{key}\"{location}) has a problem in "
-"the field \"{property}\": there are template syntax errors in the expression."
+"the field \"{property}\": there are template syntax errors in the "
+"expression."
 msgstr ""
-"Er is een fout bij de component \"{label}\" (met sleutel \"{key}"
-"\"{location}) in het veld \"{property}\": er zijn sjabloonsyntaxfouten in de "
-"expressie."
+"Er is een fout bij de component \"{label}\" (met sleutel "
+"\"{key}\"{location}) in het veld \"{property}\": er zijn "
+"sjabloonsyntaxfouten in de expressie."
 
-#: openforms/forms/api/viewsets.py:78 openforms/forms/api/viewsets.py:220
+#: openforms/forms/api/viewsets.py:81 openforms/forms/api/viewsets.py:223
 msgid "Either a UUID4 or a slug identifiying the form."
 msgstr "Een UUID4 of een slug die het formulier identificeert."
 
-#: openforms/forms/api/viewsets.py:83
+#: openforms/forms/api/viewsets.py:86
 msgid "List form steps"
 msgstr "Formulierstappen weergeven"
 
-#: openforms/forms/api/viewsets.py:84
+#: openforms/forms/api/viewsets.py:87
 msgid "Retrieve form step details"
 msgstr "Formulierstap details weergeven"
 
-#: openforms/forms/api/viewsets.py:85
+#: openforms/forms/api/viewsets.py:88
 msgid "Create a form step"
 msgstr "Formulierstap aanmaken"
 
-#: openforms/forms/api/viewsets.py:86
+#: openforms/forms/api/viewsets.py:89
 msgid "Update all details of a form step"
 msgstr "Formulierstap in zijn geheel bijwerken"
 
-#: openforms/forms/api/viewsets.py:87
+#: openforms/forms/api/viewsets.py:90
 msgid "Update some details of a form step"
 msgstr "Formulierstap gedeeltelijk bijwerken"
 
-#: openforms/forms/api/viewsets.py:88
+#: openforms/forms/api/viewsets.py:91
 msgid "Delete a form step"
 msgstr "Formulierstap verwijderen"
 
-#: openforms/forms/api/viewsets.py:131
+#: openforms/forms/api/viewsets.py:134
 msgid "List form step definitions"
 msgstr "Formulierstap definities weergeven"
 
-#: openforms/forms/api/viewsets.py:133
+#: openforms/forms/api/viewsets.py:136
 #, python-brace-format
 msgid ""
-"Get a list of existing form definitions, where a single item may be a re-"
-"usable or single-use definition. This includes form definitions not "
-"currently used in any form(s) at all.\n"
+"Get a list of existing form definitions, where a single item may be a re-usable or single-use definition. This includes form definitions not currently used in any form(s) at all.\n"
 "\n"
-"You can filter this list down to only re-usable definitions or definitions "
-"used in a particular form.\n"
+"You can filter this list down to only re-usable definitions or definitions used in a particular form.\n"
 "\n"
-"**Note**: filtering on both `is_reusable` and `used_in` at the same time is "
-"implemented as an OR-filter.\n"
+"**Note**: filtering on both `is_reusable` and `used_in` at the same time is implemented as an OR-filter.\n"
 "\n"
 "**Warning: the response data depends on user permissions**\n"
 "\n"
-"Non-staff users receive a subset of all the documented fields. The fields "
-"reserved for staff users are used for internal form configuration. These "
-"are: \n"
+"Non-staff users receive a subset of all the documented fields. The fields reserved for staff users are used for internal form configuration. These are: \n"
 "\n"
 "{admin_fields}"
 msgstr ""
-"Geef een lijst van bestaande formulierdefinities waarin één enkele definitie "
-"herbruikbaar of voor éénmalig gebruik kan zijn. Dit is inclusief definities "
-"die in geen enkel formulier gebruikt zijn.\n"
+"Geef een lijst van bestaande formulierdefinities waarin één enkele definitie herbruikbaar of voor éénmalig gebruik kan zijn. Dit is inclusief definities die in geen enkel formulier gebruikt zijn.\n"
 "\n"
-"Je kan deze lijst filteren op enkel herbruikbare definities of definities "
-"die in een specifiek formulier gebruikt worden.\n"
+"Je kan deze lijst filteren op enkel herbruikbare definities of definities die in een specifiek formulier gebruikt worden.\n"
 "\n"
-"**Merk op**: tegelijk filteren op `is_reusable` en `used_in` is "
-"geïmplementeerd als een OF-filter - je krijgt dus beide resultaten terug.\n"
+"**Merk op**: tegelijk filteren op `is_reusable` en `used_in` is geïmplementeerd als een OF-filter - je krijgt dus beide resultaten terug.\n"
 "\n"
-"**Waarschuwing: de gegevens in het antwoord zijn afhankelijk van je "
-"gebruikersrechten**\n"
+"**Waarschuwing: de gegevens in het antwoord zijn afhankelijk van je gebruikersrechten**\n"
 "\n"
-"Gebruikers die geen beheerder zijn, ontvangen maar een deel van de "
-"gedocumenteerde velden. De velden die enkel voor beheerders beschikbaar "
-"zijn, zijn voor interne formulierconfiguratie. Het gaat om de velden:\n"
+"Gebruikers die geen beheerder zijn, ontvangen maar een deel van de gedocumenteerde velden. De velden die enkel voor beheerders beschikbaar zijn, zijn voor interne formulierconfiguratie. Het gaat om de velden:\n"
 "\n"
 "{admin_fields}"
 
-#: openforms/forms/api/viewsets.py:148
+#: openforms/forms/api/viewsets.py:151
 msgid "Retrieve form step definition details"
 msgstr "Formulierstap definitie details weergeven"
 
-#: openforms/forms/api/viewsets.py:152
+#: openforms/forms/api/viewsets.py:155
 msgid "Create a form definition"
 msgstr "Formulierdefinitie toevoegen"
 
-#: openforms/forms/api/viewsets.py:156
+#: openforms/forms/api/viewsets.py:159
 msgid "Update all details of a form definition"
 msgstr "Formulierdefinitie in zijn geheel bijwerken"
 
-#: openforms/forms/api/viewsets.py:160
+#: openforms/forms/api/viewsets.py:163
 msgid "Update some details of a form definition"
 msgstr "formulierdefinitie gedeeltelijk bijwerken"
 
-#: openforms/forms/api/viewsets.py:164
+#: openforms/forms/api/viewsets.py:167
 msgid "Delete a form definition"
 msgstr "Verwijder een formulierdefinitie"
 
-#: openforms/forms/api/viewsets.py:195
+#: openforms/forms/api/viewsets.py:198
 msgid "Retrieve form definition JSON schema"
 msgstr "Formulierdefinitie JSON schema weergeven"
 
-#: openforms/forms/api/viewsets.py:230
+#: openforms/forms/api/viewsets.py:233
 #, python-brace-format
 msgid ""
-"List the active forms, including the pointers to the form steps. Form steps "
-"are included in order as they should appear.\n"
+"List the active forms, including the pointers to the form steps. Form steps are included in order as they should appear.\n"
 "\n"
 "**Warning: the response data depends on user permissions**\n"
 "\n"
-"Non-staff users receive a subset of all the documented fields. The fields "
-"reserved for staff users are used for internal form configuration. These "
-"are: \n"
+"Non-staff users receive a subset of all the documented fields. The fields reserved for staff users are used for internal form configuration. These are: \n"
 "\n"
 "{admin_fields}"
 msgstr ""
-"Geef een lijst van actieve formulieren, inclusief verwijzingen naar de "
-"formulierstappen. De formulierstappen komen voor in de volgorde waarin ze "
-"zichtbaar moeten zijn.\n"
+"Geef een lijst van actieve formulieren, inclusief verwijzingen naar de formulierstappen. De formulierstappen komen voor in de volgorde waarin ze zichtbaar moeten zijn.\n"
 "\n"
-"**Waarschuwing: de gegevens in het antwoord zijn afhankelijk van je "
-"gebruikersrechten**\n"
+"**Waarschuwing: de gegevens in het antwoord zijn afhankelijk van je gebruikersrechten**\n"
 "\n"
-"Gebruikers die geen beheerder zijn, ontvangen maar een deel van de "
-"gedocumenteerde velden. De velden die enkel voor beheerders beschikbaar "
-"zijn, zijn voor interne formulierconfiguratie. Het gaat om de velden:\n"
+"Gebruikers die geen beheerder zijn, ontvangen maar een deel van de gedocumenteerde velden. De velden die enkel voor beheerders beschikbaar zijn, zijn voor interne formulierconfiguratie. Het gaat om de velden:\n"
 "\n"
 "{admin_fields}"
 
-#: openforms/forms/api/viewsets.py:239
+#: openforms/forms/api/viewsets.py:242
 msgid "Retrieve form details"
 msgstr "Formulier details weergeven"
 
-#: openforms/forms/api/viewsets.py:247
+#: openforms/forms/api/viewsets.py:250
 msgid ""
 "If used, then all authorization methods are visible when the form starts"
 msgstr ""
-"Indien gebruikt, zijn alle autorisatieopties zichtbaar wanneer het formulier "
-"wordt gestart."
+"Indien gebruikt, zijn alle autorisatieopties zichtbaar wanneer het formulier"
+" wordt gestart."
 
-#: openforms/forms/api/viewsets.py:253
+#: openforms/forms/api/viewsets.py:256
 #, python-brace-format
 msgid ""
 "Retrieve the details/configuration of a particular form. \n"
 "\n"
-"A form is a collection of form steps, where each form step points to a "
-"formio.js form definition. Multiple definitions are combined in logical "
-"steps to build a multi-step/page form for end-users to fill out. Form "
-"definitions can be (and are) re-used among different forms.\n"
+"A form is a collection of form steps, where each form step points to a formio.js form definition. Multiple definitions are combined in logical steps to build a multi-step/page form for end-users to fill out. Form definitions can be (and are) re-used among different forms.\n"
 "\n"
 "**Warning: the response data depends on user permissions**\n"
 "\n"
-"Non-staff users receive a subset of all the documented fields. The fields "
-"reserved for staff users are used for internal form configuration. These "
-"are: \n"
+"Non-staff users receive a subset of all the documented fields. The fields reserved for staff users are used for internal form configuration. These are: \n"
 "\n"
 "{admin_fields}\n"
 "\n"
-"If the form doesn't have translations enabled, its default language is "
-"forced by setting a language cookie and reflected in the Content-Language "
-"response header. Normal HTTP Content Negotiation rules apply."
+"If the form doesn't have translations enabled, its default language is forced by setting a language cookie and reflected in the Content-Language response header. Normal HTTP Content Negotiation rules apply."
 msgstr ""
 "Haal de details/configuratie op van een specifiek formulier.\n"
 "\n"
-"Een formulier is een verzameling van één of meerdere formulierstappen "
-"waarbij elke stap een verwijzing heeft naar een formio.js "
-"formulierdefinitie. Meerdere definities samen vormen een logisch geheel van "
-"formulierstappen die de klant doorloopt tijdens het invullen van het "
-"formulier. Formulierdefinities kunnen herbruikbaar zijn tussen verschillende "
-"formulieren.\n"
+"Een formulier is een verzameling van één of meerdere formulierstappen waarbij elke stap een verwijzing heeft naar een formio.js formulierdefinitie. Meerdere definities samen vormen een logisch geheel van formulierstappen die de klant doorloopt tijdens het invullen van het formulier. Formulierdefinities kunnen herbruikbaar zijn tussen verschillende formulieren.\n"
 "\n"
 "**Waarschuwing: de response-data is afhankelijk van de gebruikersrechten**\n"
 "\n"
-"Gebruikers die geen beheerder zijn, ontvangen maar een deel van de "
-"gedocumenteerde velden. De velden die enkel voor beheerders beschikbaar "
-"zijn, zijn voor interne formulierconfiguratie. Het gaat om de velden:\n"
+"Gebruikers die geen beheerder zijn, ontvangen maar een deel van de gedocumenteerde velden. De velden die enkel voor beheerders beschikbaar zijn, zijn voor interne formulierconfiguratie. Het gaat om de velden:\n"
 "\n"
 "{admin_fields}\n"
 "\n"
-"Wanneer meertaligheid niet ingeschakeld is voor het formulier, dan wordt de "
-"standaardtaal (`settings.LANGUAGE_CODE`) geforceerd gezet in een language "
-"cookie. De actieve taal wordt gecommuniceerd in de Content-Language response "
-"header. De gebruikelijke HTTP Content Negotiation principes zijn van "
-"toepassing."
+"Wanneer meertaligheid niet ingeschakeld is voor het formulier, dan wordt de standaardtaal (`settings.LANGUAGE_CODE`) geforceerd gezet in een language cookie. De actieve taal wordt gecommuniceerd in de Content-Language response header. De gebruikelijke HTTP Content Negotiation principes zijn van toepassing."
 
-#: openforms/forms/api/viewsets.py:267
+#: openforms/forms/api/viewsets.py:270
 msgid "Create form"
 msgstr "Formulier aanmaken"
 
-#: openforms/forms/api/viewsets.py:269
+#: openforms/forms/api/viewsets.py:272
 msgid "Update all details of a form"
 msgstr "Formulier in zijn geheel bijwerken"
 
-#: openforms/forms/api/viewsets.py:273
+#: openforms/forms/api/viewsets.py:276
 msgid "Update given details of a form"
 msgstr "Formulier gedeeltelijk bijwerken"
 
-#: openforms/forms/api/viewsets.py:277
+#: openforms/forms/api/viewsets.py:280
 msgid "Mark form as deleted"
 msgstr "Formulier markeren als verwijderd"
 
-#: openforms/forms/api/viewsets.py:279
+#: openforms/forms/api/viewsets.py:282
 msgid ""
 "Destroying a form leads to a soft-delete to protect related submissions. "
 "These deleted forms are no longer visible in the API endpoints."
@@ -6200,11 +7555,11 @@ msgstr ""
 "verwijderd om gerelateerde inzendingen te beschermen. Formulieren die "
 "gemarkeerd zijn als verwijderd komen niet meer in de API naar voren."
 
-#: openforms/forms/api/viewsets.py:285
+#: openforms/forms/api/viewsets.py:288
 msgid "Bulk configure form variables"
 msgstr "Configureer formuliervariabelen in bulk"
 
-#: openforms/forms/api/viewsets.py:287
+#: openforms/forms/api/viewsets.py:290
 msgid ""
 "By sending a list of FormVariables to this endpoint, all the FormVariables "
 "related to the form will be replaced with the data sent to the endpoint."
@@ -6212,164 +7567,178 @@ msgstr ""
 "Alle variabelen van het formulier worden vervangen met de toegestuurde "
 "variabelen."
 
-#: openforms/forms/api/viewsets.py:302
+#: openforms/forms/api/viewsets.py:305
 msgid "Bulk configure logic rules"
 msgstr "Configureer logicaregels in bulk"
 
-#: openforms/forms/api/viewsets.py:304
+#: openforms/forms/api/viewsets.py:307
 msgid ""
-"By sending a list of LogicRules to this endpoint, all the LogicRules related "
-"to the form will be replaced with the data sent to the endpoint."
+"By sending a list of LogicRules to this endpoint, all the LogicRules related"
+" to the form will be replaced with the data sent to the endpoint."
 msgstr ""
 "Alle logicaregels van het formulier worden vervangen met de toegestuurde "
 "regels."
 
-#: openforms/forms/api/viewsets.py:413
+#: openforms/forms/api/viewsets.py:416
 msgid "Export form"
 msgstr "Formulier exporteren"
 
-#: openforms/forms/api/viewsets.py:448
+#: openforms/forms/api/viewsets.py:471
 msgid "Prepare form edit admin message"
 msgstr "Admin berichten voor formulier bewerken voorbereiden"
 
-#: openforms/forms/api/viewsets.py:540
+#: openforms/forms/api/viewsets.py:563
 msgid "List form variables"
 msgstr "Formuliervariabelen weergeven"
 
-#: openforms/forms/api/viewsets.py:541
+#: openforms/forms/api/viewsets.py:564
 msgid "List all variables defined for a form."
 msgstr "Geef alle variabelen terug die bij een formulier horen"
 
-#: openforms/forms/api/viewsets.py:554
+#: openforms/forms/api/viewsets.py:577
 msgid "Filter by form variable source"
 msgstr "Filteren op oorsprong formuliervariabele"
 
-#: openforms/forms/api/viewsets.py:611
+#: openforms/forms/api/viewsets.py:634
 msgid "List logic rules"
 msgstr "Logicaregels weergeven"
 
-#: openforms/forms/api/viewsets.py:612
+#: openforms/forms/api/viewsets.py:635
 msgid "List all logic rules defined for a form."
 msgstr "Geef een lijst van alle logicaregels van een formulier."
 
-#: openforms/forms/api/viewsets.py:638
+#: openforms/forms/api/viewsets.py:661
 msgid "Generate the JSON schema for a form."
 msgstr "Genereer een JSON-schema voor een formulier."
 
-#: openforms/forms/api/viewsets.py:685 openforms/forms/api/viewsets.py:702
-#: openforms/forms/api/viewsets.py:721
+#: openforms/forms/api/viewsets.py:708 openforms/forms/api/viewsets.py:725
+#: openforms/forms/api/viewsets.py:744
 msgid "Either a UUID4 or a slug identifying the form."
 msgstr "Een UUID4 of een slug die het formulier identificeert."
 
-#: openforms/forms/api/viewsets.py:691
+#: openforms/forms/api/viewsets.py:714
 msgid "Save form version"
 msgstr "Formulierversie opslaan"
 
-#: openforms/forms/api/viewsets.py:695
+#: openforms/forms/api/viewsets.py:718
 msgid "Restore form version"
 msgstr "Formulierversie terugzetten"
 
-#: openforms/forms/api/viewsets.py:708
+#: openforms/forms/api/viewsets.py:731
 msgid "The UUID of the form version"
 msgstr "Het UUID van de formulierversie"
 
-#: openforms/forms/api/viewsets.py:714
+#: openforms/forms/api/viewsets.py:737
 msgid "List form versions"
 msgstr "Formulierversies weergeven"
 
-#: openforms/forms/api/viewsets.py:762
+#: openforms/forms/api/viewsets.py:785
 #: openforms/forms/templates/admin/forms/form/import_form.html:15
 #: openforms/forms/templates/admin/forms/form/import_form.html:20
 msgid "Import form"
 msgstr "Formulier importeren"
 
-#: openforms/forms/constants.py:12
+#: openforms/forms/constants.py:10
 msgid "Mark the form step as not-applicable"
 msgstr "Markeer de formulierstap als niet van toepassing"
 
-#: openforms/forms/constants.py:14
+#: openforms/forms/constants.py:12
 msgid "Mark the form step as applicable"
 msgstr "Markeer de formulierstap als van toepassing"
 
-#: openforms/forms/constants.py:15
+#: openforms/forms/constants.py:13
 msgid "Disable the next step"
 msgstr "Volgende stap uitschakelen"
 
-#: openforms/forms/constants.py:16
+#: openforms/forms/constants.py:14
 msgid "Modify a component property"
 msgstr "Wijzig een veld attribuut"
 
-#: openforms/forms/constants.py:17
+#: openforms/forms/constants.py:15
 msgid "Set the value of a variable"
 msgstr "Stel de waarde van een variabele in"
 
-#: openforms/forms/constants.py:18
+#: openforms/forms/constants.py:16
 msgid "Fetch the value from a service"
 msgstr "Haal de waarde op uit een externe registratie"
 
-#: openforms/forms/constants.py:21
+#: openforms/forms/constants.py:19
 msgid "Set the registration backend to use for the submission"
 msgstr "Zet registratieplugin voor de inzending"
 
-#: openforms/forms/constants.py:23
+#: openforms/forms/constants.py:21
 msgid "Evaluate DMN"
 msgstr "DMN evalueren"
 
-#: openforms/forms/constants.py:26
+#: openforms/forms/constants.py:24
 msgid "Synchronize a variable with another one"
 msgstr "Synchroniseer een variable met een andere"
 
-#: openforms/forms/constants.py:44 openforms/variables/constants.py:16
+#: openforms/forms/constants.py:42 openforms/variables/constants.py:16
 msgid "Boolean"
 msgstr "Ja/Nee"
 
-#: openforms/forms/constants.py:45
+#: openforms/forms/constants.py:43
 msgid "JSON"
 msgstr "JSON"
 
-#: openforms/forms/constants.py:49
+#: openforms/forms/constants.py:47
 msgid "Form specific email"
 msgstr "Formulierspecifieke e-mail"
 
-#: openforms/forms/constants.py:50
+#: openforms/forms/constants.py:48
 msgid "Global email"
 msgstr "Globale e-mail"
 
-#: openforms/forms/constants.py:51
+#: openforms/forms/constants.py:49
 msgid "No email"
 msgstr "Geen e-mail"
 
-#: openforms/forms/constants.py:55
+#: openforms/forms/constants.py:53
 msgid "Yes"
 msgstr "Ja"
 
-#: openforms/forms/constants.py:56
+#: openforms/forms/constants.py:54
 msgid "No (with overview page)"
 msgstr "Nee (met overzichtspagina)"
 
-#: openforms/forms/constants.py:57
+#: openforms/forms/constants.py:55
 msgid "No (without overview page)"
 msgstr "Nee (zonder overzichtspagina)"
 
-#: openforms/forms/constants.py:61
+#: openforms/forms/constants.py:59
 msgid "Global setting"
 msgstr "Globale instelling"
 
-#: openforms/forms/constants.py:63
+#: openforms/forms/constants.py:61
 msgid "Disabled"
 msgstr "Uitgeschakeld"
 
-#: openforms/forms/constants.py:67
+#: openforms/forms/constants.py:65
 msgid "Regular"
 msgstr "Standaard"
 
-#: openforms/forms/constants.py:68 openforms/submissions/admin.py:274
+#: openforms/forms/constants.py:66 openforms/submissions/admin.py:274
 msgid "Appointment"
 msgstr "Afspraak"
 
-#: openforms/forms/constants.py:69
+#: openforms/forms/constants.py:67
 msgid "Single step"
 msgstr "Enkele stap"
+
+#: openforms/forms/constants.py:71
+#| msgid "Go to the payment page"
+msgid "Before the start page"
+msgstr ""
+
+#: openforms/forms/constants.py:72
+#| msgid "Go to the payment page"
+msgid "After the start page"
+msgstr ""
+
+#: openforms/forms/constants.py:73
+msgid "Never"
+msgstr ""
 
 #: openforms/forms/forms/form.py:7
 msgid "file"
@@ -6419,7 +7788,7 @@ msgid "Export form submission that were submitted before or on this date."
 msgstr "Exporteer inzendingen die op of voor deze datum ingestuurd zijn."
 
 #: openforms/forms/forms/form_statistics.py:72
-#: openforms/forms/templates/admin/forms/form/export.html:13
+#: openforms/forms/templates/admin/forms/form/export.html:14
 #: openforms/forms/templates/admin/forms/form/import_form.html:14
 #: openforms/forms/templates/admin/forms/form/migrate-payment-backend.html:19
 msgid "Forms"
@@ -6434,6 +7803,40 @@ msgstr ""
 "Beperk de export tot de geselecteerde formulieren. Selecteer niets om alle "
 "formulieren te exporteren. Houd CTRL (of COMMAND op Mac) ingedrukt om "
 "meerdere opties te selecteren."
+
+#: openforms/forms/import_export/typing.py:12
+msgid "Registration backends"
+msgstr "Registratiebackends"
+
+#: openforms/forms/import_export/typing.py:13 openforms/prefill/apps.py:7
+#: openforms/submissions/constants.py:52
+msgid "Prefill"
+msgstr "Prefill"
+
+#: openforms/forms/import_export/typing.py:14 openforms/payments/models.py:105
+msgid "Payment backend"
+msgstr "Betaalprovider backend"
+
+#: openforms/forms/import_export/typing.py:15
+msgid "Authentication backends"
+msgstr "Inlogmethoden"
+
+#: openforms/forms/import_export/typing.py:19
+#: openforms/products/models/product.py:43
+msgid "Product"
+msgstr "Product"
+
+#: openforms/forms/import_export/typing.py:20
+msgid "WMS-tile layers"
+msgstr "WMS-kaartlagen"
+
+#: openforms/forms/import_export/typing.py:21
+msgid "Background tile layers"
+msgstr "Kaartachtergrondlagen"
+
+#: openforms/forms/import_export/typing.py:22
+msgid "Yivi attribute groups"
+msgstr "Yivi-attribuutgroepen"
 
 #: openforms/forms/messages.py:38 openforms/forms/messages.py:43
 #, python-brace-format
@@ -6468,8 +7871,8 @@ msgid ""
 "The {name} \"{obj}\" was changed successfully. You may add another {name} "
 "below."
 msgstr ""
-"De {name} \"{obj}\" is met succes gewijzigd. U kunt hieronder nog een {name} "
-"bewerken."
+"De {name} \"{obj}\" is met succes gewijzigd. U kunt hieronder nog een {name}"
+" bewerken."
 
 #: openforms/forms/messages.py:70
 msgid "You may edit it again below."
@@ -6483,21 +7886,21 @@ msgstr "Eenvoudige naam"
 msgid "categories"
 msgstr "categorieën"
 
-#: openforms/forms/models/form.py:82
+#: openforms/forms/models/form.py:83
 #: openforms/forms/models/form_definition.py:42
 msgid "internal name"
 msgstr "interne naam"
 
-#: openforms/forms/models/form.py:85
+#: openforms/forms/models/form.py:86
 #: openforms/forms/models/form_definition.py:45
 msgid "internal name for management purposes"
 msgstr "interne naam voor beheerdoeleinden "
 
-#: openforms/forms/models/form.py:88
+#: openforms/forms/models/form.py:89
 msgid "internal remarks"
 msgstr "interne opmerkingen"
 
-#: openforms/forms/models/form.py:90
+#: openforms/forms/models/form.py:91
 msgid ""
 "Remarks or intentions about the form. Can also be used to save notes for "
 "later use or for another admin user."
@@ -6505,17 +7908,17 @@ msgstr ""
 "Opmerkingen of intenties over het formulier. Kan ook gebruikt worden voor "
 "het maken van notities voor later gebruik of voor een andere beheerder."
 
-#: openforms/forms/models/form.py:97
+#: openforms/forms/models/form.py:98
 #: openforms/forms/models/form_definition.py:47
 #: openforms/forms/models/form_step.py:33
 msgid "slug"
 msgstr "URL-deel"
 
-#: openforms/forms/models/form.py:100
+#: openforms/forms/models/form.py:101
 msgid "form type"
 msgstr "formuliertype"
 
-#: openforms/forms/models/form.py:104
+#: openforms/forms/models/form.py:105
 msgid ""
 "The type of the form. The choices are regular, appointment or a single step "
 "form. Depending on the choice a different form design is required/rendered."
@@ -6524,56 +7927,57 @@ msgstr ""
 "standaard, afspraak of een formulier met één stap. Afhankelijk van de keuze "
 "zijn andere formulierinstellingen beschikbaar/verplicht."
 
-#: openforms/forms/models/form.py:122
+#: openforms/forms/models/form.py:123
 msgid "form theme"
 msgstr "formulierstijl"
 
-#: openforms/forms/models/form.py:124
+#: openforms/forms/models/form.py:125
 msgid ""
 "Apply a specific appearance configuration to the form. If left blank, then "
 "the globally configured default is applied."
 msgstr ""
-"Pas een specifieke stijl toe op het formulier. Indien geen optie gekozen is, "
-"dan wordt de globale instelling toegepast."
+"Pas een specifieke stijl toe op het formulier. Indien geen optie gekozen is,"
+" dan wordt de globale instelling toegepast."
 
-#: openforms/forms/models/form.py:128
+#: openforms/forms/models/form.py:129
 msgid "translation enabled"
 msgstr "meertaligheid ingeschakeld"
 
-#: openforms/forms/models/form.py:131 openforms/forms/models/form.py:521
+#: openforms/forms/models/form.py:132 openforms/forms/models/form.py:534
 msgid "payment backend"
 msgstr "betaalprovider backend"
 
-#: openforms/forms/models/form.py:138
+#: openforms/forms/models/form.py:139
 msgid "price variable key"
 msgstr "sleutel prijsvariabele"
 
-#: openforms/forms/models/form.py:141
+#: openforms/forms/models/form.py:142
 msgid "Key of the variable that contains the calculated submission price."
 msgstr ""
-"Sleutel van de variabele die de (berekende) kostprijs van de inzending bevat."
+"Sleutel van de variabele die de (berekende) kostprijs van de inzending "
+"bevat."
 
-#: openforms/forms/models/form.py:148
+#: openforms/forms/models/form.py:149
 msgid "automatic login"
 msgstr "automatisch inloggen"
 
-#: openforms/forms/models/form.py:153
+#: openforms/forms/models/form.py:154
 msgid "maximum allowed submissions"
 msgstr "maximum aantal inzendingen"
 
-#: openforms/forms/models/form.py:157
+#: openforms/forms/models/form.py:158
 msgid ""
-"Maximum number of allowed submissions per form. Leave this empty if no limit "
-"is needed."
+"Maximum number of allowed submissions per form. Leave this empty if no limit"
+" is needed."
 msgstr ""
 "Het maximum aantal inzendingen die toegestaan zijn voor het formulier. Laat "
 "dit veld leeg als er geen beperking is."
 
-#: openforms/forms/models/form.py:161
+#: openforms/forms/models/form.py:162
 msgid "submissions counter"
 msgstr "aantal inzendingen"
 
-#: openforms/forms/models/form.py:164
+#: openforms/forms/models/form.py:165
 msgid ""
 "Counter to track how many submissions have been completed for the specific "
 "form. This works in combination with the maximum allowed submissions per "
@@ -6583,11 +7987,7 @@ msgstr ""
 "Deze werkt samen met de inzendingslimiet en kan gereset worden via de "
 "frontend."
 
-#: openforms/forms/models/form.py:170 openforms/config/models/config.py:76
-msgid "submission confirmation template"
-msgstr "Bevestigingspagina tekst"
-
-#: openforms/forms/models/form.py:172
+#: openforms/forms/models/form.py:173
 msgid ""
 "The content of the submission confirmation page. It can contain variables "
 "that will be templated from the submitted form data. If not specified, the "
@@ -6597,12 +7997,12 @@ msgstr ""
 "de ingediende formuliergegevens worden weergegeven. Indien niet opgegeven "
 "dan wordt de globale bevestingspagina gebruikt."
 
-#: openforms/forms/models/form.py:181
+#: openforms/forms/models/form.py:182
 #: openforms/submissions/api/serializers.py:157
 msgid "submission allowed"
 msgstr "inzenden toegestaan"
 
-#: openforms/forms/models/form.py:185
+#: openforms/forms/models/form.py:186
 msgid ""
 "Whether the user is allowed to submit this form or not, and whether the "
 "overview page should be shown if they are not."
@@ -6610,63 +8010,63 @@ msgstr ""
 "Geeft aan of de gebruiker het formulier kan verzenden en of de "
 "overzichtspagina getoond wordt als het formulier niet verzonden kan worden."
 
-#: openforms/forms/models/form.py:191
+#: openforms/forms/models/form.py:192
 msgid "suspension allowed"
 msgstr "tussentijds opslaan"
 
-#: openforms/forms/models/form.py:193
+#: openforms/forms/models/form.py:194
 msgid "Whether the user is allowed to suspend this form or not."
 msgstr ""
 "Geeft aan of de gebruiker het formulier tussentijds kan opslaan/pauzeren of "
 "niet."
 
-#: openforms/forms/models/form.py:196
+#: openforms/forms/models/form.py:197
 msgid "show progress indicator"
 msgstr "toon formulierstappen"
 
-#: openforms/forms/models/form.py:199
+#: openforms/forms/models/form.py:200
 msgid "Whether the step progression should be displayed in the UI or not."
 msgstr ""
 "Indien aangevinkt dan worden de stappen van het formulier aan de gebruiker "
 "getoond."
 
-#: openforms/forms/models/form.py:203
+#: openforms/forms/models/form.py:204
 msgid "show summary of the progress"
 msgstr "toon voortgangsoverzicht"
 
-#: openforms/forms/models/form.py:206
+#: openforms/forms/models/form.py:207
 msgid ""
 "Whether to display the short progress summary, indicating the current step "
 "number and total amount of steps."
 msgstr ""
-"Vink aan om het korte voortgangsoverzicht weer te geven. Dit overzicht toont "
-"de huidige stap en het totaal aantal stappen, typisch onder de "
+"Vink aan om het korte voortgangsoverzicht weer te geven. Dit overzicht toont"
+" de huidige stap en het totaal aantal stappen, typisch onder de "
 "formuliertitel."
 
-#: openforms/forms/models/form.py:211
+#: openforms/forms/models/form.py:212
 msgid "display main website link"
 msgstr "toon hoofdsite link"
 
-#: openforms/forms/models/form.py:214
+#: openforms/forms/models/form.py:215
 msgid ""
 "Display the link to the main website on the submission confirmation page."
 msgstr "Toon de link naar de hoofdsite op de bevestigingspagina na inzenden."
 
-#: openforms/forms/models/form.py:218
+#: openforms/forms/models/form.py:219
 msgid "include confirmation page content in PDF"
 msgstr "voeg de \"bevestigingspaginatekst\" toe in de bevestigings-PDF"
 
-#: openforms/forms/models/form.py:220
+#: openforms/forms/models/form.py:221
 msgid "Display the instruction from the confirmation page in the PDF."
 msgstr ""
-"Vink aan om de inhoud van het \"bevestigingspaginatekst\"-veld toe te voegen "
-"aan de PDF met gegevens ter bevestiging."
+"Vink aan om de inhoud van het \"bevestigingspaginatekst\"-veld toe te voegen"
+" aan de PDF met gegevens ter bevestiging."
 
-#: openforms/forms/models/form.py:223
+#: openforms/forms/models/form.py:224
 msgid "send confirmation email"
 msgstr "verstuur bevestigingsmail"
 
-#: openforms/forms/models/form.py:225
+#: openforms/forms/models/form.py:226
 msgid ""
 "Whether a confirmation email should be sent to the end user filling in the "
 "form."
@@ -6674,35 +8074,7 @@ msgstr ""
 "Geef aan of er een bevestigingsmail naar de formulierinzender verstuurd "
 "dient te worden."
 
-#: openforms/forms/models/form.py:230 openforms/config/models/config.py:434
-msgid "ask privacy consent"
-msgstr "vraag toestemming om gegevens te verwerken"
-
-#: openforms/forms/models/form.py:235 openforms/config/models/config.py:437
-msgid ""
-"If enabled, the user will have to agree to the privacy policy before "
-"submitting a form."
-msgstr ""
-"Indien ingeschakeld, moet de gebruiker akkoord gaan met het privacybeleid "
-"voordat hij een formulier indient."
-
-#: openforms/forms/models/form.py:239 openforms/config/models/config.py:467
-msgid "ask statement of truth"
-msgstr "vraag waarheidsverklaring"
-
-#: openforms/forms/models/form.py:244 openforms/config/models/config.py:470
-msgid ""
-"If enabled, the user will have to agree that they filled out the form "
-"truthfully before submitting it."
-msgstr ""
-"Indien verplicht dient de gebruiker de verklaring naar waarheid te "
-"accepteren voor die het formulier indient."
-
-#: openforms/forms/models/form.py:251 openforms/config/models/config.py:258
-msgid "begin text"
-msgstr "Formulier starten-label"
-
-#: openforms/forms/models/form.py:255
+#: openforms/forms/models/form.py:256
 msgid ""
 "The text that will be displayed at the start of the form to indicate the "
 "user can begin to fill in the form. Leave blank to get value from global "
@@ -6711,23 +8083,19 @@ msgstr ""
 "Het label van de knop om het formulier te starten. Laat leeg om de waarde "
 "van de algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:261
+#: openforms/forms/models/form.py:262
 msgid "previous text"
 msgstr "Vorige stap-label"
 
-#: openforms/forms/models/form.py:265
+#: openforms/forms/models/form.py:266
 msgid ""
 "The text that will be displayed in the overview page to go to the previous "
 "step. Leave blank to get value from global configuration."
 msgstr ""
-"Het label van de knop op de overzichtspagina om naar de vorige stap te gaan. "
-"Laat leeg om de waarde van de algemene configuratie te gebruiken."
+"Het label van de knop op de overzichtspagina om naar de vorige stap te gaan."
+" Laat leeg om de waarde van de algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:271 openforms/config/models/config.py:240
-msgid "change text"
-msgstr "Stap wijzigen-label"
-
-#: openforms/forms/models/form.py:275
+#: openforms/forms/models/form.py:276
 msgid ""
 "The text that will be displayed in the overview page to change a certain "
 "step. Leave blank to get value from global configuration."
@@ -6735,11 +8103,7 @@ msgstr ""
 "Het label de link op de overzichtspagina om een bepaalde stap te wijzigen. "
 "Laat leeg om de waarde van de algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:281 openforms/config/models/config.py:249
-msgid "confirm text"
-msgstr "Formulier verzenden-label"
-
-#: openforms/forms/models/form.py:285
+#: openforms/forms/models/form.py:286
 msgid ""
 "The text that will be displayed in the overview page to confirm the form is "
 "filled in correctly. Leave blank to get value from global configuration."
@@ -6747,11 +8111,11 @@ msgstr ""
 "Het label van de knop op de overzichtspagina om het formulier in te dienen. "
 "Laat leeg om de waarde van de algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:293
+#: openforms/forms/models/form.py:294
 msgid "introduction page"
 msgstr "introductiepagina"
 
-#: openforms/forms/models/form.py:295
+#: openforms/forms/models/form.py:296
 msgid ""
 "Content for the introduction page that leads to the start page of the form. "
 "Leave blank to disable the introduction page."
@@ -6759,47 +8123,43 @@ msgstr ""
 "Inhoud voor de introductiepagina die naar de formulierstartpagina leidt. "
 "Laat deze leeg om de introductiepagina uit te schakelen."
 
-#: openforms/forms/models/form.py:303
+#: openforms/forms/models/form.py:304
 msgid "explanation template"
 msgstr "Toelichtingssjabloon"
 
-#: openforms/forms/models/form.py:305
+#: openforms/forms/models/form.py:306
 msgid ""
 "Content that will be shown on the start page of the form, below the title "
 "and above the log in text."
 msgstr ""
-"Inhoud die op de formulierstartpagina wordt getoond, onder de titel en boven "
-"de startknop(pen)."
+"Inhoud die op de formulierstartpagina wordt getoond, onder de titel en boven"
+" de startknop(pen)."
 
-#: openforms/forms/models/form.py:313
+#: openforms/forms/models/form.py:314
 msgid "maintenance mode"
 msgstr "onderhoudsmodus"
 
-#: openforms/forms/models/form.py:316
+#: openforms/forms/models/form.py:317
 msgid "Users will not be able to start the form if it is in maintenance mode."
 msgstr "Gebruikers kunnen een formulier in onderhoudsmodus niet starten."
 
-#: openforms/forms/models/form.py:321
+#: openforms/forms/models/form.py:322
 msgid "activate on"
 msgstr "Activeren op"
 
-#: openforms/forms/models/form.py:324
+#: openforms/forms/models/form.py:325
 msgid "Date and time on which the form should be activated."
 msgstr "Datum en tijdstip waarop het formulier geactiveerd moet worden."
 
-#: openforms/forms/models/form.py:327
+#: openforms/forms/models/form.py:328
 msgid "deactivate on"
 msgstr "Deactiveren op"
 
-#: openforms/forms/models/form.py:330
+#: openforms/forms/models/form.py:331
 msgid "Date and time on which the form should be deactivated."
 msgstr "Datum en tijdstip waarop het formulier gedeactiveerd moet worden."
 
-#: openforms/forms/models/form.py:335 openforms/config/models/config.py:492
-msgid "successful submission removal limit"
-msgstr "bewaartermijn voor voltooide inzendingen."
-
-#: openforms/forms/models/form.py:340
+#: openforms/forms/models/form.py:341
 msgid ""
 "Amount of days successful submissions of this form will remain before being "
 "removed. Leave blank to use value in General Configuration."
@@ -6807,11 +8167,7 @@ msgstr ""
 "Aantal dagen dat een voltooide inzending bewaard blijft. Laat leeg om de "
 "waarde van de algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:345 openforms/config/models/config.py:500
-msgid "successful submissions removal method"
-msgstr "opschoonmethode voor voltooide inzendingen"
-
-#: openforms/forms/models/form.py:350
+#: openforms/forms/models/form.py:351
 msgid ""
 "How successful submissions of this form will be removed after the limit. "
 "Leave blank to use value in General Configuration."
@@ -6819,11 +8175,7 @@ msgstr ""
 "Geeft aan hoe voltooide inzendingen worden opgeschoond na de bewaartermijn. "
 "Laat leeg om de waarde van de algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:355 openforms/config/models/config.py:507
-msgid "incomplete submission removal limit"
-msgstr "bewaartermijn voor sessies"
-
-#: openforms/forms/models/form.py:360
+#: openforms/forms/models/form.py:361
 msgid ""
 "Amount of days incomplete submissions of this form will remain before being "
 "removed. Leave blank to use value in General Configuration."
@@ -6831,11 +8183,7 @@ msgstr ""
 "Aantal dagen dat een sessie bewaard blijft. Laat leeg om de waarde van de "
 "algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:365 openforms/config/models/config.py:515
-msgid "incomplete submissions removal method"
-msgstr "opschoonmethode voor sessies."
-
-#: openforms/forms/models/form.py:370
+#: openforms/forms/models/form.py:371
 msgid ""
 "How incomplete submissions of this form will be removed after the limit. "
 "Leave blank to use value in General Configuration."
@@ -6843,12 +8191,7 @@ msgstr ""
 "Geeft aan hoe sessies worden opgeschoond na de bewaartermijn. Laat leeg om "
 "de waarde van de algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:375 openforms/forms/models/form.py:385
-#: openforms/config/models/config.py:522
-msgid "errored submission removal limit"
-msgstr "bewaartermijn voor niet voltooide inzendingen"
-
-#: openforms/forms/models/form.py:380
+#: openforms/forms/models/form.py:381
 msgid ""
 "Amount of days errored submissions of this form will remain before being "
 "removed. Leave blank to use value in General Configuration."
@@ -6857,7 +8200,7 @@ msgstr ""
 "afhandeling) bewaard blijft. Laat leeg om de waarde van de algemene "
 "configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:390
+#: openforms/forms/models/form.py:391
 msgid ""
 "How errored submissions of this form will be removed after the limit. Leave "
 "blank to use value in General Configuration."
@@ -6866,11 +8209,7 @@ msgstr ""
 "worden opgeschoond na de bewaartermijn. Laat leeg om de waarde van de "
 "algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:395 openforms/config/models/config.py:537
-msgid "all submissions removal limit"
-msgstr "bewaartermijn van inzendingen"
-
-#: openforms/forms/models/form.py:400
+#: openforms/forms/models/form.py:401
 msgid ""
 "Amount of days when all submissions of this form will be permanently "
 "deleted. Leave blank to use value in General Configuration."
@@ -6880,10 +8219,20 @@ msgstr ""
 "gebruiken."
 
 #: openforms/forms/models/form.py:408
+msgid "help callout page display"
+msgstr ""
+
+#: openforms/forms/models/form.py:412
+msgid ""
+"When to display the help callout page. Note that this field is disabled when"
+" the help callout page content in the global configuration is not specified."
+msgstr ""
+
+#: openforms/forms/models/form.py:421
 msgid "enable new logic rule evaluation"
 msgstr "gebruik nieuwe logica-evaluatie"
 
-#: openforms/forms/models/form.py:411
+#: openforms/forms/models/form.py:424
 msgid ""
 "Enabling this will analyze logic rules and re-order them according to their "
 "dependency on other logic rules (happens when the form is saved). Each rule "
@@ -6897,76 +8246,76 @@ msgstr ""
 "Daarnaast zullen ook andere snelheidsverbeteringen toegepast worden waar "
 "mogelijk."
 
-#: openforms/forms/models/form.py:438
+#: openforms/forms/models/form.py:451
 msgid "forms"
 msgstr "formulieren"
 
-#: openforms/forms/models/form.py:442
+#: openforms/forms/models/form.py:455
 #, python-brace-format
 msgid "{name} (deleted)"
 msgstr "{name} (verwijderd)"
 
-#: openforms/forms/models/form.py:502 openforms/forms/models/form.py:518
-#: openforms/forms/models/form.py:531
+#: openforms/forms/models/form.py:515 openforms/forms/models/form.py:531
+#: openforms/forms/models/form.py:544
 #, python-brace-format
 msgid "{backend} (invalid)"
 msgstr "{backend} (ongeldig)"
 
-#: openforms/forms/models/form.py:509
+#: openforms/forms/models/form.py:522
 msgid "registrations"
 msgstr "Registraties"
 
-#: openforms/forms/models/form.py:536
+#: openforms/forms/models/form.py:549
 msgid "logins"
 msgstr "inloggen"
 
-#: openforms/forms/models/form.py:581 openforms/forms/models/form.py:596
+#: openforms/forms/models/form.py:594 openforms/forms/models/form.py:609
 #: openforms/forms/models/form_definition.py:106
 #: openforms/forms/models/form_definition.py:124
 #, python-brace-format
 msgid "{name} (copy)"
 msgstr "{name} (kopie)"
 
-#: openforms/forms/models/form.py:585
+#: openforms/forms/models/form.py:598
 #: openforms/forms/models/form_definition.py:110
 #, python-brace-format
 msgid "{slug}-copy"
 msgstr "{slug}-kopie"
 
-#: openforms/forms/models/form.py:708
+#: openforms/forms/models/form.py:721
 #, python-brace-format
 msgid "Restored form version {version} (from {created})."
 msgstr "Formulierversie {version} hersteld (van {created})."
 
-#: openforms/forms/models/form.py:830
+#: openforms/forms/models/form.py:843
 msgid "export content"
 msgstr "Exportinhoud"
 
-#: openforms/forms/models/form.py:832
+#: openforms/forms/models/form.py:845
 msgid "Zip file containing all the exported forms."
 msgstr "Het ZIP-bestand met daarin alle geëxporteerde formulieren."
 
-#: openforms/forms/models/form.py:835
+#: openforms/forms/models/form.py:848
 msgid "date time requested"
 msgstr "Moment van aanvraag"
 
-#: openforms/forms/models/form.py:836
+#: openforms/forms/models/form.py:849
 msgid "The date and time on which the bulk export was requested."
 msgstr "De datum en tijdstip waarop de bulk export aangevraagd is."
 
-#: openforms/forms/models/form.py:842
+#: openforms/forms/models/form.py:855
 msgid "The user that requested the download."
 msgstr "De gebruiker die de download heeft aangevraagd."
 
-#: openforms/forms/models/form.py:849
+#: openforms/forms/models/form.py:862
 msgid "forms export"
 msgstr "formulierenexport"
 
-#: openforms/forms/models/form.py:850
+#: openforms/forms/models/form.py:863
 msgid "forms exports"
 msgstr "Formulierexports"
 
-#: openforms/forms/models/form.py:853
+#: openforms/forms/models/form.py:866
 #, python-format
 msgid "Bulk export requested by %(username)s on %(datetime)s"
 msgstr "Bulk-export aangevraagd door %(username)s op %(datetime)s"
@@ -7024,7 +8373,7 @@ msgstr ""
 
 #: openforms/forms/models/form_registration_backend.py:18
 #: openforms/forms/models/form_variable.py:269
-#: openforms/submissions/models/submission_value_variable.py:454
+#: openforms/submissions/models/submission_value_variable.py:449
 msgid "key"
 msgstr "sleutel"
 
@@ -7052,35 +8401,27 @@ msgstr "Vorige stap-label"
 
 #: openforms/forms/models/form_step.py:46
 msgid ""
-"The text that will be displayed in the form step to go to the previous step. "
-"Leave blank to get value from global configuration."
+"The text that will be displayed in the form step to go to the previous step."
+" Leave blank to get value from global configuration."
 msgstr ""
 "Het label van de knop om naar de vorige stap binnen het formulier te gaan. "
 "Laat leeg om de waarde van de algemene configuratie te gebruiken."
-
-#: openforms/forms/models/form_step.py:51 openforms/config/models/config.py:276
-msgid "step save text"
-msgstr "Opslaan-label"
 
 #: openforms/forms/models/form_step.py:55
 msgid ""
 "The text that will be displayed in the form step to save the current "
 "information. Leave blank to get value from global configuration."
 msgstr ""
-"Het label van de knop om het formulier tussentijds op te slaan. Laat leeg om "
-"de waarde van de algemene configuratie te gebruiken."
-
-#: openforms/forms/models/form_step.py:60 openforms/config/models/config.py:284
-msgid "step next text"
-msgstr "Volgende stap-label"
+"Het label van de knop om het formulier tussentijds op te slaan. Laat leeg om"
+" de waarde van de algemene configuratie te gebruiken."
 
 #: openforms/forms/models/form_step.py:64
 msgid ""
 "The text that will be displayed in the form step to go to the next step. "
 "Leave blank to get value from global configuration."
 msgstr ""
-"Het label van de knop om naar de volgende stap binnen het formulier te gaan. "
-"Laat leeg om de waarde van de algemene configuratie te gebruiken."
+"Het label van de knop om naar de volgende stap binnen het formulier te gaan."
+" Laat leeg om de waarde van de algemene configuratie te gebruiken."
 
 #: openforms/forms/models/form_step.py:69
 msgid "is applicable"
@@ -7122,7 +8463,7 @@ msgid "Key of the variable, should be unique with the form."
 msgstr "Sleutel van de variabele, uniek binnen het formulier."
 
 #: openforms/forms/models/form_variable.py:274
-#: openforms/submissions/models/submission_value_variable.py:465
+#: openforms/submissions/models/submission_value_variable.py:460
 msgid "source"
 msgstr "bron"
 
@@ -7165,30 +8506,30 @@ msgid ""
 "main identifier be used, or that related to the authorised person?"
 msgstr ""
 "Indien meerdere unieke identificaties beschikbaar zijn (bijvoorbeeld bij "
-"eHerkenning Bewindvoering en DigiD Machtigen), welke prefill-gegevens moeten "
-"dan opgehaald worden? Deze voor de machtiger of de gemachtigde?"
+"eHerkenning Bewindvoering en DigiD Machtigen), welke prefill-gegevens moeten"
+" dan opgehaald worden? Deze voor de machtiger of de gemachtigde?"
 
 #: openforms/forms/models/form_variable.py:313
 msgid "prefill options"
 msgstr "prefillopties"
 
 #: openforms/forms/models/form_variable.py:318
-#: openforms/submissions/models/submission_value_variable.py:498
+#: openforms/submissions/models/submission_value_variable.py:493
 msgid "data type"
 msgstr "datatype"
 
 #: openforms/forms/models/form_variable.py:319
-#: openforms/submissions/models/submission_value_variable.py:499
+#: openforms/submissions/models/submission_value_variable.py:494
 msgid "The type of the value that will be associated with this variable"
 msgstr "Datatype van de waarden voor deze variabele"
 
 #: openforms/forms/models/form_variable.py:324
-#: openforms/submissions/models/submission_value_variable.py:504
+#: openforms/submissions/models/submission_value_variable.py:499
 msgid "data subtype"
 msgstr "data subtype"
 
 #: openforms/forms/models/form_variable.py:326
-#: openforms/submissions/models/submission_value_variable.py:506
+#: openforms/submissions/models/submission_value_variable.py:501
 msgid ""
 "This field represents the data type of the values inside the container for "
 "components that are configured as 'multiple'."
@@ -7234,12 +8575,12 @@ msgstr "Formuliervariabelen"
 msgid "Form variable '{key}'"
 msgstr "Formuliervariabele '{key}'"
 
-#: openforms/forms/models/form_version.py:29
+#: openforms/forms/models/form_version.py:51
 #, python-brace-format
 msgid "Version {number}"
 msgstr "Versie {number}"
 
-#: openforms/forms/models/form_version.py:52
+#: openforms/forms/models/form_version.py:74
 msgid ""
 "The form, form definitions and form steps that make up this version, saved "
 "as JSON data."
@@ -7247,44 +8588,44 @@ msgstr ""
 "Het formulier, formulierdefinities en formulierstappen waaruit deze versie "
 "bestaat, bewaard als JSON."
 
-#: openforms/forms/models/form_version.py:57
+#: openforms/forms/models/form_version.py:79
 msgid "Date and time of creation of the form version."
 msgstr "Datum en tijd waarop de formulierversie is aangemaakt."
 
-#: openforms/forms/models/form_version.py:65
+#: openforms/forms/models/form_version.py:87
 msgid "User who authored this version."
 msgstr "Gebruiker die deze versie aangemaakt heeft."
 
-#: openforms/forms/models/form_version.py:68
+#: openforms/forms/models/form_version.py:90
 msgid "version description"
 msgstr "Versie-omschrijving"
 
-#: openforms/forms/models/form_version.py:70
+#: openforms/forms/models/form_version.py:92
 msgid "Description/context about this particular version."
 msgstr "Omschrijving/context bij deze specifieke versie."
 
-#: openforms/forms/models/form_version.py:73
+#: openforms/forms/models/form_version.py:95
 #: openforms/translations/models.py:78
 msgid "application version"
 msgstr "applicatieversie"
 
-#: openforms/forms/models/form_version.py:76
+#: openforms/forms/models/form_version.py:98
 msgid "App release/version at the time this version was created."
 msgstr "Applicatieversie op het moment dat deze versie onstond."
 
-#: openforms/forms/models/form_version.py:81
+#: openforms/forms/models/form_version.py:103
 msgid "application commit hash"
 msgstr "Commit hash van de applicatie"
 
-#: openforms/forms/models/form_version.py:84
+#: openforms/forms/models/form_version.py:106
 msgid "Application commit hash at the time this version was created."
 msgstr "Commit hash van de applicatie op het moment dat deze versie onstond."
 
-#: openforms/forms/models/form_version.py:92
+#: openforms/forms/models/form_version.py:114
 msgid "form version"
 msgstr "formulierversie"
 
-#: openforms/forms/models/form_version.py:93
+#: openforms/forms/models/form_version.py:115
 msgid "form versions"
 msgstr "formulierversies"
 
@@ -7341,7 +8682,8 @@ msgstr "Is geavanceerd"
 
 #: openforms/forms/models/logic.py:67
 msgid ""
-"Is this an advanced rule (the admin user manually wrote the trigger as JSON)?"
+"Is this an advanced rule (the admin user manually wrote the trigger as "
+"JSON)?"
 msgstr ""
 "Is dit een geavanceerde regel (de beheerder heeft de trigger handmatig als "
 "JSON geschreven)?"
@@ -7408,29 +8750,29 @@ msgstr "Sorteren in/uitschakelen"
 msgid "Forms without category"
 msgstr "Formulieren zonder categorie"
 
-#: openforms/forms/templates/admin/forms/form/export.html:12
-#: openforms/forms/templates/admin/forms/form/import_form.html:13
-#: openforms/forms/templates/admin/forms/form/migrate-payment-backend.html:18
-#: openforms/forms/templates/admin/forms/formsubmissionstatistics/export_form.html:19
-#: openforms/config/templates/admin/config/overview.html:8
-#: openforms/config/templates/admin/config/theme/preview.html:13
-msgid "Home"
-msgstr "Thuis"
-
-#: openforms/forms/templates/admin/forms/form/export.html:24
+#: openforms/forms/templates/admin/forms/form/export.html:34
 msgid ""
-"\n"
-"            Once your request has been processed, you will be sent an email "
-"(at the address configured in your admin\n"
-"            profile) containing a link where you can download a zip file "
-"with all the exported forms.\n"
-"            "
+"<p> Here you can control how the previously selected forms will be exported."
+" Using these options, sensitive information can be anonymized, certain form "
+"configuration can be left out, and additional information can be included. "
+"</p> <p> These export options will be used for each form that will be "
+"exported. </p> <p> After you've clicked the \"Export\" button, the forms "
+"will be exported in the background. <br/> Once your request has been "
+"processed, you will be sent an email (at the address configured in your "
+"admin profile) containing a link where you can download a zip file with all "
+"the exported forms. </p>"
 msgstr ""
-"\n"
-"Zodra uw verzoek verwerkt is, ontvangt u een e-mail met een link naar het "
-"ZIP-bestand dat alle geëxporteerde formulieren bevat."
+"<p>Hier kan je bepalen hoe de eerder geselecteerde formuliere geëxporteerd "
+"worden. Met deze opties kan gevoelige informatie geanonimiseerd worden, "
+"kunnen formulierinstellingen uitgesloten worden en aanvullende gegevens "
+"toegevoegd worden. </p><p>Deze exporteeropties worden gebruikt voor ieder "
+"formulier dat geëxporteerd zal worden. </p><p> Nadat je op de "
+"\\\"Exporteren\\\" knop hebt gedrukt, worden de formulieren in de "
+"achtergrond geëxporteerd. <br/> Zodra uw verzoek verwerkt is, ontvangt u een"
+" e-mail met een link naar het ZIP-bestand dat alle geëxporteerde formulieren"
+" bevat.</p>"
 
-#: openforms/forms/templates/admin/forms/form/export.html:41
+#: openforms/forms/templates/admin/forms/form/export.html:72
 #: openforms/forms/templates/admin/forms/formsubmissionstatistics/export_form.html:62
 msgid "Export"
 msgstr "Exporteren"
@@ -7457,21 +8799,14 @@ msgstr "Terug"
 #: openforms/forms/templates/admin/forms/form/migrate-payment-backend.html:45
 msgid ""
 "\n"
-"                Please confirm that the forms below should be migrated to "
-"the Worldline payment\n"
+"                Please confirm that the forms below should be migrated to the Worldline payment\n"
 "                provider backend:\n"
 "                "
 msgstr ""
 "\n"
-"                Bevestig dat de onderstaande formulieren gemigreerd moeten "
-"worden\n"
+"                Bevestig dat de onderstaande formulieren gemigreerd moeten worden\n"
 "                naar de Worldline betalingsprovider backend:\n"
 "                 "
-
-#: openforms/forms/templates/admin/forms/form/migrate-payment-backend.html:69
-#: openforms/config/models/config.py:251
-msgid "Confirm"
-msgstr "Verzenden"
 
 #: openforms/forms/templates/admin/forms/formsexport/email_content.html:3
 msgid "Hi,"
@@ -7481,13 +8816,11 @@ msgstr "Hallo,"
 #, python-format
 msgid ""
 "\n"
-"    Your zip file containing the exported forms is ready and can be "
-"downloaded at the following URL:\n"
+"    Your zip file containing the exported forms is ready and can be downloaded at the following URL:\n"
 "    %(download_url)s\n"
 msgstr ""
 "\n"
-"Uw ZIP-bestand met formulier-exports is klaar. U kunt deze downloaden op de "
-"volgende URL: %(download_url)s.\n"
+"Uw ZIP-bestand met formulier-exports is klaar. U kunt deze downloaden op de volgende URL: %(download_url)s.\n"
 
 #: openforms/forms/templates/admin/forms/formsexport/email_content.html:13
 msgid "Best wishes,"
@@ -7517,8 +8850,8 @@ msgid ""
 "<p>Here you can create an export of successfully registered form "
 "submissions. The export file contains the following columns: public "
 "reference, form name, form internal name, the submission datetime and the "
-"timestamp of registration.</p> <p>You can use the filters below to limit the "
-"result set in the export.</p>"
+"timestamp of registration.</p> <p>You can use the filters below to limit the"
+" result set in the export.</p>"
 msgstr ""
 "<p>Je kan hier een export maken van inzendingen die met success "
 "geregistreerd zijn. Het exportbestand bevat de volgende kolommen: publieke "
@@ -7816,8 +9149,8 @@ msgstr "%(lead)s: bulk-export bestand gedownload."
 #: openforms/logging/templates/logging/events/email_status_change.txt:2
 #, python-format
 msgid ""
-"%(lead)s: The status of the email being sent for the event \"%(event)s\" has "
-"changed. It is now: \"%(status)s\""
+"%(lead)s: The status of the email being sent for the event \"%(event)s\" has"
+" changed. It is now: \"%(status)s\""
 msgstr ""
 "%(lead)s: De e-mailverzendstatus voor het event \"%(event)s\" is gewijzigd "
 "naar \"%(status)s\"."
@@ -7872,17 +9205,17 @@ msgstr ""
 #: openforms/logging/templates/logging/events/object_ownership_check_failure.txt:2
 #, python-format
 msgid ""
-"%(lead)s: Registration plugin %(plugin)s reported: authenticated user is not "
-"the owner of referenced object."
+"%(lead)s: Registration plugin %(plugin)s reported: authenticated user is not"
+" the owner of referenced object."
 msgstr ""
-"%(lead)s: Registratieplugin %(plugin)s meldt: de ingelogde gebruiker is niet "
-"de eigenaar van het aangewezen object."
+"%(lead)s: Registratieplugin %(plugin)s meldt: de ingelogde gebruiker is niet"
+" de eigenaar van het aangewezen object."
 
 #: openforms/logging/templates/logging/events/object_ownership_check_success.txt:2
 #, python-format
 msgid ""
-"%(lead)s: Registration plugin %(plugin)s reported: authenticated user is the "
-"owner of referenced object."
+"%(lead)s: Registration plugin %(plugin)s reported: authenticated user is the"
+" owner of referenced object."
 msgstr ""
 "%(lead)s: Registratieplugin %(plugin)s meldt: de ingelogde gebruiker is de "
 "eigenaar van het aangewezen object."
@@ -7893,8 +9226,8 @@ msgid ""
 "%(lead)s: User %(user)s viewed outgoing request log %(method)s %(url)s in "
 "the admin"
 msgstr ""
-"%(lead)s: Gebruiker %(user)s bekeek de log voor uitgaande verzoek %(method)s "
-"%(url)s in de admin."
+"%(lead)s: Gebruiker %(user)s bekeek de log voor uitgaande verzoek %(method)s"
+" %(url)s in de admin."
 
 #: openforms/logging/templates/logging/events/payment_flow_failure.txt:2
 #, python-format
@@ -7982,7 +9315,8 @@ msgstr "%(lead)s: Prefillplugin %(plugin)s gaf lege waarden terug."
 #: openforms/logging/templates/logging/events/prefill_retrieve_failure.txt:2
 #, python-format
 msgid ""
-"%(lead)s: Prefill plugin %(plugin)s reported: Failed to retrieve information."
+"%(lead)s: Prefill plugin %(plugin)s reported: Failed to retrieve "
+"information."
 msgstr ""
 "%(lead)s: Prefillplugin %(plugin)s meldt: Informatie kon niet worden "
 "opgehaald."
@@ -7993,8 +9327,8 @@ msgid ""
 "%(lead)s: Prefill plugin %(plugin)s reported: Successfully retrieved "
 "information to prefill fields: %(fields)s"
 msgstr ""
-"%(lead)s: Prefillplugin %(plugin)s meldt: Informatie met succes opgehaald om "
-"velden te prefillen: %(fields)s."
+"%(lead)s: Prefillplugin %(plugin)s meldt: Informatie met succes opgehaald om"
+" velden te prefillen: %(fields)s."
 
 #: openforms/logging/templates/logging/events/price_calculation_variable_error.txt:2
 #, python-format
@@ -8034,7 +9368,8 @@ msgstr "%(lead)s: Registratie-debuggegevens: %(message)s %(resolved_backend)s"
 
 #: openforms/logging/templates/logging/events/registration_failure.txt:2
 #, python-format
-msgid "%(lead)s: Registration plugin %(plugin)s reported: Registration failed."
+msgid ""
+"%(lead)s: Registration plugin %(plugin)s reported: Registration failed."
 msgstr "%(lead)s: Registratieplugin %(plugin)s meldt: Registratie mislukt."
 
 #: openforms/logging/templates/logging/events/registration_payment_update_failure.txt:2
@@ -8103,8 +9438,8 @@ msgstr ""
 #: openforms/logging/templates/logging/events/registration_update_with_confirmation_email_skip.txt:2
 #, python-format
 msgid ""
-"%(lead)s: Update submission registration with confirmation email skipped: no "
-"backend configured."
+"%(lead)s: Update submission registration with confirmation email skipped: no"
+" backend configured."
 msgstr ""
 "%(lead)s: Wijzigen registratietaak met bevestigingsmail overgeslagen: Geen "
 "\"backend geconfigureerd."
@@ -8220,8 +9555,8 @@ msgid ""
 "[%(lead)s] (Form %(form)s): User authenticated with plugin %(plugin)s "
 "(identifier: %(identifier)s)"
 msgstr ""
-"[%(lead)s] (Formulier %(form)s): Gebruiker is ingelogd met plugin %(plugin)s "
-"(identificatie: %(identifier)s)"
+"[%(lead)s] (Formulier %(form)s): Gebruiker is ingelogd met plugin %(plugin)s"
+" (identificatie: %(identifier)s)"
 
 #: openforms/multidomain/models.py:9
 msgid "The name to show in the domain switcher."
@@ -8230,12 +9565,14 @@ msgstr "De naam om weer te geven in de domeinwisselaar"
 #: openforms/multidomain/models.py:14
 msgid ""
 "The absolute URL to redirect to. Typically this starts the login process on "
-"the other domain. For example: https://open-forms.example.com/oidc/"
-"authenticate/ or https://open-forms.example.com/admin/login/"
+"the other domain. For example: https://open-"
+"forms.example.com/oidc/authenticate/ or https://open-"
+"forms.example.com/admin/login/"
 msgstr ""
 "De volledige URL om naar om te leiden. Deze URL start typisch het login "
-"proces op het doeldomein. Bijvoorbeeld: https://open-forms.example.com/oidc/"
-"authenticate/ of https://open-forms.example.com/admin/login/"
+"proces op het doeldomein. Bijvoorbeeld: https://open-"
+"forms.example.com/oidc/authenticate/ of https://open-"
+"forms.example.com/admin/login/"
 
 #: openforms/multidomain/models.py:20
 msgid "current"
@@ -8243,11 +9580,11 @@ msgstr "huidige"
 
 #: openforms/multidomain/models.py:22
 msgid ""
-"Select this to show this domain as the current domain. The current domain is "
-"selected by default and will not trigger a redirect."
+"Select this to show this domain as the current domain. The current domain is"
+" selected by default and will not trigger a redirect."
 msgstr ""
-"Selecteer deze optie om dit domein weer te geven als het huidige domein. Het "
-"huidige domein is standaard geselecteerd in de domeinwisselaar."
+"Selecteer deze optie om dit domein weer te geven als het huidige domein. Het"
+" huidige domein is standaard geselecteerd in de domeinwisselaar."
 
 #: openforms/multidomain/models.py:29
 msgid "domains"
@@ -8393,13 +9730,13 @@ msgid ""
 "Optional custom template for the description, included in the payment "
 "overviews for the backoffice. Use this to link the payment back to a "
 "particular process or form. You can include all form variables (using their "
-"keys) and the 'public_reference' variable (using expression "
-"'{{ public_reference }}'). If unspecified, a default description is used. "
-"Note that the length of the result is capped to 32 characters."
+"keys) and the 'public_reference' variable (using expression '{{ "
+"public_reference }}'). If unspecified, a default description is used. Note "
+"that the length of the result is capped to 32 characters."
 msgstr ""
 "Sjabloon voor de omschrijving van de betaling in de afschriften die je bij "
-"Worldline kan ophalen. Gebruik dit om betalingen aan processen/afdelingen te "
-"koppelen. Je kan alle formuliervariabelen gebruiken (gebruik de "
+"Worldline kan ophalen. Gebruik dit om betalingen aan processen/afdelingen te"
+" koppelen. Je kan alle formuliervariabelen gebruiken (gebruik de "
 "variabelesleutel als naam) en de 'public_reference' sjabloonvariabele "
 "(gebruik de expressie '{{ public_reference }}'). Indien geen sjabloon "
 "opgegeven is, dan wordt een standaardomschrijving gebruikt. Merk op dat het "
@@ -8446,11 +9783,8 @@ msgstr "Webhooks instellen"
 #, python-brace-format
 msgid ""
 "[Open Forms] {form_name} - submission payment received {public_reference}"
-msgstr "[Open Formulieren] {form_name} - betaling ontvangen {public_reference}"
-
-#: openforms/payments/models.py:105
-msgid "Payment backend"
-msgstr "Betaalprovider backend"
+msgstr ""
+"[Open Formulieren] {form_name} - betaling ontvangen {public_reference}"
 
 #: openforms/payments/models.py:107
 msgid "Payment options"
@@ -8468,8 +9802,8 @@ msgstr "Bestelling ID"
 #: openforms/payments/models.py:118
 msgid ""
 "The order ID to be sent to the payment provider. This ID is built by "
-"concatenating an optional global prefix, the submission public reference and "
-"a unique incrementing ID."
+"concatenating an optional global prefix, the submission public reference and"
+" a unique incrementing ID."
 msgstr ""
 "Het ordernummer wat naar de betaalprovider gestuurd wordt. Dit nummer wordt "
 "opgebouwd met een (optionele) globale prefix, publieke "
@@ -8527,11 +9861,9 @@ msgstr "Start het betaalproces"
 
 #: openforms/payments/views.py:52
 msgid ""
-"This endpoint provides information to start the payment flow for a "
-"submission.\n"
+"This endpoint provides information to start the payment flow for a submission.\n"
 "\n"
-"Due to support for legacy platforms this view doesn't redirect but provides "
-"information for the frontend to be used client side.\n"
+"Due to support for legacy platforms this view doesn't redirect but provides information for the frontend to be used client side.\n"
 "\n"
 "Various validations are performed:\n"
 "* the form and submission must require payment\n"
@@ -8540,16 +9872,11 @@ msgid ""
 "* the `next` parameter must be present\n"
 "* the `next` parameter must match the CORS policy\n"
 "\n"
-"The HTTP 200 response contains the information to start the flow with the "
-"payment provider. Depending on the 'type', send a `GET` or `POST` request "
-"with the `data` as 'Form Data' to the given 'url'."
+"The HTTP 200 response contains the information to start the flow with the payment provider. Depending on the 'type', send a `GET` or `POST` request with the `data` as 'Form Data' to the given 'url'."
 msgstr ""
-"Dit endpoint geeft informatie om het betaalproces te starten voor een "
-"inzending.\n"
+"Dit endpoint geeft informatie om het betaalproces te starten voor een inzending.\n"
 "\n"
-"Om legacy platformen te ondersteunen kan dit endpoint niet doorverwijzen "
-"maar geeft doorverwijs informatie terug aan de frontend die het verder moet "
-"afhandelen.\n"
+"Om legacy platformen te ondersteunen kan dit endpoint niet doorverwijzen maar geeft doorverwijs informatie terug aan de frontend die het verder moet afhandelen.\n"
 "\n"
 "Diverse validaties worden uitgevoerd:\n"
 "* het formulier vereist betaling\n"
@@ -8557,9 +9884,7 @@ msgstr ""
 "* de `next` parameter moet aanwezig zijn\n"
 "* de `next` parameter moet overeenkomen met het CORS-beleid\n"
 "\n"
-"Het HTTP 200 antwoord bevat informatie om het betaalproces te starten bij de "
-"betaalprovider. Afhankelijk van het `type`, een `POST` of `GET` is wordt "
-"verstuurd met de `data` als 'Form Data' naar de opgegeven 'url'."
+"Het HTTP 200 antwoord bevat informatie om het betaalproces te starten bij de betaalprovider. Afhankelijk van het `type`, een `POST` of `GET` is wordt verstuurd met de `data` als 'Form Data' naar de opgegeven 'url'."
 
 #: openforms/payments/views.py:70
 msgid "UUID identifying the submission."
@@ -8587,11 +9912,9 @@ msgstr "Aanroeppunt van het externe betaalprovider proces"
 
 #: openforms/payments/views.py:154
 msgid ""
-"Payment plugins call this endpoint in the return step of the payment flow. "
-"Depending on the plugin, either `GET` or `POST` is allowed as HTTP method.\n"
+"Payment plugins call this endpoint in the return step of the payment flow. Depending on the plugin, either `GET` or `POST` is allowed as HTTP method.\n"
 "\n"
-"Typically payment plugins will redirect again to the URL where the SDK is "
-"embedded.\n"
+"Typically payment plugins will redirect again to the URL where the SDK is embedded.\n"
 "\n"
 "Various validations are performed:\n"
 "* the form and submission must require payment\n"
@@ -8599,9 +9922,7 @@ msgid ""
 "* payment is required and configured on the form\n"
 "* the redirect target must match the CORS policy"
 msgstr ""
-"Betaalproviderplugins roepen dit endpoint aan zodra het externe betaalproces "
-"is afgerond. Afhankelijk van de plugin, een `POST` of `GET` is toegestaan "
-"als HTTP-methode.\n"
+"Betaalproviderplugins roepen dit endpoint aan zodra het externe betaalproces is afgerond. Afhankelijk van de plugin, een `POST` of `GET` is toegestaan als HTTP-methode.\n"
 "\n"
 "Betaalproviderplugins zullen typisch een redirect uitvoeren naar de SDK.\n"
 "\n"
@@ -8636,30 +9957,21 @@ msgstr "Webhook-handler voor externe betalingsproces"
 
 #: openforms/payments/views.py:299
 msgid ""
-"This endpoint is used for server-to-server calls. Depending on the plugin, "
-"multiple request HTTP methods are supported.\n"
+"This endpoint is used for server-to-server calls. Depending on the plugin, multiple request HTTP methods are supported.\n"
 "\n"
 "Various validations are performed:\n"
 "* the `plugin_id` is configured on the form\n"
 "* payment is required and configured on the form\n"
 "\n"
-"Whenever the webhook_verification_header and webhook_verification_method "
-"settings are set for a plugin and a request has an empty request body, the "
-"request headers will be searched for the webhook_verification_header and "
-"will be returned as the response body."
+"Whenever the webhook_verification_header and webhook_verification_method settings are set for a plugin and a request has an empty request body, the request headers will be searched for the webhook_verification_header and will be returned as the response body."
 msgstr ""
-"Deze endpoint wordt gebruikt voor server-to-server verzoeken. Afhankelijk "
-"van de plugin, worden meerdere HTTP methoden ondersteund.\n"
+"Deze endpoint wordt gebruikt voor server-to-server verzoeken. Afhankelijk van de plugin, worden meerdere HTTP methoden ondersteund.\n"
 "\n"
 "Verschillende acties omtrent validatie vinden plaats:\n"
 "* de `plugin_id` is geconfigureerd in het formulier\n"
 "* betalingen zijn verplicht en geconfigureerd in het formulier\n"
 "\n"
-"Wanneer de webhook_verification_header en de webook_verification_method "
-"instellingen een waarde toegekend hebben en de body van de HTTP-request leeg "
-"is zullen de HTTP headers doorzocht worden voor de "
-"webhook_verification_header header en zal deze teruggeven worden als inhoud "
-"van de response."
+"Wanneer de webhook_verification_header en de webook_verification_method instellingen een waarde toegekend hebben en de body van de HTTP-request leeg is zullen de HTTP headers doorzocht worden voor de webhook_verification_header header en zal deze teruggeven worden als inhoud van de response."
 
 #: openforms/payments/views.py:339
 msgid "The response returned when a webhook event is processed."
@@ -8714,8 +10026,8 @@ msgstr "Verplichte authenticatieplugin"
 
 #: openforms/prefill/api/serializers.py:27
 msgid ""
-"The specific authentication plugin required for this plugin to be activated. "
-"If empty, then no requirements apply."
+"The specific authentication plugin required for this plugin to be activated."
+" If empty, then no requirements apply."
 msgstr ""
 "De specifieke authenticatieplugin die noodzakelijk is voor het inschakelen "
 "van deze plugin. Als dit veld leeg is, dan zijn er geen verplichtingen van "
@@ -8738,7 +10050,8 @@ msgstr "Form.io componenttype"
 
 #: openforms/prefill/api/serializers.py:45
 msgid "Only return plugins applicable for the specified component type."
-msgstr "Geef enkel plugins die relevant zijn voor het opgegeven componenttype."
+msgstr ""
+"Geef enkel plugins die relevant zijn voor het opgegeven componenttype."
 
 #: openforms/prefill/api/serializers.py:79
 #: openforms/registrations/api/serializers.py:31
@@ -8762,10 +10075,6 @@ msgstr "Lijst van beschikbare attributen"
 #, python-brace-format
 msgid "No plugin with ID '{plugin}' found"
 msgstr "Geen plugin met ID '{plugin}' gevonden"
-
-#: openforms/prefill/apps.py:7 openforms/submissions/constants.py:52
-msgid "Prefill"
-msgstr "Prefill"
 
 #: openforms/prefill/constants.py:6
 msgid "Main"
@@ -8817,7 +10126,8 @@ msgid ""
 "The format should comply to how Formio handles nested component keys."
 msgstr ""
 "De sleutel van de formuliervariabele die naar de klantprofielcomponent "
-"wijst. Het formaat moet overeenkomen met hoe Formio omgaat met geneste paden."
+"wijst. Het formaat moet overeenkomen met hoe Formio omgaat met geneste "
+"paden."
 
 #: openforms/prefill/contrib/customer_interactions/config.py:45
 #, python-brace-format
@@ -8908,7 +10218,8 @@ msgstr "Geen (ingeschakelde) OIDC-client gevonden voor eIDAS (burger)."
 #: openforms/prefill/contrib/eidas/plugin.py:96
 msgid "Missing OIDC client identity settings for eIDAS."
 msgstr ""
-"Ontbrekende identificatie-instellingen in de OIDC-client voor eIDAS (burger)."
+"Ontbrekende identificatie-instellingen in de OIDC-client voor eIDAS "
+"(burger)."
 
 #: openforms/prefill/contrib/eidas/plugin.py:109
 #: openforms/prefill/contrib/eidas/plugin.py:187
@@ -8966,8 +10277,8 @@ msgstr "formuliervariabelesleutel van de gegevens"
 
 #: openforms/prefill/contrib/family_members/config.py:42
 msgid ""
-"The 'dotted' path to a form variable key which is a copy of the initial data "
-"which has been retrieved and may change. The format should comply to how "
+"The 'dotted' path to a form variable key which is a copy of the initial data"
+" which has been retrieved and may change. The format should comply to how "
 "Formio handles nested component keys."
 msgstr ""
 "Het 'gestippelde' pad naar een formuliervariabelesleutel die een kopie is "
@@ -10211,10 +11522,6 @@ msgstr ""
 "Informatietekst die moet worden weergegeven op de bevestigingspagina en "
 "bevestigingsmail. "
 
-#: openforms/products/models/product.py:43
-msgid "Product"
-msgstr "Product"
-
 #: openforms/registrations/api/views.py:19
 msgid "List available registration plugins"
 msgstr "Lijst van beschikbare registratieplugins"
@@ -10266,10 +11573,10 @@ msgid ""
 "using this field, the mailing will only be sent to this email address. The "
 "email addresses field would then be ignored. "
 msgstr ""
-"Sleutel van de variabele waarvan de waarde gebruikt wordt als ontvanger (e-"
-"mailadres). Als je dit instelt en de variabele heeft een waarde, dan wordt "
-"de e-mail enkel naar dit adres gestuurd - de vaste e-mailaddressen worden "
-"genegeerd."
+"Sleutel van de variabele waarvan de waarde gebruikt wordt als ontvanger "
+"(e-mailadres). Als je dit instelt en de variabele heeft een waarde, dan "
+"wordt de e-mail enkel naar dit adres gestuurd - de vaste e-mailaddressen "
+"worden genegeerd."
 
 #: openforms/registrations/contrib/email/config.py:55
 msgid "The format(s) of the attachment(s) containing the submission details"
@@ -10298,8 +11605,8 @@ msgid ""
 msgstr ""
 "Vink aan om gebruikersbestanden als bijlage aan de registratiemail toe te "
 "voegen. Als een waarde gezet is, dan heeft deze hogere prioriteit dan de "
-"globale configuratie. Formulierbeheerders moeten ervoor zorgen dat de totale "
-"maximale bestandsgrootte onder de maximale e-mailbestandsgrootte blijft."
+"globale configuratie. Formulierbeheerders moeten ervoor zorgen dat de totale"
+" maximale bestandsgrootte onder de maximale e-mailbestandsgrootte blijft."
 
 #: openforms/registrations/contrib/email/config.py:77
 msgid "email subject"
@@ -10574,13 +11881,13 @@ msgstr "maplocatie"
 
 #: openforms/registrations/contrib/microsoft_graph/config.py:28
 msgid ""
-"The path of the folder where folders containing Open-Forms related documents "
-"will be created. You can use the expressions {{ year }}, {{ month }} and "
-"{{ day }}. It should be an absolute path - i.e. it should start with /"
+"The path of the folder where folders containing Open-Forms related documents"
+" will be created. You can use the expressions {{ year }}, {{ month }} and {{"
+" day }}. It should be an absolute path - i.e. it should start with /"
 msgstr ""
 "Het pad naar de map waar mappen voor documenten van Open Formulieren "
-"aangemaakt worden. Je kan de expressies {{ year }}, {{ month }} en {{ day }} "
-"gebruiken. Dit moet een absoluut pad zijn (dus beginnen met een /)."
+"aangemaakt worden. Je kan de expressies {{ year }}, {{ month }} en {{ day }}"
+" gebruiken. Dit moet een absoluut pad zijn (dus beginnen met een /)."
 
 #: openforms/registrations/contrib/microsoft_graph/config.py:36
 msgid "drive ID"
@@ -10630,8 +11937,7 @@ msgstr "verplicht"
 
 #: openforms/registrations/contrib/objects_api/api/serializers.py:18
 msgid "Wether the path is marked as required in the JSON Schema."
-msgstr ""
-"Geeft aan of het pad als \"verplicht\" gemarkeerd is in het JSON-schema."
+msgstr "Geeft aan of het pad als \"verplicht\" gemarkeerd is in het JSON-schema."
 
 #: openforms/registrations/contrib/objects_api/api/serializers.py:28
 msgid "objecttype uuid"
@@ -10689,14 +11995,14 @@ msgstr "Documenttypeomschrijving"
 #: openforms/registrations/contrib/zgw_apis/options.py:69
 msgid ""
 "The document type will be retrieved from the catalogue and case type "
-"specified in the backend options. The version will automatically be selected "
-"based on the submission completion timestamp. Only document types related to "
-"the case type are valid."
+"specified in the backend options. The version will automatically be selected"
+" based on the submission completion timestamp. Only document types related "
+"to the case type are valid."
 msgstr ""
-"Het documenttype wordt opgehaald binnen de ingestelde catalogus en zaaktype. "
-"De juiste versie van het documenttype wordt automatisch bepaald aan de hand "
-"van de inzendingsdatum. Enkel documenttypen die bij het zaaktype horen zijn "
-"geldig."
+"Het documenttype wordt opgehaald binnen de ingestelde catalogus en zaaktype."
+" De juiste versie van het documenttype wordt automatisch bepaald aan de hand"
+" van de inzendingsdatum. Enkel documenttypen die bij het zaaktype horen zijn"
+" geldig."
 
 #: openforms/registrations/contrib/objects_api/config.py:88
 #: openforms/registrations/contrib/zgw_apis/options.py:79
@@ -10741,8 +12047,8 @@ msgid ""
 "The schema version of the objects API Options. Not to be confused with the "
 "objecttype version."
 msgstr ""
-"De versie van de optiesconfiguratie. Niet te verwarren met de versie van het "
-"objecttype."
+"De versie van de optiesconfiguratie. Niet te verwarren met de versie van het"
+" objecttype."
 
 #: openforms/registrations/contrib/objects_api/config.py:138
 msgid ""
@@ -10750,8 +12056,8 @@ msgid ""
 "objecttype should have the following three attributes: 1) submission_id; 2) "
 "type (the type of productaanvraag); 3) data (the submitted form data)"
 msgstr ""
-"UUID van het OBJECTTYPE voor de 'ProductAanvraag' in de Objecttypen API. Het "
-"objecttype moet de volgende attributen bevatten: 1) submission_id; 2) type "
+"UUID van het OBJECTTYPE voor de 'ProductAanvraag' in de Objecttypen API. Het"
+" objecttype moet de volgende attributen bevatten: 1) submission_id; 2) type "
 "(het type van de 'ProductAanvraag'); 3) data (ingezonden formuliergegevens)"
 
 #: openforms/registrations/contrib/objects_api/config.py:150
@@ -10772,8 +12078,8 @@ msgstr "CSV bestand inzending uploaden"
 
 #: openforms/registrations/contrib/objects_api/config.py:167
 msgid ""
-"Indicates whether or not the submission CSV should be uploaded as a Document "
-"in Documenten API and attached to the ProductAanvraag."
+"Indicates whether or not the submission CSV should be uploaded as a Document"
+" in Documenten API and attached to the ProductAanvraag."
 msgstr ""
 "Geeft aan of de inzendingsgegevens als CSV in de Documenten API moet "
 "geüpload worden en toegevoegd aan de ProductAanvraag."
@@ -10791,7 +12097,8 @@ msgid ""
 msgstr ""
 "Omschrijving van het documenttype in de Catalogi API voor het PDF-document "
 "met inzendingsgegevens. De juiste versie wordt automatisch geselecteerd op "
-"basis van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
+"basis van de inzendingsdatum en geldigheidsdatums van de "
+"documenttypeversies."
 
 #: openforms/registrations/contrib/objects_api/config.py:200
 msgid ""
@@ -10802,7 +12109,8 @@ msgid ""
 msgstr ""
 "Omschrijving van het documenttype in de Catalogi API voor het CSV-document "
 "met inzendingsgegevens. De juiste versie wordt automatisch geselecteerd op "
-"basis van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
+"basis van de inzendingsdatum en geldigheidsdatums van de "
+"documenttypeversies."
 
 #: openforms/registrations/contrib/objects_api/config.py:213
 msgid ""
@@ -10812,8 +12120,8 @@ msgid ""
 "document type versions."
 msgstr ""
 "Omschrijving van het documenttype in de Catalogi API voor "
-"inzendingsbijlagen. De juiste versie wordt automatisch geselecteerd op basis "
-"van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
+"inzendingsbijlagen. De juiste versie wordt automatisch geselecteerd op basis"
+" van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
 
 #: openforms/registrations/contrib/objects_api/config.py:223
 #: openforms/registrations/contrib/stuf_zds/options.py:135
@@ -10825,16 +12133,16 @@ msgstr "Bestanden"
 #: openforms/registrations/contrib/stuf_zds/options.py:138
 #: openforms/registrations/contrib/zgw_apis/options.py:329
 msgid ""
-"List of file upload options for file components. Each entry contains the key "
-"of the file component in the form, which may be a child in an edit grid. Any "
-"specified option overrides the equivalent option on the backend level. If "
-"unspecified, the backend configuration is used."
+"List of file upload options for file components. Each entry contains the key"
+" of the file component in the form, which may be a child in an edit grid. "
+"Any specified option overrides the equivalent option on the backend level. "
+"If unspecified, the backend configuration is used."
 msgstr ""
 "Lijst van instellingen voor bestandsupload-componenten. Elk item bevat de "
 "sleutel van het bestandsupload-component in het formulier, wat een item "
 "binnen een herhalende groep kan zijn. De opgegeven instellingen "
-"overschrijven de standaardinstellingen. Indien niet gespecifieerd, worden de "
-"backend-instellingen gebruikt."
+"overschrijven de standaardinstellingen. Indien niet gespecifieerd, worden de"
+" backend-instellingen gebruikt."
 
 #: openforms/registrations/contrib/objects_api/config.py:236
 msgid "productaanvraag type"
@@ -10954,8 +12262,8 @@ msgstr "Productaanvraag type"
 
 #: openforms/registrations/contrib/objects_api/models.py:30
 msgid ""
-"Description of the 'ProductAanvraag' type. This value is saved in the 'type' "
-"attribute of the 'ProductAanvraag'."
+"Description of the 'ProductAanvraag' type. This value is saved in the 'type'"
+" attribute of the 'ProductAanvraag'."
 msgstr ""
 "Omschrijving van het type van de 'Productaanvraag'. Deze waarde wordt "
 "bewaard in het 'type' attribuut van de 'ProductAanvraag'."
@@ -10985,7 +12293,7 @@ msgstr "Objecten API configuratie"
 #: openforms/submissions/models/submission_files.py:55
 #: openforms/submissions/models/submission_files.py:204
 #: openforms/submissions/models/submission_report.py:30
-#: openforms/submissions/models/submission_value_variable.py:448
+#: openforms/submissions/models/submission_value_variable.py:443
 msgid "submission"
 msgstr "inzending"
 
@@ -11025,7 +12333,8 @@ msgstr "Documenten URL"
 #: openforms/registrations/contrib/objects_api/models.py:106
 msgid "The URL of the submission attachment registered in the Documents API."
 msgstr ""
-"De resource-URL in de Documenten API van de geregistreerde inzendingsbijlage."
+"De resource-URL in de Documenten API van de geregistreerde "
+"inzendingsbijlage."
 
 #: openforms/registrations/contrib/objects_api/plugin.py:44
 msgid "Objects API registration"
@@ -11116,8 +12425,8 @@ msgstr ""
 #: openforms/registrations/contrib/stuf_zds/options.py:64
 #: openforms/registrations/contrib/zgw_apis/options.py:96
 msgid ""
-"Optional custom title for the document. By default, the attachment file name "
-"is used."
+"Optional custom title for the document. By default, the attachment file name"
+" is used."
 msgstr ""
 "Optionele aangepaste documenttitel. Standaard wordt de bijlage-bestandsnaam "
 "gebruikt."
@@ -11136,7 +12445,8 @@ msgstr "Zaaktype status code voor nieuw aangemaakte zaken via StUF-ZDS"
 
 #: openforms/registrations/contrib/stuf_zds/options.py:90
 msgid "Zaaktype status omschrijving for newly created zaken in StUF-ZDS"
-msgstr "Zaaktype status omschrijving voor nieuw aangemaakte zaken via StUF-ZDS"
+msgstr ""
+"Zaaktype status omschrijving voor nieuw aangemaakte zaken via StUF-ZDS"
 
 #: openforms/registrations/contrib/stuf_zds/options.py:96
 msgid "Documenttype description for newly created zaken in StUF-ZDS"
@@ -11165,8 +12475,8 @@ msgid ""
 "is sent to StUF-ZDS. Those keys and the values belonging to them in the "
 "submission data are included in Object/extraElementen."
 msgstr ""
-"Met deze variabelekoppelingen stel je in welke formuliervariabelen als extra "
-"elementen in Object/extraElementen binnen StUF-ZDS meegestuurd worden, en "
+"Met deze variabelekoppelingen stel je in welke formuliervariabelen als extra"
+" elementen in Object/extraElementen binnen StUF-ZDS meegestuurd worden, en "
 "met welke naam."
 
 #: openforms/registrations/contrib/stuf_zds/options.py:123
@@ -11179,8 +12489,8 @@ msgid ""
 "is sent to StUF-ZDS. Those keys and the values belonging to them in the "
 "submission data are included in heeftAlsInitiator/extraElementen."
 msgstr ""
-"Met deze variabelekoppelingen stel je in welke formuliervariabelen als extra "
-"elementen in heeftAlsInitiator/extraElementen binnen StUF-ZDS meegestuurd "
+"Met deze variabelekoppelingen stel je in welke formuliervariabelen als extra"
+" elementen in heeftAlsInitiator/extraElementen binnen StUF-ZDS meegestuurd "
 "worden, en met welke naam."
 
 #: openforms/registrations/contrib/stuf_zds/plugin.py:201
@@ -11311,8 +12621,8 @@ msgid ""
 "be overridden in the Registration tab of a given form."
 msgstr ""
 "Aanduiding van de mate waarin het zaakdossier van de ZAAK voor de "
-"openbaarheid bestemd is. Dit kan per formulier in de registratieconfiguratie "
-"overschreven worden."
+"openbaarheid bestemd is. Dit kan per formulier in de registratieconfiguratie"
+" overschreven worden."
 
 #: openforms/registrations/contrib/zgw_apis/models.py:105
 msgid "vertrouwelijkheidaanduiding document"
@@ -11447,9 +12757,9 @@ msgstr "Zaaktype-identificatie"
 
 #: openforms/registrations/contrib/zgw_apis/options.py:161
 msgid ""
-"The case type will be retrieved in the specified catalogue. The version will "
-"automatically be selected based on the submission completion timestamp. When "
-"you specify this field, you MUST also specify a catalogue."
+"The case type will be retrieved in the specified catalogue. The version will"
+" automatically be selected based on the submission completion timestamp. "
+"When you specify this field, you MUST also specify a catalogue."
 msgstr ""
 "Het zaaktype wordt opgehaald binnen de ingestelde catalogus. De juiste "
 "versie van het zaaktype wordt automatisch bepaald aan de hand van de "
@@ -11459,15 +12769,15 @@ msgstr ""
 #: openforms/registrations/contrib/zgw_apis/options.py:171
 msgid ""
 "The document type will be retrieved in the specified catalogue. The version "
-"will automatically be selected based on the submission completion timestamp. "
-"When you specify this field, you MUST also specify the case type via its "
+"will automatically be selected based on the submission completion timestamp."
+" When you specify this field, you MUST also specify the case type via its "
 "identification. Only document types related to the case type are valid."
 msgstr ""
 "Het documenttype wordt opgehaald binnen de ingestelde catalogus. De juiste "
 "versie van het documenttype wordt automatisch bepaald aan de hand van de "
 "inzendingsdatum. Als je een waarde voor dit veld opgeeft, dan MOET je ook "
-"het zaaktype via haar identificatie opgeven. Enkel documenttypen die bij het "
-"zaaktype horen zijn geldig."
+"het zaaktype via haar identificatie opgeven. Enkel documenttypen die bij het"
+" zaaktype horen zijn geldig."
 
 #: openforms/registrations/contrib/zgw_apis/options.py:180
 msgid "Product url"
@@ -11541,9 +12851,9 @@ msgstr "Omschrijving"
 
 #: openforms/registrations/contrib/zgw_apis/options.py:253
 msgid ""
-"Description (omschrijving) of the case. You can use the expressions like "
-"'{{ form_name }}' or other variables here. The resolved string is limited to "
-"80 chars. If empty, the form name is used."
+"Description (omschrijving) of the case. You can use the expressions like '{{"
+" form_name }}' or other variables here. The resolved string is limited to 80"
+" chars. If empty, the form name is used."
 msgstr ""
 "Omschrijving van de zaak. Je kan hier expressies zoals '{{ form_name }}' of "
 "andere variabelen gebruiken. De resulterende tekst is beperkt tot 80 "
@@ -11555,8 +12865,8 @@ msgstr "Toelichting"
 
 #: openforms/registrations/contrib/zgw_apis/options.py:266
 msgid ""
-"Explanation (toelichting) of the case. You can use the expressions like "
-"'{{ form_name }}' or other variables here."
+"Explanation (toelichting) of the case. You can use the expressions like '{{ "
+"form_name }}' or other variables here."
 msgstr ""
 "Toelichting van de zaak. Je kan hier expressies zoals '{{ form_name }}' of "
 "andere variabelen gebruiken."
@@ -11576,11 +12886,11 @@ msgstr "objecten API - objecttype"
 #: openforms/registrations/contrib/zgw_apis/options.py:288
 msgid ""
 "URL that points to the ProductAanvraag objecttype in the Objecttypes API. "
-"The objecttype should have the following three attributes: 1) submission_id; "
-"2) type (the type of productaanvraag); 3) data (the submitted form data)"
+"The objecttype should have the following three attributes: 1) submission_id;"
+" 2) type (the type of productaanvraag); 3) data (the submitted form data)"
 msgstr ""
-"URL naar het OBJECTTYPE voor de 'ProductAanvraag' in de Objecttypen API. Het "
-"objecttype moet de volgende attributen bevatten: 1) submission_id; 2) type "
+"URL naar het OBJECTTYPE voor de 'ProductAanvraag' in de Objecttypen API. Het"
+" objecttype moet de volgende attributen bevatten: 1) submission_id; 2) type "
 "(het type van de 'ProductAanvraag'); 3) data (ingezonden formuliergegevens)"
 
 #: openforms/registrations/contrib/zgw_apis/options.py:298
@@ -11614,8 +12924,8 @@ msgstr ""
 
 #: openforms/registrations/contrib/zgw_apis/options.py:467
 msgid ""
-"The specified objecttype is not present in the selected Objecttypes API (the "
-"URL does not start with the API root of the Objecttypes API)."
+"The specified objecttype is not present in the selected Objecttypes API (the"
+" URL does not start with the API root of the Objecttypes API)."
 msgstr ""
 "Het gekozen objecttype bestaat niet binnen de gekozen Objecttypen-API (de "
 "URL begint niet met de basis-URL van de Objecttypen-API-service)."
@@ -11644,7 +12954,8 @@ msgstr ""
 "zaaktype."
 
 #: openforms/registrations/contrib/zgw_apis/options.py:673
-msgid "Could not find a roltype with this description related to the zaaktype."
+msgid ""
+"Could not find a roltype with this description related to the zaaktype."
 msgstr ""
 "Kon geen roltype vinden met deze omschrijving binnen het opgegeven zaaktype."
 
@@ -11662,13 +12973,11 @@ msgstr "Lijst van beschikbare services"
 
 #: openforms/services/api/viewsets.py:17
 msgid ""
-"Return a list of available (JSON) services/registrations configured in the "
-"backend.\n"
+"Return a list of available (JSON) services/registrations configured in the backend.\n"
 "\n"
 "Note that this endpoint is **EXPERIMENTAL**."
 msgstr ""
-"Geef een lijst van beschikbare (JSON) services/registraties die in de "
-"backend ingesteld zijn.\n"
+"Geef een lijst van beschikbare (JSON) services/registraties die in de backend ingesteld zijn.\n"
 "\n"
 "Dit endpoint is **EXPERIMENTEEL**."
 
@@ -11679,10 +12988,6 @@ msgstr "Het type Service om te tonen."
 #: openforms/submissions/admin.py:73
 msgid "All"
 msgstr "Alle"
-
-#: openforms/submissions/admin.py:80 openforms/config/admin.py:35
-msgid "Submissions"
-msgstr "Inzendingen"
 
 #: openforms/submissions/admin.py:94
 msgid "registration time"
@@ -11755,7 +13060,8 @@ msgstr "Registratie: e-mailpluginpreview"
 #: openforms/submissions/admin.py:447
 msgid "You can only export the submissions of the same form type."
 msgstr ""
-"Je kan alleen de inzendingen van één enkel formuliertype tegelijk exporteren."
+"Je kan alleen de inzendingen van één enkel formuliertype tegelijk "
+"exporteren."
 
 #: openforms/submissions/admin.py:457
 #, python-format
@@ -11951,8 +13257,8 @@ msgstr "Formuliergegevens"
 #: openforms/submissions/api/serializers.py:514
 msgid ""
 "The Form.io submission data object. This will be merged with the full form "
-"submission data, including data from other steps, to evaluate the configured "
-"form logic."
+"submission data, including data from other steps, to evaluate the configured"
+" form logic."
 msgstr ""
 "De Form.io inzendingsgegevens. Dit wordt samengevoegd met de "
 "inzendingsgegevens, inclusief de gegevens van de andere stappen, om de "
@@ -11965,7 +13271,8 @@ msgstr "Contact e-mailadres"
 #: openforms/submissions/api/serializers.py:527
 msgid "The email address where the 'magic' resume link should be sent to"
 msgstr ""
-"Het e-mailadres waar de 'magische' vervolg link naar toe gestuurd moet worden"
+"Het e-mailadres waar de 'magische' vervolg link naar toe gestuurd moet "
+"worden"
 
 #: openforms/submissions/api/serializers.py:621
 msgid "background processing status"
@@ -11988,8 +13295,8 @@ msgid ""
 "The result from the background processing. This field only has a value if "
 "the processing has completed (both successfully or with errors)."
 msgstr ""
-"Het resultaat van de achtergrondverwerking. Dit veld heeft alleen een waarde "
-"als de verwerking is voltooid (zowel met succes als met fouten)."
+"Het resultaat van de achtergrondverwerking. Dit veld heeft alleen een waarde"
+" als de verwerking is voltooid (zowel met succes als met fouten)."
 
 #: openforms/submissions/api/serializers.py:642
 msgid "Error information"
@@ -12169,15 +13476,13 @@ msgid ""
 "\n"
 "This is called by the default Form.io file upload widget. \n"
 "\n"
-"Access to this view requires an active form submission. Unclaimed temporary "
-"files automatically expire after {expire_days} day(s). "
+"Access to this view requires an active form submission. Unclaimed temporary files automatically expire after {expire_days} day(s). "
 msgstr ""
 "Haal tijdelijk bestand op.\n"
 "\n"
 "Deze aanroep wordt gedaan door het standaard Form.io bestandsupload widget.\n"
 "\n"
-"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet "
-"gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en)"
+"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en)"
 
 #: openforms/submissions/api/views.py:41
 msgid "Delete temporary file upload"
@@ -12190,15 +13495,13 @@ msgid ""
 "\n"
 "This is called by the default Form.io file upload widget. \n"
 "\n"
-"Access to this view requires an active form submission. Unclaimed temporary "
-"files automatically expire after {expire_days} day(s). "
+"Access to this view requires an active form submission. Unclaimed temporary files automatically expire after {expire_days} day(s). "
 msgstr ""
 "Verwijder tijdelijk bestand.\n"
 "\n"
 "Deze aanroep wordt gedaan door het standaard Form.io bestandsupload widget.\n"
 "\n"
-"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet "
-"gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en)"
+"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en)"
 
 #: openforms/submissions/api/views.py:84
 msgid "Start email verification"
@@ -12206,19 +13509,13 @@ msgstr "Start de e-mailverificatie"
 
 #: openforms/submissions/api/views.py:86
 msgid ""
-"Create an email verification resource to start the verification process. A "
-"verification e-mail will be scheduled and sent to the provided email "
-"address, containing the verification code to use during verification.\n"
+"Create an email verification resource to start the verification process. A verification e-mail will be scheduled and sent to the provided email address, containing the verification code to use during verification.\n"
 "\n"
-"Validations check that the provided component key is present in the form of "
-"the submission and that it actually is an `email` component."
+"Validations check that the provided component key is present in the form of the submission and that it actually is an `email` component."
 msgstr ""
-"Maak een e-mailbevestigingverzoek aan om het verificatieproces te beginnen. "
-"Hierna wordt een verificatie-e-mail verstuurd naar het opgegeven e-mailadres "
-"die de bevestigingscode bevat die in het proces ingevoerd dient te worden.\n"
+"Maak een e-mailbevestigingverzoek aan om het verificatieproces te beginnen. Hierna wordt een verificatie-e-mail verstuurd naar het opgegeven e-mailadres die de bevestigingscode bevat die in het proces ingevoerd dient te worden.\n"
 "\n"
-"De validaties controleren dat de componentsleutel bestaat in het formulier, "
-"en dat de component daadwerkelijk een e-mailcomponent is."
+"De validaties controleren dat de componentsleutel bestaat in het formulier, en dat de component daadwerkelijk een e-mailcomponent is."
 
 #: openforms/submissions/api/views.py:109
 msgid "Verify email address"
@@ -12227,41 +13524,42 @@ msgstr "Verifieer een e-mailadres"
 #: openforms/submissions/api/views.py:111
 msgid ""
 "Using the code obtained from the verification email, mark the email address "
-"as verified. Using an invalid code results in validation errors in the error "
-"response."
+"as verified. Using an invalid code results in validation errors in the error"
+" response."
 msgstr ""
-"Gebruik de bevestigingscode uit de verificatie-e-mail om het e-mailadres als "
-"\"geverifieerd\" te markeren. Als geen geldige code gebruikt wordt, dan "
+"Gebruik de bevestigingscode uit de verificatie-e-mail om het e-mailadres als"
+" \"geverifieerd\" te markeren. Als geen geldige code gebruikt wordt, dan "
 "bevat het antwoord validatiefouten."
 
-#: openforms/submissions/api/viewsets.py:97
+#: openforms/submissions/api/viewsets.py:96
 msgid "List active submissions"
 msgstr "Actieve inzendingen weergeven"
 
-#: openforms/submissions/api/viewsets.py:99
+#: openforms/submissions/api/viewsets.py:98
 msgid ""
 "Active submissions are submissions whose ID is in the user session. This "
-"endpoint returns user-bound submissions. Note that you get different results "
-"on different results because of the differing sessions."
+"endpoint returns user-bound submissions. Note that you get different results"
+" on different results because of the differing sessions."
 msgstr ""
 "Actieve inzendingen zijn inzendingen waarvan het ID zich in de "
 "gebruikerssessie bevindt. Dit endpoint geeft alle inzendingen terug die "
 "gekoppeld zijn aan de gebruiker. Het antwoord hangt dus af van de actieve "
 "sessie."
 
-#: openforms/submissions/api/viewsets.py:105
+#: openforms/submissions/api/viewsets.py:104
 msgid "Retrieve submission details"
 msgstr "Inzending detail weergeven"
 
-#: openforms/submissions/api/viewsets.py:106
+#: openforms/submissions/api/viewsets.py:105
 msgid "Get the state of a single submission in the user session."
-msgstr "Haal de status op van een enkele inzending op van de gebruikerssessie."
+msgstr ""
+"Haal de status op van een enkele inzending op van de gebruikerssessie."
 
-#: openforms/submissions/api/viewsets.py:109
+#: openforms/submissions/api/viewsets.py:108
 msgid "Start a submission"
 msgstr "Inzending starten"
 
-#: openforms/submissions/api/viewsets.py:111
+#: openforms/submissions/api/viewsets.py:110
 msgid ""
 "Start a submission for a particular form. The submission is added to the "
 "user session."
@@ -12269,20 +13567,20 @@ msgstr ""
 "Start een inzending voor een specifiek formulier. De inzending wordt "
 "onderdeel van de gebruikerssessie."
 
-#: openforms/submissions/api/viewsets.py:215
+#: openforms/submissions/api/viewsets.py:214
 msgid "Retrieve co-sign state"
 msgstr "Haal mede-ondertekeningstatus op"
 
-#: openforms/submissions/api/viewsets.py:237
+#: openforms/submissions/api/viewsets.py:236
 msgid "Co-sign submission"
 msgstr "inzending mede-ondertekenen"
 
-#: openforms/submissions/api/viewsets.py:257
+#: openforms/submissions/api/viewsets.py:256
 msgid "The submission must be completed before being able to co-sign it."
 msgstr ""
 "Het formulier moet volledig ingevuld zijn voor u het kunt mede-ondertekenen."
 
-#: openforms/submissions/api/viewsets.py:263
+#: openforms/submissions/api/viewsets.py:262
 msgid ""
 "You need to be logged in with one of the allowed authentication backends to "
 "co-sign the submission."
@@ -12290,43 +13588,43 @@ msgstr ""
 "Je moet ingelogd zijn met één van de toegestane inlogmethoden om de "
 "inzending mede te ondertekenen."
 
-#: openforms/submissions/api/viewsets.py:303
+#: openforms/submissions/api/viewsets.py:302
 msgid "Complete a submission"
 msgstr "Inzending voltooien"
 
-#: openforms/submissions/api/viewsets.py:363
+#: openforms/submissions/api/viewsets.py:362
 msgid "Submission is not enabled for this form."
 msgstr "Dit formulier kan niet worden ingezonden."
 
-#: openforms/submissions/api/viewsets.py:395
+#: openforms/submissions/api/viewsets.py:394
 msgid "Get the submission processing status"
 msgstr "De verwerkingsstatus van de inzending ophalen"
 
-#: openforms/submissions/api/viewsets.py:407
+#: openforms/submissions/api/viewsets.py:406
 msgid "Time-based authentication token"
 msgstr "Op tijd gebaseerde authenticatietoken"
 
-#: openforms/submissions/api/viewsets.py:436
+#: openforms/submissions/api/viewsets.py:435
 msgid "Suspend a submission"
 msgstr "Inzending onderbreken"
 
-#: openforms/submissions/api/viewsets.py:458
+#: openforms/submissions/api/viewsets.py:457
 msgid "Suspending this form is not allowed."
 msgstr "Het is niet mogelijk om dit formulier te pauzeren."
 
-#: openforms/submissions/api/viewsets.py:488
+#: openforms/submissions/api/viewsets.py:487
 msgid "Summary page data"
 msgstr "Gegevenssamenvatting"
 
-#: openforms/submissions/api/viewsets.py:489
+#: openforms/submissions/api/viewsets.py:488
 msgid "Retrieve the data to display in the submission summary page."
 msgstr "Haal alle inzendinggegevens om op een overzichtspagina weer te geven."
 
-#: openforms/submissions/api/viewsets.py:513
+#: openforms/submissions/api/viewsets.py:512
 msgid "Retrieve step details"
 msgstr "Stap details weergeven"
 
-#: openforms/submissions/api/viewsets.py:515
+#: openforms/submissions/api/viewsets.py:514
 msgid ""
 "The details of a particular submission step always return the related form "
 "step configuration. If there is no data yet for the step, the ID will be "
@@ -12336,19 +13634,19 @@ msgstr ""
 "formulierstap configuratie terug. Indien er nog geen gegevens zijn voor de "
 "stap dan zal het ID `null` zijn."
 
-#: openforms/submissions/api/viewsets.py:585
+#: openforms/submissions/api/viewsets.py:584
 msgid "Invalid form step reference given."
 msgstr "Ongeldige formulierstapverwijzing."
 
-#: openforms/submissions/api/viewsets.py:595
+#: openforms/submissions/api/viewsets.py:594
 msgid "Store submission step data"
 msgstr "Inzendingsstap gegevens bewaren"
 
-#: openforms/submissions/api/viewsets.py:687
+#: openforms/submissions/api/viewsets.py:686
 msgid "Apply/check form logic"
 msgstr "Pas formulier logica toe"
 
-#: openforms/submissions/api/viewsets.py:688
+#: openforms/submissions/api/viewsets.py:687
 msgid "Apply/check the logic rules specified on the form step."
 msgstr ""
 "Pas de logische regels toe die zijn gespecificeerd in de formulierstap."
@@ -12672,8 +13970,10 @@ msgstr "registratie backend status"
 
 #: openforms/submissions/models/submission.py:205
 msgid ""
-"Indication whether the registration in the configured backend was successful."
-msgstr "Indicatie of de doorzetting naar de registratie backend succesvol was."
+"Indication whether the registration in the configured backend was "
+"successful."
+msgstr ""
+"Indicatie of de doorzetting naar de registratie backend succesvol was."
 
 #: openforms/submissions/models/submission.py:209
 msgid "pre-registration completed"
@@ -12689,9 +13989,9 @@ msgstr "publieke referentie"
 
 #: openforms/submissions/models/submission.py:220
 msgid ""
-"The registration reference communicated to the end-user completing the form. "
-"This reference is intended to be unique and the reference the end-user uses "
-"to communicate with the service desk. It should be extracted from the "
+"The registration reference communicated to the end-user completing the form."
+" This reference is intended to be unique and the reference the end-user uses"
+" to communicate with the service desk. It should be extracted from the "
 "registration result where possible, and otherwise generated to be unique. "
 "Note that this reference is displayed to the end-user and used as payment "
 "reference!"
@@ -12801,9 +14101,9 @@ msgid ""
 msgstr ""
 "Een identificatie die als query-parameter opgegeven kan worden bij het "
 "starten van een formulier. Op basis van deze identificatie worden bestaande "
-"gegevens opgehaald en gebruikt om formuliervelden voor in te vullen. Bij het "
-"registreren kunnen de bestaande gegevens ook weer bijgewerkt worden, indien "
-"gewenst, of de gegevens worden als 'nieuw' geregistreerd. Dit kan "
+"gegevens opgehaald en gebruikt om formuliervelden voor in te vullen. Bij het"
+" registreren kunnen de bestaande gegevens ook weer bijgewerkt worden, indien"
+" gewenst, of de gegevens worden als 'nieuw' geregistreerd. Dit kan "
 "bijvoorbeeld een referentie zijn naar een record in de Objecten API."
 
 #: openforms/submissions/models/submission.py:300
@@ -12816,11 +14116,11 @@ msgstr "bij voltooiing taak-ID's"
 
 #: openforms/submissions/models/submission.py:308
 msgid ""
-"Celery task IDs of the on_completion workflow. Use this to inspect the state "
-"of the async jobs."
+"Celery task IDs of the on_completion workflow. Use this to inspect the state"
+" of the async jobs."
 msgstr ""
-"Celery-taak-ID's van de on_completion-workflow. Gebruik dit om de status van "
-"de asynchrone taken te inspecteren. "
+"Celery-taak-ID's van de on_completion-workflow. Gebruik dit om de status van"
+" de asynchrone taken te inspecteren. "
 
 #: openforms/submissions/models/submission.py:314
 msgid "needs on_completion retry"
@@ -12902,12 +14202,6 @@ msgstr "inhoud van de bijlage."
 msgid "original name"
 msgstr "originele naam"
 
-#: openforms/submissions/models/submission_files.py:64
-#: openforms/submissions/models/submission_files.py:268
-#: openforms/config/models/csp.py:85
-msgid "content type"
-msgstr "content type"
-
 #: openforms/submissions/models/submission_files.py:67
 msgid "file size"
 msgstr "Bestandsgrootte"
@@ -12966,12 +14260,13 @@ msgstr "Pad naar de bijlage in de inzendinsgegevens."
 msgid ""
 "Key of the file component for which the upload was made. Most of the time "
 "this will be identical to the submission_variable.key, except when the file "
-"component is inside an edit grid - the variable then points to the edit grid."
+"component is inside an edit grid - the variable then points to the edit "
+"grid."
 msgstr ""
 "Sleutel van het bestandsupload-component waarvoor de upload was toegevoegd. "
 "In de meeste gevallen zal dit gelijk zijn aan submission_variable.key, "
-"tenzij het bestandsupload-component zich binnen een herhalende groep bevindt "
-"- de variabele verwijst dan naar de herhalende groep."
+"tenzij het bestandsupload-component zich binnen een herhalende groep bevindt"
+" - de variabele verwijst dan naar de herhalende groep."
 
 #: openforms/submissions/models/submission_files.py:260
 msgid "Content of the submission file attachment."
@@ -13015,8 +14310,8 @@ msgstr "laatst gedownload"
 
 #: openforms/submissions/models/submission_report.py:39
 msgid ""
-"When the submission report was last accessed. This value is updated when the "
-"report is downloaded."
+"When the submission report was last accessed. This value is updated when the"
+" report is downloaded."
 msgstr ""
 "Datum waarom het document voor het laatst is opgevraagd. Deze waarde wordt "
 "bijgewerkt zodra het document wordt gedownload."
@@ -13062,84 +14357,85 @@ msgstr "formulierstap (historisch)"
 msgid "Submission step"
 msgstr "Inzendingsstap"
 
-#: openforms/submissions/models/submission_value_variable.py:449
+#: openforms/submissions/models/submission_value_variable.py:444
 msgid "The submission to which this variable value is related"
 msgstr "Inzending waar deze variabelewaarde bij hoort"
 
-#: openforms/submissions/models/submission_value_variable.py:455
+#: openforms/submissions/models/submission_value_variable.py:450
 msgid "Key of the variable"
 msgstr "Sleutel van de variabele"
 
-#: openforms/submissions/models/submission_value_variable.py:459
+#: openforms/submissions/models/submission_value_variable.py:454
 msgid "The value of the variable"
 msgstr "Waarde van de variabele"
 
-#: openforms/submissions/models/submission_value_variable.py:466
+#: openforms/submissions/models/submission_value_variable.py:461
 msgid "Where variable value came from"
 msgstr "Bron van de waarde"
 
-#: openforms/submissions/models/submission_value_variable.py:471
+#: openforms/submissions/models/submission_value_variable.py:466
 msgid "created at"
 msgstr "aangemaakt op"
 
-#: openforms/submissions/models/submission_value_variable.py:472
+#: openforms/submissions/models/submission_value_variable.py:467
 msgid "The date/time at which the value of this variable was created"
 msgstr "De timestamp waarop de waarde van deze variabele aangemaakt werd"
 
-#: openforms/submissions/models/submission_value_variable.py:476
+#: openforms/submissions/models/submission_value_variable.py:471
 msgid "modified at"
 msgstr "gewijzigd op"
 
-#: openforms/submissions/models/submission_value_variable.py:477
+#: openforms/submissions/models/submission_value_variable.py:472
 msgid "The date/time at which the value of this variable was last set"
 msgstr "Timestamp wanneer de waarde laatst gezet is"
 
-#: openforms/submissions/models/submission_value_variable.py:483
+#: openforms/submissions/models/submission_value_variable.py:478
 msgid "is initially prefilled"
 msgstr "gevuld vanuit prefill-gegevens"
 
-#: openforms/submissions/models/submission_value_variable.py:484
+#: openforms/submissions/models/submission_value_variable.py:479
 msgid "Can this variable be prefilled at the beginning of a submission?"
 msgstr ""
-"Is de waarde bij het starten van de inzending door een prefill-plugin gevuld?"
+"Is de waarde bij het starten van de inzending door een prefill-plugin "
+"gevuld?"
 
-#: openforms/submissions/models/submission_value_variable.py:492
+#: openforms/submissions/models/submission_value_variable.py:487
 msgid "Form.io component configuration"
 msgstr "Form.io component configuratie"
 
-#: openforms/submissions/models/submission_value_variable.py:493
+#: openforms/submissions/models/submission_value_variable.py:488
 msgid "The component configuration as Form.io JSON schema"
 msgstr "De formulierdefinitie als Form.io JSON schema"
 
-#: openforms/submissions/models/submission_value_variable.py:514
+#: openforms/submissions/models/submission_value_variable.py:509
 msgid "pre-registration status"
 msgstr "pre-registratiestatus"
 
-#: openforms/submissions/models/submission_value_variable.py:516
+#: openforms/submissions/models/submission_value_variable.py:511
 msgid ""
 "Indication whether the pre-registration hook in the component plugin was "
 "successful."
 msgstr "Indicatie of de pre-registratiestap van de component succesvol was."
 
-#: openforms/submissions/models/submission_value_variable.py:523
+#: openforms/submissions/models/submission_value_variable.py:518
 msgid "pre-registration result"
 msgstr "pre-registratieresultaat"
 
-#: openforms/submissions/models/submission_value_variable.py:527
+#: openforms/submissions/models/submission_value_variable.py:522
 msgid "Contains data returned by the pre-registration hook of the component."
 msgstr ""
 "Bevat de gegevens zoals teruggegeven door de pre-registratie van de "
 "component."
 
-#: openforms/submissions/models/submission_value_variable.py:537
+#: openforms/submissions/models/submission_value_variable.py:532
 msgid "Submission value variable"
 msgstr "Inzendingswaarde"
 
-#: openforms/submissions/models/submission_value_variable.py:538
+#: openforms/submissions/models/submission_value_variable.py:533
 msgid "Submission values variables"
 msgstr "Inzendingswaarden"
 
-#: openforms/submissions/models/submission_value_variable.py:555
+#: openforms/submissions/models/submission_value_variable.py:550
 #, python-brace-format
 msgid "Submission value variable {key}"
 msgstr "Inzendingswaarde {key}"
@@ -13171,8 +14467,8 @@ msgid ""
 "This PDF was generated before submission processing has started because it "
 "needs to be cosigned first. The cosign request email was sent to {email}."
 msgstr ""
-"Deze samenvatting is gemaakt vóór de inzending in behandeling genomen wordt. "
-"De inzending wordt pas verwerkt als deze mede-ondertekend is. Het verzoek "
+"Deze samenvatting is gemaakt vóór de inzending in behandeling genomen wordt."
+" De inzending wordt pas verwerkt als deze mede-ondertekend is. Het verzoek "
 "hiervoor is verstuurd naar {email}."
 
 #: openforms/submissions/tasks/emails.py:142
@@ -13198,11 +14494,6 @@ msgstr "%(form_name)s: samenvatting-PDF "
 #, python-format
 msgid "Logo %(name)s"
 msgstr "Logo %(name)s"
-
-#: openforms/submissions/templates/report/submission_report.html:36
-#: openforms/config/admin.py:314
-msgid "Logo"
-msgstr "Logo"
 
 #: openforms/submissions/templates/report/submission_report.html:58
 #, python-format
@@ -13274,11 +14565,6 @@ msgstr ""
 "Helaas accepteert dit formulier geen nieuwe inzendingen - de limiet is "
 "bereikt."
 
-#: openforms/submissions/templatetags/cosign.py:17
-#: openforms/config/templates/config/default_cosign_submission_confirmation.html:9
-msgid "Cosign now"
-msgstr "Nu mede-ondertekenen"
-
 #: openforms/submissions/views.py:254 openforms/submissions/views.py:262
 msgid "File access denied."
 msgstr "Bestandstoegang geblokkeerd."
@@ -13294,8 +14580,8 @@ msgstr "Sorry, u hebt geen toegang tot deze pagina (403)"
 
 #: openforms/templates/403.html:15
 msgid ""
-"You don't appear to have sufficient permissions to view this content. Please "
-"contact an administrator if you believe this to be an error."
+"You don't appear to have sufficient permissions to view this content. Please"
+" contact an administrator if you believe this to be an error."
 msgstr ""
 "U lijkt onvoldoende rechten te hebben om deze inhoud te bekijken. Gelieve "
 "contact op te nemen met uw beheerder indien dit onterecht is."
@@ -13459,8 +14745,8 @@ msgstr "RFC5646 taalcode, bijvoorbeeld `en` of `en-us`"
 
 #: openforms/translations/api/serializers.py:25
 msgid ""
-"Language name in its local representation. e.g. \"fy\" = \"frysk\", \"nl\" = "
-"\"Nederlands\""
+"Language name in its local representation. e.g. \"fy\" = \"frysk\", \"nl\" ="
+" \"Nederlands\""
 msgstr ""
 "Taalnaam in de lokale weergave. Bijvoorbeeld \"fy\" = \"frysk\", \"nl\" = "
 "\"Nederlands\""
@@ -13494,8 +14780,8 @@ msgid ""
 "custom translations exist, an empty object `{}` is returned."
 msgstr ""
 "Haal de nieuwe aangepaste (gecompileerde) vertalingen op nadat de "
-"wijzigingen zijn toegepast. Dit gebeurt op basis van de taalcode in het pad. "
-"Als er geen aangepaste vertalingen bestaan, wordt een leeg object `{}` "
+"wijzigingen zijn toegepast. Dit gebeurt op basis van de taalcode in het pad."
+" Als er geen aangepaste vertalingen bestaan, wordt een leeg object `{}` "
 "geretourneerd."
 
 #: openforms/translations/api/views.py:108
@@ -13540,8 +14826,8 @@ msgid ""
 "JSON file containing user's custom translations after it has been "
 "successfully compiled."
 msgstr ""
-"JSON-bestand met aangepaste vertalingen van de gebruiker nadat het succesvol "
-"is gecompileerd."
+"JSON-bestand met aangepaste vertalingen van de gebruiker nadat het succesvol"
+" is gecompileerd."
 
 #: openforms/translations/models.py:48
 msgid "The status of the uploaded custom translations JSON file."
@@ -13573,8 +14859,8 @@ msgstr "aantal aangepaste berichten"
 
 #: openforms/translations/models.py:73
 msgid ""
-"How many custom messages are included, this is set once processing completes "
-"successfully."
+"How many custom messages are included, this is set once processing completes"
+" successfully."
 msgstr ""
 "Geeft aan hoeveel aangepaste berichten zijn opgenomen. Dit wordt ingesteld "
 "zodra de verwerking succesvol is voltooid."
@@ -13946,11 +15232,11 @@ msgstr "Waarde om te valideren."
 
 #: openforms/validations/api/views.py:84
 msgid ""
-"ID of the validation plugin, see the [`validation_plugin_list`](./#operation/"
-"validation_plugin_list) operation"
+"ID of the validation plugin, see the "
+"[`validation_plugin_list`](./#operation/validation_plugin_list) operation"
 msgstr ""
-"ID van de validatie plugin. Zie de [`validation_plugin_list`](./#operation/"
-"validation_plugin_list) operatie"
+"ID van de validatie plugin. Zie de "
+"[`validation_plugin_list`](./#operation/validation_plugin_list) operatie"
 
 #: openforms/validations/registry.py:78
 #, python-brace-format
@@ -14050,8 +15336,7 @@ msgstr "Geef een lijst van beschikbare servicebevragingconfiguraties"
 
 #: openforms/variables/api/viewsets.py:19
 msgid ""
-"Return a list of available services fetch configurations configured in the "
-"backend.\n"
+"Return a list of available services fetch configurations configured in the backend.\n"
 "\n"
 "Note that this endpoint is **EXPERIMENTAL**."
 msgstr ""
@@ -14212,7 +15497,8 @@ msgstr "{header!s}: waarde '{value!s}' moet een string zijn maar is dat niet."
 
 #: openforms/variables/validators.py:84
 msgid ""
-"{header!s}: value '{value!s}' contains {illegal_chars}, which is not allowed."
+"{header!s}: value '{value!s}' contains {illegal_chars}, which is not "
+"allowed."
 msgstr ""
 "{header!s}: waarde '{value!s}' bevat {illegal_chars}, deze karakters zijn "
 "niet toegestaan."
@@ -14225,13 +15511,15 @@ msgstr ""
 "{header!s}: waarde '{value!s}' mag niet starten of eindigen met whitespace."
 
 #: openforms/variables/validators.py:101
-msgid "{header!s}: value '{value!s}' contains characters that are not allowed."
+msgid ""
+"{header!s}: value '{value!s}' contains characters that are not allowed."
 msgstr ""
 "{header!s}: waarde '{value!s}' bevat karakters die niet toegestaan zijn."
 
 #: openforms/variables/validators.py:108
 msgid "{header!s}: header '{header!s}' should be a string, but isn't."
-msgstr "{header!s}: header '{header!s}' moet een string zijn maar is dat niet."
+msgstr ""
+"{header!s}: header '{header!s}' moet een string zijn maar is dat niet."
 
 #: openforms/variables/validators.py:114
 msgid ""
@@ -14261,8 +15549,8 @@ msgstr ""
 msgid ""
 "{parameter!s}: value '{value!s}' should be a list of strings, but isn't."
 msgstr ""
-"{parameter!s}: de waarde '{value!s}' moet een lijst van strings zijn maar is "
-"dat niet."
+"{parameter!s}: de waarde '{value!s}' moet een lijst van strings zijn maar is"
+" dat niet."
 
 #: openforms/variables/validators.py:165
 msgid "query parameter key '{parameter!s}' should be a string, but isn't."
@@ -14461,11 +15749,11 @@ msgstr "endpoint VrijeBerichten"
 
 #: stuf/models.py:84
 msgid ""
-"Endpoint for synchronous free messages, usually '[...]/"
-"VerwerkSynchroonVrijBericht' or '[...]/VrijeBerichten'."
+"Endpoint for synchronous free messages, usually "
+"'[...]/VerwerkSynchroonVrijBericht' or '[...]/VrijeBerichten'."
 msgstr ""
-"Endpoint voor synchrone vrije berichten, typisch '[...]/"
-"VerwerkSynchroonVrijBericht' of '[...]/VrijeBerichten'."
+"Endpoint voor synchrone vrije berichten, typisch "
+"'[...]/VerwerkSynchroonVrijBericht' of '[...]/VrijeBerichten'."
 
 #: stuf/models.py:88
 msgid "endpoint OntvangAsynchroon"
@@ -14620,11 +15908,11 @@ msgstr ""
 
 #: stuf/stuf_zds/models.py:60
 msgid ""
-"The 'zaakbetrokkene.omschrijving' value for the person who cosigned the form "
-"submission."
+"The 'zaakbetrokkene.omschrijving' value for the person who cosigned the form"
+" submission."
 msgstr ""
-"De waarde van 'zaakbetrokkene.omschrijving' voor de persoon die de inzending "
-"heeft mede-ondertekend."
+"De waarde van 'zaakbetrokkene.omschrijving' voor de persoon die de inzending"
+" heeft mede-ondertekend."
 
 #: stuf/stuf_zds/models.py:68
 msgid "StUF-ZDS configuration"
@@ -14636,11 +15924,11 @@ msgstr "Binding address Bijstandsregelingen"
 
 #: suwinet/models.py:33
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/Bijstandsregelingen/"
-"v0500}BijstandsregelingenBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/Bijstandsregelingen/v0500}BijstandsregelingenBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/Bijstandsregelingen/"
-"v0500}BijstandsregelingenBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/Bijstandsregelingen/v0500}BijstandsregelingenBinding"
 
 #: suwinet/models.py:39
 msgid "BRPDossierPersoonGSD Binding Address"
@@ -14648,11 +15936,11 @@ msgstr "Binding address BRPDossierPersoonGSD"
 
 #: suwinet/models.py:41
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/BRPDossierPersoonGSD/"
-"v0200}BRPBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/BRPDossierPersoonGSD/v0200}BRPBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/BRPDossierPersoonGSD/"
-"v0200}BRPBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/BRPDossierPersoonGSD/v0200}BRPBinding"
 
 #: suwinet/models.py:46
 msgid "DUODossierPersoonGSD Binding Address"
@@ -14660,11 +15948,11 @@ msgstr "Binding address DUODossierPersoonGSD"
 
 #: suwinet/models.py:48
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/DUODossierPersoonGSD/"
-"v0300}DUOBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/DUODossierPersoonGSD/v0300}DUOBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/DUODossierPersoonGSD/"
-"v0300}DUOBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/DUODossierPersoonGSD/v0300}DUOBinding"
 
 #: suwinet/models.py:53
 msgid "DUODossierStudiefinancieringGSD Binding Address"
@@ -14672,11 +15960,11 @@ msgstr "Binding address DUODossierStudiefinancieringGSD"
 
 #: suwinet/models.py:55
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/"
-"DUODossierStudiefinancieringGSD/v0200}DUOBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/DUODossierStudiefinancieringGSD/v0200}DUOBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/"
-"DUODossierStudiefinancieringGSD/v0200}DUOBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/DUODossierStudiefinancieringGSD/v0200}DUOBinding"
 
 #: suwinet/models.py:60
 msgid "GSDDossierReintegratie Binding Address"
@@ -14684,11 +15972,11 @@ msgstr "Binding address GSDDossierReintegratie"
 
 #: suwinet/models.py:62
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/GSDDossierReintegratie/"
-"v0200}GSDReintegratieBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/GSDDossierReintegratie/v0200}GSDReintegratieBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/GSDDossierReintegratie/"
-"v0200}GSDReintegratieBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/GSDDossierReintegratie/v0200}GSDReintegratieBinding"
 
 #: suwinet/models.py:67
 msgid "IBVerwijsindex Binding Address"
@@ -14696,11 +15984,11 @@ msgstr "Binding address IBVerwijsindex"
 
 #: suwinet/models.py:69
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/IBVerwijsindex/v0300}"
-"IBVerwijsindexBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/IBVerwijsindex/v0300}IBVerwijsindexBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/IBVerwijsindex/v0300}"
-"IBVerwijsindexBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/IBVerwijsindex/v0300}IBVerwijsindexBinding"
 
 #: suwinet/models.py:74
 msgid "KadasterDossierGSD Binding Address"
@@ -14708,11 +15996,11 @@ msgstr "Binding address KadasterDossierGSD"
 
 #: suwinet/models.py:76
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/KadasterDossierGSD/v0300}"
-"KadasterBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/KadasterDossierGSD/v0300}KadasterBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/KadasterDossierGSD/"
-"v0300}KadasterBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/KadasterDossierGSD/v0300}KadasterBinding"
 
 #: suwinet/models.py:81
 msgid "RDWDossierDigitaleDiensten Binding Address"
@@ -14720,11 +16008,11 @@ msgstr "Binding address RDWDossierDigitaleDiensten"
 
 #: suwinet/models.py:83
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/"
-"RDWDossierDigitaleDiensten/v0200}RDWBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/RDWDossierDigitaleDiensten/v0200}RDWBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/"
-"RDWDossierDigitaleDiensten/v0200}RDWBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/RDWDossierDigitaleDiensten/v0200}RDWBinding"
 
 #: suwinet/models.py:88
 msgid "RDWDossierGSD Binding Address"
@@ -14732,11 +16020,11 @@ msgstr "Binding address RDWDossierGSD"
 
 #: suwinet/models.py:90
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/RDWDossierGSD/v0200}"
-"RDWBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/RDWDossierGSD/v0200}RDWBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/RDWDossierGSD/v0200}"
-"RDWBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/RDWDossierGSD/v0200}RDWBinding"
 
 #: suwinet/models.py:95
 msgid "SVBDossierPersoonGSD Binding Address"
@@ -14744,11 +16032,11 @@ msgstr "Binding address SVBDossierPersoonGSD"
 
 #: suwinet/models.py:97
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/SVBDossierPersoonGSD/"
-"v0200}SVBBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/SVBDossierPersoonGSD/v0200}SVBBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/SVBDossierPersoonGSD/"
-"v0200}SVBBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/SVBDossierPersoonGSD/v0200}SVBBinding"
 
 #: suwinet/models.py:102
 msgid "UWVDossierAanvraagUitkeringStatusGSD Binding Address"
@@ -14756,11 +16044,11 @@ msgstr "Binding address UWVDossierAanvraagUitkeringStatusGSD"
 
 #: suwinet/models.py:104
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/"
-"UWVDossierAanvraagUitkeringStatusGSD/v0200}UWVAanvraagUitkeringStatusBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/UWVDossierAanvraagUitkeringStatusGSD/v0200}UWVAanvraagUitkeringStatusBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/"
-"UWVDossierAanvraagUitkeringStatusGSD/v0200}UWVAanvraagUitkeringStatusBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/UWVDossierAanvraagUitkeringStatusGSD/v0200}UWVAanvraagUitkeringStatusBinding"
 
 #: suwinet/models.py:109
 msgid "UWVDossierInkomstenGSDDigitaleDiensten Binding Address"
@@ -14768,11 +16056,11 @@ msgstr "Binding address UWVDossierInkomstenGSDDigitaleDiensten"
 
 #: suwinet/models.py:111
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/"
-"UWVDossierInkomstenGSDDigitaleDiensten/v0200}UWVIkvBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/UWVDossierInkomstenGSDDigitaleDiensten/v0200}UWVIkvBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/"
-"UWVDossierInkomstenGSDDigitaleDiensten/v0200}UWVIkvBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/UWVDossierInkomstenGSDDigitaleDiensten/v0200}UWVIkvBinding"
 
 #: suwinet/models.py:116
 msgid "UWVDossierInkomstenGSD Binding Address"
@@ -14780,11 +16068,11 @@ msgstr "Binding address UWVDossierInkomstenGSD"
 
 #: suwinet/models.py:118
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/UWVDossierInkomstenGSD/"
-"v0200}UWVIkvBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/UWVDossierInkomstenGSD/v0200}UWVIkvBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/UWVDossierInkomstenGSD/"
-"v0200}UWVIkvBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/UWVDossierInkomstenGSD/v0200}UWVIkvBinding"
 
 #: suwinet/models.py:123
 msgid "UWVDossierQuotumArbeidsbeperktenGSD Binding Address"
@@ -14792,11 +16080,11 @@ msgstr "Binding address UWVDossierQuotumArbeidsbeperktenGSD"
 
 #: suwinet/models.py:125
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/"
-"UWVDossierQuotumArbeidsbeperktenGSD/v0300}UWVArbeidsbeperktenBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/UWVDossierQuotumArbeidsbeperktenGSD/v0300}UWVArbeidsbeperktenBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/"
-"UWVDossierQuotumArbeidsbeperktenGSD/v0300}UWVArbeidsbeperktenBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/UWVDossierQuotumArbeidsbeperktenGSD/v0300}UWVArbeidsbeperktenBinding"
 
 #: suwinet/models.py:130
 msgid "UWVDossierWerknemersverzekeringenGSDDigitaleDiensten Binding Address"
@@ -14804,11 +16092,11 @@ msgstr "Binding address UWVDossierWerknemersverzekeringenGSDDigitaleDiensten"
 
 #: suwinet/models.py:133
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/"
-"UWVDossierWerknemersverzekeringenGSDDigitaleDiensten/v0200}UWVBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/UWVDossierWerknemersverzekeringenGSDDigitaleDiensten/v0200}UWVBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/"
-"UWVDossierWerknemersverzekeringenGSDDigitaleDiensten/v0200}UWVBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/UWVDossierWerknemersverzekeringenGSDDigitaleDiensten/v0200}UWVBinding"
 
 #: suwinet/models.py:138
 msgid "UWVDossierWerknemersverzekeringenGSD Binding Address"
@@ -14816,11 +16104,11 @@ msgstr "Binding address UWVDossierWerknemersverzekeringenGSD"
 
 #: suwinet/models.py:140
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/"
-"UWVDossierWerknemersverzekeringenGSD/v0200}UWVBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/UWVDossierWerknemersverzekeringenGSD/v0200}UWVBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/"
-"UWVDossierWerknemersverzekeringenGSD/v0200}UWVBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/UWVDossierWerknemersverzekeringenGSD/v0200}UWVBinding"
 
 #: suwinet/models.py:145
 msgid "UWVWbDossierPersoonGSD Binding Address"
@@ -14828,11 +16116,11 @@ msgstr "Binding address UWVWbDossierPersoonGSD"
 
 #: suwinet/models.py:147
 msgid ""
-"Binding address for {http://bkwi.nl/SuwiML/Diensten/UWVWbDossierPersoonGSD/"
-"v0200}UwvWbBinding"
+"Binding address for "
+"{http://bkwi.nl/SuwiML/Diensten/UWVWbDossierPersoonGSD/v0200}UwvWbBinding"
 msgstr ""
-"Binding address voor {http://bkwi.nl/SuwiML/Diensten/UWVWbDossierPersoonGSD/"
-"v0200}UwvWbBinding"
+"Binding address voor "
+"{http://bkwi.nl/SuwiML/Diensten/UWVWbDossierPersoonGSD/v0200}UwvWbBinding"
 
 #: suwinet/models.py:154
 msgid "Suwinet configuration"
@@ -14851,1245 +16139,3 @@ msgstr ""
 #: openforms/conf/base.py:64
 msgid "English"
 msgstr "Engels"
-
-#: openforms/config/admin.py:29
-msgid "Email security configuration"
-msgstr "E-mail beveiligingsconfiguratie"
-
-#: openforms/config/admin.py:46
-msgid "Confirmation Email"
-msgstr "Bevestigingse-mail"
-
-#: openforms/config/admin.py:52
-msgid "Save Form Email"
-msgstr "Sjabloon \"pauzeer\"-email"
-
-#: openforms/config/admin.py:61
-msgid "Submissions with cosigning"
-msgstr "Formulieren met mede-ondertekenen"
-
-#: openforms/config/admin.py:70
-msgid "Co-sign emails"
-msgstr "Mede-ondertekenen e-mails"
-
-#: openforms/config/admin.py:80
-msgid "Email address verification emails"
-msgstr "E-mails voor e-mailadresbevestiging"
-
-#: openforms/config/admin.py:88
-msgid "General Email settings"
-msgstr "Algemene e-mailinstellingen"
-
-#: openforms/config/admin.py:90
-msgid "Button labels"
-msgstr "Knop labels"
-
-#: openforms/config/admin.py:104
-msgid "General form options"
-msgstr "Standaardformulieropties"
-
-#: openforms/config/admin.py:120 openforms/config/admin.py:311
-msgid "Organization configuration"
-msgstr "Organisatie configuratie"
-
-#: openforms/config/admin.py:132
-msgid "Statement of truth"
-msgstr "Verklaring van waarheid"
-
-#: openforms/config/admin.py:141
-msgid "Privacy"
-msgstr "Privacy"
-
-#: openforms/config/admin.py:151
-msgid "Sessions"
-msgstr "Sessies"
-
-#: openforms/config/admin.py:160
-msgid "Data removal"
-msgstr "Gegevens schonen"
-
-#: openforms/config/admin.py:173
-msgid "Search engines"
-msgstr "Zoekmachines"
-
-#: openforms/config/admin.py:175
-msgid "Plugin configuration"
-msgstr "Pluginconfiguratie"
-
-#: openforms/config/admin.py:196
-msgid "Virus scan"
-msgstr "Virusscan"
-
-#: openforms/config/admin.py:207
-msgid "Payments"
-msgstr "Betalingen"
-
-#: openforms/config/admin.py:213
-msgid "Feature flags & fields for testing"
-msgstr "Feature flags, test- en ontwikkelinstellingen"
-
-#: openforms/config/admin.py:223
-msgid "feature flags"
-msgstr "feature flags"
-
-#: openforms/config/admin.py:228
-msgid "Manage"
-msgstr "Beheren"
-
-#: openforms/config/admin.py:299
-msgid "Content type"
-msgstr "inhoudstype"
-
-#: openforms/config/admin.py:316
-msgid "Appearance"
-msgstr "Weergave"
-
-#: openforms/config/admin.py:339
-#: openforms/config/templates/admin/config/theme/preview.html:33
-msgid "Preview"
-msgstr "Voorvertoning"
-
-#: openforms/config/admin.py:342
-msgid "Show preview"
-msgstr "Toon voorvertoning"
-
-#: openforms/config/api/constants.py:11
-msgid "Statement checkbox"
-msgstr "Verklaringselectievakje"
-
-#: openforms/config/api/constants.py:13
-msgid ""
-"A single Form.io checkbox component for the statements that a user may have "
-"to accept before submitting a form."
-msgstr ""
-"Eén enkel Form.io selectievakjecomponent voor de verklaring die een "
-"gebruiker mogelijks moet accepteren voor het formulier ingestuurd kan worden."
-
-#: openforms/config/api/constants.py:19
-msgid "Component type (checkbox)"
-msgstr "Componenttype (selectievakje)"
-
-#: openforms/config/api/constants.py:23
-msgid "Key of the statement field"
-msgstr "Sleutel van het verklaringsveld"
-
-#: openforms/config/api/constants.py:27
-msgid "Text of the statement"
-msgstr "Tekst van de verklaring"
-
-#: openforms/config/api/constants.py:34
-msgid "Whether accepting this statement is required or not."
-msgstr "Indicatie of de verklaring verplicht is."
-
-#: openforms/config/api/serializers.py:21
-msgid ""
-"Whether the user must agree to the privacy policy before submitting a form."
-msgstr ""
-"Of de gebruiker akkoord moet gaan met het privacybeleid voordat hij een "
-"formulier indient."
-
-#: openforms/config/api/serializers.py:26
-msgid ""
-"The formatted label to use next to the checkbox when asking the user to "
-"agree to the privacy policy."
-msgstr ""
-"Het opgemaakte label dat naast het selectievakje moet worden getoond wanneer "
-"de gebruiker wordt gevraagd akkoord te gaan met het privacybeleid."
-
-#: openforms/config/api/viewsets.py:11
-msgid "List available themes"
-msgstr "Lijst van beschikbare stijlen"
-
-#: openforms/config/api/viewsets.py:12
-msgid "Retrieve theme details"
-msgstr "Stijldetails weergeven"
-
-#: openforms/config/checks.py:57
-msgid "Address lookup plugins"
-msgstr "Adresopzoekplugins"
-
-#: openforms/config/checks.py:70
-msgid "Validator plugins"
-msgstr "Validatieplugins"
-
-#: openforms/config/checks.py:81
-msgid "Appointment plugins"
-msgstr "Afspraakplugins"
-
-#: openforms/config/checks.py:82
-msgid "Registration plugins"
-msgstr "Registratieplugins"
-
-#: openforms/config/checks.py:84
-msgid "Payment plugins"
-msgstr "Betaalproviderplugins"
-
-#: openforms/config/checks.py:85
-msgid "DMN plugins"
-msgstr "DMN plugins"
-
-#: openforms/config/checks.py:131
-#, python-brace-format
-msgid "Internal error: {exception}"
-msgstr "Interne fout: {exception}"
-
-#: openforms/config/constants.py:63
-msgid "any filetype"
-msgstr "elk bestandstype"
-
-#: openforms/config/constants.py:65
-msgid ".png"
-msgstr ".png"
-
-#: openforms/config/constants.py:66
-msgid ".jpg"
-msgstr ".jpg"
-
-#: openforms/config/constants.py:67
-msgid ".pdf"
-msgstr ".pdf"
-
-#: openforms/config/constants.py:68
-msgid ".xls"
-msgstr ".xls"
-
-#: openforms/config/constants.py:71
-msgid ".xlsx"
-msgstr ".xlsx"
-
-#: openforms/config/constants.py:73
-msgid ".csv"
-msgstr ".csv"
-
-#: openforms/config/constants.py:75
-msgid ".doc"
-msgstr ".doc"
-
-#: openforms/config/constants.py:78
-msgid ".docx"
-msgstr ".docx"
-
-#: openforms/config/constants.py:82
-msgid "Open Office"
-msgstr "Open Office"
-
-#: openforms/config/constants.py:86
-msgid ".zip"
-msgstr ".zip"
-
-#: openforms/config/constants.py:88
-msgid ".rar"
-msgstr ".rar"
-
-#: openforms/config/constants.py:89
-msgid ".tar"
-msgstr ".tar"
-
-#: openforms/config/constants.py:90
-msgid ".msg"
-msgstr ".msg"
-
-#: openforms/config/constants.py:94
-msgid ".dwg"
-msgstr ".dwg"
-
-#: openforms/config/constants.py:99
-msgid "Haal Centraal"
-msgstr "Haal Centraal"
-
-#: openforms/config/constants.py:100
-msgid "StufBg"
-msgstr "StUF-BG"
-
-#: openforms/config/forms.py:60
-msgid "Form for preview"
-msgstr "Formulier voor voorvertoning"
-
-#: openforms/config/forms.py:62
-msgid "Pick a form to preview the theme with."
-msgstr "Kies een formulier om de stijl in voor te vertonen."
-
-#: openforms/config/models/color.py:10
-msgid "color"
-msgstr "kleur"
-
-#: openforms/config/models/color.py:12
-msgid "Color in RGB hex format (#RRGGBB)"
-msgstr "Kleur in RGB hex-formaat (#RRGGBB)"
-
-#: openforms/config/models/color.py:17
-msgid "Human readable label for reference"
-msgstr "Label ter referentie"
-
-#: openforms/config/models/color.py:21
-msgid "text editor color preset"
-msgstr "WYSIWYG-editor tekstkleur"
-
-#: openforms/config/models/color.py:22
-msgid "text editor color presets"
-msgstr "WYSIWYG-editor tekstkleuren"
-
-#: openforms/config/models/color.py:34
-msgid "Example"
-msgstr "Voorbeeld"
-
-#: openforms/config/models/config.py:52
-msgid "allowed email (sub)domain names"
-msgstr "toegestane e-mail(sub)domeinen"
-
-#: openforms/config/models/config.py:54
-msgid ""
-"Provide a list of allowed (sub)domains (without 'https://www').Hyperlinks in "
-"a (confirmation) email are removed, unless the (sub)domain is provided here."
-msgstr ""
-"Geef een lijst van toegelaten (sub)domeinen op (zonder 'https://www.'). "
-"Hyperlinks in (bevestigings)e-mails worden verwijderd, tenzij het "
-"(sub)domein hier opgegeven is."
-
-#: openforms/config/models/config.py:64
-msgid "submission confirmation title"
-msgstr "Paginatitel inzendingsbevestiging"
-
-#: openforms/config/models/config.py:67
-msgid ""
-"The content of the confirmation page title. You can (and should) include the "
-"'public_reference' variable (using expression '{{ public_reference }}') so "
-"the users have a reference in case they need to contact the customer service."
-msgstr ""
-"De inhoud van de bevestigingspaginatitel. De 'public_reference' "
-"sjablooninstructie is beschikbaar (gebruik de expressie "
-"'{{ public_reference }}') en we adviseren om deze weer te geven zodat "
-"gebruikers een referentie hebben als ze de klantenservice moeten contacteren."
-
-#: openforms/config/models/config.py:72
-msgid "Confirmation: {{ public_reference }}"
-msgstr "Bevestiging: {{ public_reference }}"
-
-#: openforms/config/models/config.py:78
-msgid ""
-"The content of the submission confirmation page. It can contain variables "
-"that will be templated from the submitted form data."
-msgstr ""
-"De inhoud van bevestigingspagina kan variabelen bevatten die op basis van de "
-"ingediende formuliergegevens worden weergegeven. "
-
-#: openforms/config/models/config.py:81
-msgid "Thank you for submitting this form."
-msgstr "Wij hebben uw inzending ontvangen. "
-
-#: openforms/config/models/config.py:85
-msgid "submission report download link title"
-msgstr "titel downloadlink inzendings-PDF"
-
-#: openforms/config/models/config.py:87
-msgid "The title of the link to download the report of a submission."
-msgstr "Titel/tekst van de downloadlink om de inzending als PDF te downloaden."
-
-#: openforms/config/models/config.py:88
-msgid "Download PDF"
-msgstr "Download het document."
-
-#: openforms/config/models/config.py:91
-msgid "cosign submission confirmation title"
-msgstr "Titel mede-ondertekenenbevestigingspagina"
-
-#: openforms/config/models/config.py:94
-msgid ""
-"The content of the confirmation page title for submissions requiring "
-"cosigning."
-msgstr ""
-"De inhoud van de bevestigingspaginatitel wanneer de inzending mede-"
-"ondertekend moet worden."
-
-#: openforms/config/models/config.py:97
-msgid "Request not complete yet"
-msgstr "Aanvraag niet compleet"
-
-#: openforms/config/models/config.py:101
-msgid "cosign submission confirmation template"
-msgstr "Mede-ondertekenenbevestigingspagina tekst"
-
-#: openforms/config/models/config.py:103
-msgid ""
-"The content of the submission confirmation page for submissions requiring "
-"cosigning. The variables 'public_reference' and 'cosigner_email' are "
-"available (using expressions '{{ public_reference }}' and "
-"'{{ cosigner_email }}', respectively). We strongly advise you to include the "
-"'public_reference' in case users need to contact the customer service."
-msgstr ""
-"De inhoud van de bevestigingspagina wanneer de inzending mede-ondertekend "
-"moet worden. Je kan de variabelen 'public_reference' en 'cosigner_email' "
-"gebruiken (gebruik de expressies '{{ public_reference }}' en "
-"'{{ cosigner_email }}'). We raden sterk aan om de publieke referentie weer "
-"te geven zodat gebruikers hiernaar kunnen verwijzen als ze de klantenservice "
-"moeten contacteren."
-
-#: openforms/config/models/config.py:123
-msgid ""
-"Subject of the confirmation email message. Can be overridden on the form "
-"level"
-msgstr ""
-"Onderwerp van de bevestigingsmail. Bij het formulier kan een afwijkend "
-"onderwerp worden opgegeven."
-
-#: openforms/config/models/config.py:131
-msgid ""
-"Content of the confirmation email message. Can be overridden on the form "
-"level"
-msgstr ""
-"Inhoud van de bevestigingsmail. Bij het formulier kan een afwijkende inhoud "
-"worden opgegeven."
-
-#: openforms/config/models/config.py:148
-msgid "Subject of the save form email message."
-msgstr "Onderwerp van de \"pauzeer\"-email"
-
-#: openforms/config/models/config.py:154
-msgid "Content of the save form email message."
-msgstr "Inhoud van de \"pauzeer\"-email"
-
-#: openforms/config/models/config.py:163
-msgid "co-sign request template"
-msgstr "mede-ondertekenenverzoeksjabloon"
-
-#: openforms/config/models/config.py:165
-msgid ""
-"Content of the co-sign request email. The available template variables are: "
-"'form_name', 'submission_date', 'form_url' and 'code'."
-msgstr ""
-"De inhoud van de e-mail voor het mede-ondertekenenverzoek. De beschikbare "
-"sjabloonvariabelen zijn: 'form_name', 'submission_date', 'form_url' en "
-"'code'."
-
-#: openforms/config/models/config.py:178
-msgid ""
-"Subject of the confirmation email message when the form requires cosigning. "
-"Can be overridden on the form level."
-msgstr ""
-"Onderwerp van de bevestigingsmail voor formulieren met mede-ondertekenen. "
-"Bij het formulier kan een afwijkend onderwerp worden opgegeven."
-
-#: openforms/config/models/config.py:187
-msgid ""
-"Content of the confirmation email message when the form requires cosigning. "
-"Can be overridden on the form level."
-msgstr ""
-"Inhoud van de bevestigingsmail voor formulieren met mede-ondertekenen. Bij "
-"het formulier kan een afwijkende inhoud worden opgegeven."
-
-#: openforms/config/models/config.py:206
-msgid "Subject of the email verification email."
-msgstr "Onderwerp van de \"e-mailverificatie\"-email."
-
-#: openforms/config/models/config.py:212
-msgid "Content of the email verification email message."
-msgstr "Inhoud van de \"e-mailverificatie\"-email."
-
-#: openforms/config/models/config.py:221
-msgid "allow empty initiator"
-msgstr "Lege initiator toestaan"
-
-#: openforms/config/models/config.py:224
-msgid ""
-"When enabled and the submitter is not authenticated, a case is created "
-"without any initiator. Otherwise, a fake initiator is added with BSN "
-"111222333."
-msgstr ""
-"Indien aangevinkt en de inzender is niet geauthenticeerd, dan wordt een zaak "
-"aangemaakt zonder initiator. Indien uitgevinkt, dan zal een nep-initiator "
-"worden toegevoegd met BSN 111222333."
-
-#: openforms/config/models/config.py:231
-msgid "back to form text"
-msgstr "\"terug naar formulier\"-tekst"
-
-#: openforms/config/models/config.py:233 openforms/config/models/config.py:270
-msgid "Previous page"
-msgstr "Vorige stap"
-
-#: openforms/config/models/config.py:235
-msgid ""
-"The text that will be displayed in the overview page to go to the previous "
-"step"
-msgstr ""
-"Het label van de knop op de overzichtspagina om naar de vorige stap te gaan."
-
-#: openforms/config/models/config.py:242
-msgid "Change"
-msgstr "Wijzigen"
-
-#: openforms/config/models/config.py:244
-msgid ""
-"The text that will be displayed in the overview page to change a certain step"
-msgstr ""
-"Het label de link op de overzichtspagina om een bepaalde stap te wijzigen"
-
-#: openforms/config/models/config.py:253
-msgid ""
-"The text that will be displayed in the overview page to confirm the form is "
-"filled in correctly"
-msgstr ""
-"Het label van de knop op de overzichtspagina om het formulier in te dienen"
-
-#: openforms/config/models/config.py:260
-msgid "Begin form"
-msgstr "Formulier starten"
-
-#: openforms/config/models/config.py:262
-msgid ""
-"The text that will be displayed at the start of the form to indicate the "
-"user can begin to fill in the form"
-msgstr "Het label van de knop om het formulier te starten."
-
-#: openforms/config/models/config.py:268
-msgid "previous step text"
-msgstr "\"vorige stap\"-tekst"
-
-#: openforms/config/models/config.py:272
-msgid ""
-"The text that will be displayed in the form step to go to the previous step"
-msgstr ""
-"Het label van de knop om naar de vorige stap binnen het formulier te gaan"
-
-#: openforms/config/models/config.py:278
-msgid "Save current information"
-msgstr "Tussentijds opslaan"
-
-#: openforms/config/models/config.py:280
-msgid ""
-"The text that will be displayed in the form step to save the current "
-"information"
-msgstr "Het label van de knop om het formulier tussentijds op te slaan"
-
-#: openforms/config/models/config.py:286
-msgid "Next"
-msgstr "Volgende"
-
-#: openforms/config/models/config.py:288
-msgid "The text that will be displayed in the form step to go to the next step"
-msgstr ""
-"Het label van de knop om naar de volgende stap binnen het formulier te gaan"
-
-#: openforms/config/models/config.py:292
-msgid "Mark form fields 'required' by default"
-msgstr "Formulierenvelden zijn standaard 'verplicht'"
-
-#: openforms/config/models/config.py:295
-msgid ""
-"Whether the checkbox 'required' on form fields should be checked by default."
-msgstr ""
-"Configureer of formuliervelden standaard 'verplicht' moeten zijn bij het "
-"ontwerpen van een formulier."
-
-#: openforms/config/models/config.py:299
-msgid "Mark required fields with asterisks"
-msgstr "Markeer verplichte velden met een asterisk"
-
-#: openforms/config/models/config.py:302
-msgid ""
-"If checked, required fields are marked with an asterisk and optional fields "
-"are unmarked. If unchecked, optional fields will be marked with '(optional)' "
-"and required fields are unmarked."
-msgstr ""
-"Indien aangevinkt, dan zijn verplichte velden gemarkeerd met een asterisk en "
-"optionele velden niet gemarkeerd. Indien uitgevinkt, dan zijn optionele "
-"velden gemarkeerd met '(niet verplicht)' en verplichte velden ongemarkeerd."
-
-#: openforms/config/models/config.py:309
-msgid "Default allowed file upload types"
-msgstr "Standaard-toegestane upload-bestandstypen"
-
-#: openforms/config/models/config.py:311
-msgid ""
-"Provide a list of default allowed file upload types. If empty, all "
-"extensions are allowed."
-msgstr ""
-"Geef aan welke bestandstypen standaard toegestaan zijn. Indien deze waarde "
-"leeg is, dan zijn alle bestandstypen toegelaten."
-
-#: openforms/config/models/config.py:317
-msgid "Hide non-applicable form steps"
-msgstr "Verberg formulierstappen die niet van toepassing zijn"
-
-#: openforms/config/models/config.py:320
-msgid ""
-"If checked, form steps that become non-applicable as a result of user input "
-"are hidden from the progress indicator display (by default, they are "
-"displayed but marked as non-applicable.)"
-msgstr ""
-"Indien aangevinkt, dan worden stappen die (via logicaregels) niet van "
-"toepassing zijn verborgen. Standaard zijn deze zichtbaar maar gemarkeerd als "
-"n.v.t."
-
-#: openforms/config/models/config.py:326
-msgid "The default zoom level for the leaflet map."
-msgstr "Standaard zoomniveau voor kaartmateriaal."
-
-#: openforms/config/models/config.py:331
-msgid "The default latitude for the leaflet map."
-msgstr ""
-"Standaard latitude voor kaartmateriaal (in coördinatenstelsel EPSG:4326/WGS "
-"84)."
-
-#: openforms/config/models/config.py:339
-msgid "The default longitude for the leaflet map."
-msgstr ""
-"Standaard longitude voor kaartmateriaal (in coördinatenstelsel EPSG:4326/WGS "
-"84)."
-
-#: openforms/config/models/config.py:352
-msgid "default theme"
-msgstr "Standaardstijl"
-
-#: openforms/config/models/config.py:354
-msgid ""
-"If no explicit theme is configured, the configured default theme will be "
-"used as a fallback."
-msgstr ""
-"Indien geen expliciete stijl ingesteld is, dan wordt de standaardstijl "
-"gebruikt."
-
-#: openforms/config/models/config.py:360 openforms/config/models/theme.py:51
-msgid "favicon"
-msgstr "favicon"
-
-#: openforms/config/models/config.py:364
-msgid ""
-"Allow the uploading of a favicon, .png .jpg .svg and .ico are compatible."
-msgstr ""
-"Upload het favicon voor de applicatie. Enkel .png, .jpg, .svg en .ico "
-"bestanden zijn toegestaan."
-
-#: openforms/config/models/config.py:368 openforms/config/models/theme.py:42
-msgid "main website link"
-msgstr "hoofdsite link"
-
-#: openforms/config/models/config.py:371
-msgid ""
-"URL to the main website. Used for the 'back to municipality website' link."
-msgstr ""
-"URL naar de hoofdsite van de organisatie. Wordt gebruikt voor 'terug naar de "
-"gemeentewebsite' link."
-
-#: openforms/config/models/config.py:375 openforms/config/models/theme.py:32
-msgid "organization name"
-msgstr "organisatienaam"
-
-#: openforms/config/models/config.py:379
-msgid ""
-"The name of your organization that will be used as label for elements like "
-"the logo."
-msgstr ""
-"De naam van de organisatie/gemeente - dit wordt gebruikt in label bij "
-"elementen zoals het logo en de link terug naar de website."
-
-#: openforms/config/models/config.py:386
-msgid "organization OIN"
-msgstr "organisatie-OIN"
-
-#: openforms/config/models/config.py:389
-msgid "The OIN of the organization."
-msgstr "Het (door Logius toegekende) organisatie-identificatienummer (OIN)."
-
-#: openforms/config/models/config.py:395
-msgid "admin session timeout"
-msgstr "beheersessie time-out"
-
-#: openforms/config/models/config.py:399
-msgid ""
-"Amount of time in minutes the admin can be inactive for before being logged "
-"out"
-msgstr "Tijd in minuten voordat de sessie van een beheerder verloopt."
-
-#: openforms/config/models/config.py:403
-msgid "form session timeout"
-msgstr "formuliersessie time-out"
-
-#: openforms/config/models/config.py:410
-#, python-format
-msgid ""
-"Due to DigiD requirements this value has to be less than or equal to "
-"%(limit_value)s minutes."
-msgstr ""
-"Om veiligheidsredenen mag de waarde niet groter zijn %(limit_value)s minuten."
-
-#: openforms/config/models/config.py:415
-msgid ""
-"Amount of time in minutes a user filling in a form can be inactive for "
-"before being logged out"
-msgstr "Tijd in minuten voordat de sessie van een gebruiker verloopt."
-
-#: openforms/config/models/config.py:421
-msgid "Payment Order ID template"
-msgstr "Betaling: bestellingsnummersjabloon"
-
-#: openforms/config/models/config.py:426
-#, python-brace-format
-msgid ""
-"Template to use when generating payment order IDs. It should be alpha-"
-"numerical and can contain the '/._-' characters. You can use the placeholder "
-"tokens: {year}, {public_reference}, {uid}."
-msgstr ""
-"Sjabloon voor de generatie van unieke betalingsreferenties. Het sjabloon "
-"moet alfanumeriek zijn en mag de karakters '/._-' bevatten. De placeholder "
-"tokens {year}, {public_reference} en {uid} zijn beschikbaar. Het sjabloon "
-"moet de placeholder {uid} bevatten."
-
-#: openforms/config/models/config.py:441
-msgid "privacy policy URL"
-msgstr "Privacybeleid URL"
-
-#: openforms/config/models/config.py:441
-msgid "URL to the privacy policy"
-msgstr "URL naar het privacybeleid op uw eigen website"
-
-#: openforms/config/models/config.py:444
-msgid "privacy policy label"
-msgstr "Privacybeleid label"
-
-#: openforms/config/models/config.py:447
-msgid ""
-"The label of the checkbox that prompts the user to agree to the privacy "
-"policy."
-msgstr ""
-"Het label van het selectievakje dat de gebruiker vraagt om akkoord te gaan "
-"met het privacybeleid. "
-
-#: openforms/config/models/config.py:451
-msgid ""
-"Yes, I have read the {% privacy_policy %} and explicitly agree to the "
-"processing of my submitted information."
-msgstr ""
-"Ja, ik heb kennis genomen van het {% privacy_policy %} en geef uitdrukkelijk "
-"toestemming voor het verwerken van de door mij opgegeven gegevens."
-
-#: openforms/config/models/config.py:475
-msgid "statement of truth label"
-msgstr "waarheidsverklaringtekst"
-
-#: openforms/config/models/config.py:478
-msgid ""
-"The label of the checkbox that prompts the user to agree that they filled "
-"out the form truthfully. Note that this field does not have templating "
-"support."
-msgstr ""
-"Het label van het selectievakje dat de gebruiker vraagt om akkoord te gaan "
-"met de waarheidsverklaring. Merk op dat dit veld geen sjablonen ondersteunt."
-
-#: openforms/config/models/config.py:484
-msgid ""
-"I declare that I have filled out the form truthfully and have not omitted "
-"any information."
-msgstr ""
-"Ik verklaar dat ik deze aanvraag naar waarheid heb ingevuld en geen "
-"informatie heb verzwegen."
-
-#: openforms/config/models/config.py:496
-msgid "Amount of days successful submissions will remain before being removed"
-msgstr "Aantal dagen dat een voltooide inzending bewaard blijft."
-
-#: openforms/config/models/config.py:504
-msgid "How successful submissions will be removed after the limit"
-msgstr ""
-"Geeft aan hoe voltooide inzendingen worden opgeschoond na de bewaartermijn."
-
-#: openforms/config/models/config.py:511
-msgid "Amount of days incomplete submissions will remain before being removed"
-msgstr "Aantal dagen dat een sessie bewaard blijft."
-
-#: openforms/config/models/config.py:519
-msgid "How incomplete submissions will be removed after the limit"
-msgstr "Geeft aan hoe sessies worden opgeschoond na de bewaartermijn."
-
-#: openforms/config/models/config.py:526
-msgid "Amount of days errored submissions will remain before being removed"
-msgstr ""
-"Aantal dagen dat een niet voltooide inzendingen (door fouten in de "
-"afhandeling) bewaard blijft."
-
-#: openforms/config/models/config.py:530
-msgid "errored submissions removal method"
-msgstr "opschoonmethode voor niet voltooide inzendingen"
-
-#: openforms/config/models/config.py:534
-msgid "How errored submissions will be removed after the"
-msgstr ""
-"Geeft aan hoe niet voltooide inzendingen (door fouten in de afhandeling) "
-"worden opgeschoond na de bewaartermijn."
-
-#: openforms/config/models/config.py:540
-msgid "Amount of days when all submissions will be permanently deleted"
-msgstr ""
-"Aantal dagen dat een inzending bewaard blijft voordat deze definitief "
-"verwijderd wordt."
-
-#: openforms/config/models/config.py:544
-msgid "default registration backend attempt limit"
-msgstr "limiet aantal registratiepogingen"
-
-#: openforms/config/models/config.py:548
-msgid ""
-"How often we attempt to register the submission at the registration backend "
-"before giving up"
-msgstr ""
-"Stel in hoe vaak het systeem een inzending probeert af te leveren bij de "
-"registratie-backend voor er opgegeven wordt."
-
-#: openforms/config/models/config.py:553
-msgid "plugin configuration"
-msgstr "pluginconfiguratie"
-
-#: openforms/config/models/config.py:557
-msgid ""
-"Configuration of plugins for authentication, payments, prefill, "
-"registrations and validation"
-msgstr ""
-"Configuratie van plugins voor authenticatie, betaalproviders, prefill, "
-"registraties en validaties."
-
-#: openforms/config/models/config.py:564
-msgid "reference lists services"
-msgstr "referentielijstenservices"
-
-#: openforms/config/models/config.py:566
-msgid ""
-"List of services that are instances of the Referentielijsten API. The "
-"selected services will be shown as options when configuring select or "
-"selectboxes components to be populated from Referentielijsten."
-msgstr ""
-"Selecteer de services die referentielijsten ontsluiten. Je kan vervolgens in "
-"de formuliercomponenten uit deze lijst van services een optie selecteren om "
-"de keuzeopties uit de referentielijsten op te halen."
-
-#: openforms/config/models/config.py:573
-msgid "family members data api"
-msgstr "familieledengegevens-API"
-
-#: openforms/config/models/config.py:574
-msgid "Which API to use to retrieve the data of the family members."
-msgstr "Welke API gebruikt wordt om familiegegevens op te halen."
-
-#: openforms/config/models/config.py:580
-msgid "communication preferences portal url"
-msgstr "url naar communicatievoorkeurenportaal"
-
-#: openforms/config/models/config.py:583
-msgid ""
-"Url to the online portal where users can update their communication "
-"preferences. This is used by the profile component."
-msgstr ""
-"URL naar het portaal/de Mijn-omgeving waar gebruikers hun "
-"communicatievoorkeuren kunnen inzien en beheren. Dit wordt gebruikt in het "
-"Profiel-component."
-
-#: openforms/config/models/config.py:590
-msgid "Allow form page indexing"
-msgstr "Laat indexeren van formulierpagina's toe"
-
-#: openforms/config/models/config.py:593
-msgid ""
-"Whether form detail pages may be indexed and displayed in search engine "
-"result lists. Disable this to prevent listing."
-msgstr ""
-"Geeft aan of formulierpagina's geïndexeerd én getoond mogen worden in de "
-"resultaten van zoekmachines. Schakel dit uit om weergave te voorkomen."
-
-#: openforms/config/models/config.py:599
-msgid "Enable virus scan"
-msgstr "Virusscan inschakelen"
-
-#: openforms/config/models/config.py:602
-msgid ""
-"Whether the files uploaded by the users should be scanned by ClamAV virus "
-"scanner.In case a file is found to be infected, the file is deleted."
-msgstr ""
-"Indien aangevinkt, dan worden uploads van eindgebruikers op virussen "
-"gescand. Geïnfecteerde bestanden worden meteen verwijdered en geblokkeerd."
-
-#: openforms/config/models/config.py:607
-msgid "ClamAV server hostname"
-msgstr "ClamAV server hostname"
-
-#: openforms/config/models/config.py:609
-msgid "Hostname or IP address where ClamAV is running."
-msgstr "Hostname of IP-adres waarop de ClamAV service bereikbaar is."
-
-#: openforms/config/models/config.py:614
-msgid "ClamAV port number"
-msgstr "ClamAV poortnummer"
-
-#: openforms/config/models/config.py:615
-msgid "The TCP port on which ClamAV is listening."
-msgstr "Poortnummer (TCP) waarop de ClamAV service luistert."
-
-#: openforms/config/models/config.py:623
-msgid "ClamAV socket timeout"
-msgstr "ClamAV-connectie timeout"
-
-#: openforms/config/models/config.py:624
-msgid "ClamAV socket timeout expressed in seconds (optional)."
-msgstr "ClamAV socket timeout, in seconden."
-
-#: openforms/config/models/config.py:632
-msgid "recipients email digest"
-msgstr "ontvangers (probleem)rapportage"
-
-#: openforms/config/models/config.py:634
-msgid ""
-"The email addresses that should receive a daily report of items requiring "
-"attention."
-msgstr ""
-"Geef de e-mailaddressen op van beheerders die een dagelijkse rapportage "
-"dienen te ontvangen van eventuele problemen die actie vereisen."
-
-#: openforms/config/models/config.py:640
-msgid "wait for payment to register"
-msgstr "wacht tot betalingen voltooid zijn om inzendingen te verwerken"
-
-#: openforms/config/models/config.py:642
-msgid ""
-"Should a submission be processed (sent to the registration backend) only "
-"after payment has been received?"
-msgstr "Mag een inzending pas verwerkt worden nadat de betaling ontvangen is?"
-
-#: openforms/config/models/config.py:648
-msgid "Public reference template"
-msgstr "Publiek referentiesjabloon"
-
-#: openforms/config/models/config.py:652
-#, python-brace-format
-msgid ""
-"Template to use when generating public reference of the submission. It "
-"should be alpha-numerical and can contain the '/._-' characters. You can use "
-"the placeholder tokens: {year}, {uid}."
-msgstr ""
-"Sjabloon voor de generatie van de publieke referentie voor een inzending. "
-"Het sjabloon moet alfanumeriek zijn en mag de karakters '/._-' bevatten. De "
-"placeholder tokens {year} en {uid} zijn beschikbaar. Het sjabloon moet de "
-"placeholder {uid} bevatten."
-
-#: openforms/config/models/config.py:661
-msgid "Public reference alphabet"
-msgstr "Publiek referentie-alfabet"
-
-#: openforms/config/models/config.py:665
-#, python-brace-format
-msgid ""
-"Alphabet used to generate the {uid} part of the public reference of the "
-"submission. The sequence is shuffled in the unique way for each instance of "
-"Open Forms "
-msgstr ""
-"Alfabet dat wordt gebruikt om het {uid}-gedeelte van de publieke referentie "
-"van de inzending te genereren. Elke Open Formulieren-instantie heeft een "
-"unieke volgorde van het alfabet."
-
-#: openforms/config/models/config.py:673
-msgid "General configuration"
-msgstr "Algemene configuratie"
-
-#: openforms/config/models/config.py:699
-msgid "ClamAV host and port need to be configured if virus scan is enabled."
-msgstr ""
-"De ClamAV host en poortnummer moeten ingesteld zijn om virusscannen in te "
-"schakelen."
-
-#: openforms/config/models/config.py:710
-#, python-brace-format
-msgid "Cannot connect to ClamAV: {error}"
-msgstr "Kon niet verbinden met de antivirus-service: {error}"
-
-#: openforms/config/models/csp.py:64
-msgid "directive"
-msgstr "directive"
-
-#: openforms/config/models/csp.py:67
-msgid "CSP header directive."
-msgstr "CSP header directive."
-
-#: openforms/config/models/csp.py:72
-msgid "CSP header value."
-msgstr "CSP header waarde."
-
-#: openforms/config/models/csp.py:79
-msgid "An extra tag for this CSP entry, to identify the exact source."
-msgstr ""
-"Een extra label voor de CSP-configuratie zodat de precieze bron bepaald kan "
-"worden."
-
-#: openforms/config/models/csp.py:91
-msgid "object id"
-msgstr "object-ID"
-
-#: openforms/config/models/map.py:23
-msgid "A unique identifier for the tile layer."
-msgstr "Unieke identificatie voor de achtergrondlaag."
-
-#: openforms/config/models/map.py:26 openforms/config/models/map.py:77
-msgid "tile layer url"
-msgstr "achtergrondlaag-URL"
-
-#: openforms/config/models/map.py:29
-#, python-brace-format
-msgid ""
-"URL to the tile layer image, used to define the map component background. To "
-"ensure correct functionality of the map, EPSG 28992 projection should be "
-"used. Example value: https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/"
-"standaard/EPSG:28992/{z}/{x}/{y}.png"
-msgstr ""
-"URL naar de tegels van de achtergrondlaag van de kaart. Om de juiste werking "
-"te garanderen moet de laag de EPSG:28992-projectie gebruiken. Bijvoorbeeld: "
-"https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/"
-"{z}/{x}/{y}.png"
-
-#: openforms/config/models/map.py:39
-msgid "An easily recognizable name for the tile layer, used to identify it."
-msgstr ""
-"Een herkenbare naam voor de achtergrondlaag zodat je deze kan selecteren in "
-"keuzemenu's."
-
-#: openforms/config/models/map.py:46
-msgid "map tile layer"
-msgstr "kaartachtergrondlaag"
-
-#: openforms/config/models/map.py:47
-msgid "map tile layers"
-msgstr "kaartachtergrondlagen"
-
-#: openforms/config/models/map.py:73
-msgid ""
-"An easily recognizable name for the WMS tile layer, used to identify it."
-msgstr ""
-"Een herkenbare naam voor de WMS-kaartlaag zodat je deze kan selecteren in "
-"keuzemenu's."
-
-#: openforms/config/models/map.py:80
-msgid ""
-"URL to collect the WMS tile layer capabilities. To ensure correct "
-"functionality of the map, EPSG 28992 projection should be available on the "
-"WMS tile layer. Example value: https://service.pdok.nl/lv/bag/wms/v2_0?"
-"request=getCapabilities&service=WMS"
-msgstr ""
-"URL naar de tegels van de WMS-kaartlaag. Om de juiste werking te garanderen "
-"moet de laag de EPSG:28992-projectie gebruiken. Bijvoorbeeld: https://"
-"service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/"
-"{y}.png"
-
-#: openforms/config/models/map.py:91
-msgid "WMS layer"
-msgstr "WMS-kaartlaag"
-
-#: openforms/config/models/map.py:92
-msgid "WMS layers"
-msgstr "WMS-kaartlagen"
-
-#: openforms/config/models/theme.py:23
-msgid "An easily recognizable name for the theme, used to identify it."
-msgstr "Een herkenbare naam om deze stijl te identificeren."
-
-#: openforms/config/models/theme.py:36
-msgid ""
-"The name of your organization that will be used as label for elements like "
-"the logo. If left blank, the matching configuration option from the global "
-"configuration is used."
-msgstr ""
-"De naam van de organisatie/gemeente - dit wordt gebruikt in label bij "
-"elementen zoals het logo en de link terug naar de website. Als je dit "
-"leeglaat, dan wordt de algemene instelling gebruikt."
-
-#: openforms/config/models/theme.py:45
-msgid ""
-"URL to the main website. Used for the 'back to municipality website' link. "
-"If left blank, the matching configuration option from the global "
-"configuration is used."
-msgstr ""
-"URL naar de hoofdsite van de organisatie. Wordt gebruikt voor de 'terug naar "
-"de gemeentewebsite' link. Als je dit leeglaat, dan wordt de algemene "
-"instelling gebruikt."
-
-#: openforms/config/models/theme.py:55
-msgid ""
-"Allow the uploading of a favicon, .png .jpg .svg and .ico are compatible. If "
-"left blank, the matching configuration option from the global configuration "
-"is used."
-msgstr ""
-"Upload het favicon voor de applicatie. Enkel .png, .jpg, .svg en .ico "
-"bestanden zijn toegestaan. Als je dit leeglaat, dan wordt de algemene "
-"instelling gebruikt."
-
-#: openforms/config/models/theme.py:71
-msgid "theme logo"
-msgstr "logo"
-
-#: openforms/config/models/theme.py:75
-msgid ""
-"Upload the theme/organization logo, visible to users filling out forms. We "
-"advise dimensions around 150px by 75px. SVG's are permitted."
-msgstr ""
-"Upload het logo van de gemeente dat zichtbaar is op de formulierwebsite. We "
-"adviseren de dimensies van 150 x 75 pixels. SVG-bestanden zijn toegestaan."
-
-#: openforms/config/models/theme.py:80
-msgid "email logo"
-msgstr "emaillogo"
-
-#: openforms/config/models/theme.py:84
-msgid ""
-"Upload the email logo, visible to users who receive an email. We advise "
-"dimensions around 150px by 75px. SVG's are not permitted."
-msgstr ""
-"Upload het logo van de gemeente dat zichtbaar is in e-mails. We adviseren de "
-"dimensies van 150 x 75 pixels. SVG-bestanden zijn niet toegestaan."
-
-#: openforms/config/models/theme.py:93
-msgid "theme CSS class name"
-msgstr "Thema CSS class name"
-
-#: openforms/config/models/theme.py:95
-msgid "If provided, this class name will be set on the <html> element."
-msgstr ""
-"Indien ingevuld, dan wordt deze class name aan het <html> element toegevoegd."
-
-#: openforms/config/models/theme.py:98
-msgid "theme stylesheet URL"
-msgstr "Stylesheet-URL thema"
-
-#: openforms/config/models/theme.py:104
-msgid "The URL must point to a CSS resource (.css extension)."
-msgstr "De URL moet naar een CSS bestand wijzen (.css extensie)."
-
-#: openforms/config/models/theme.py:108
-msgid ""
-"The URL stylesheet with theme-specific rules for your organization. This "
-"will be included as final stylesheet, overriding previously defined styles. "
-"Note that you also have to include the host to the `style-src` CSP "
-"directive. Example value: https://unpkg.com/@utrecht/design-tokens@1.0.0-"
-"alpha.20/dist/index.css."
-msgstr ""
-"URL naar de stylesheet met thema-specifieke regels voor uw organisatie. Deze "
-"stylesheet wordt als laatste ingeladen, waarbij eerdere stijlregels dus "
-"overschreven worden. Vergeet niet dat u ook de host van deze URL aan de "
-"`style-src` CSP configuratie moet toevoegen. Voorbeeldwaarde: https://"
-"unpkg.com/@utrecht/design-tokens@1.0.0-alpha.20/dist/index.css."
-
-#: openforms/config/models/theme.py:115
-msgid "theme stylesheet"
-msgstr "Stylesheet thema"
-
-#: openforms/config/models/theme.py:120
-msgid ""
-"A stylesheet with theme-specific rules for your organization. This will be "
-"included as final stylesheet, overriding previously defined styles. If both "
-"a URL to a stylesheet and a stylesheet file have been configured, the "
-"uploaded file is included after the stylesheet URL."
-msgstr ""
-"Een stylesheet met thema-specifieke regels voor uw organisatie. Deze "
-"stylesheet wordt als laatste ingeladen. Indien je tegelijkertijd een "
-"stylesheet-URL en -bestand opgeeft, dan wordt het bestand na de URL "
-"ingeladen."
-
-#: openforms/config/models/theme.py:144
-msgid "design token values"
-msgstr "design token waarden"
-
-#: openforms/config/models/theme.py:148
-msgid ""
-"Values of various style parameters, such as border radii, background "
-"colors... Note that this is advanced usage. Any available but un-specified "
-"values will use fallback default values. See https://open-"
-"forms.readthedocs.io/en/latest/installation/form_hosting.html#run-time-"
-"configuration for documentation."
-msgstr ""
-"Waarden met diverse stijl parameters, zoals randen, achtergrondkleuren, etc. "
-"Dit is voor geavanceerde gebruikers. Attributen die niet zijn opgegeven "
-"vallen terug op standaardwaarden. Zie https://open-forms.readthedocs.io/en/"
-"latest/installation/form_hosting.html#run-time-configuration voor "
-"documentatie."
-
-#: openforms/config/models/theme.py:157
-msgid "themes"
-msgstr "stijlen"
-
-#: openforms/config/templates/admin/config/overview.html:10
-msgid "Overview"
-msgstr "Overzicht"
-
-#: openforms/config/templates/admin/config/overview.html:23
-msgid "Name"
-msgstr "Naam"
-
-#: openforms/config/templates/admin/config/overview.html:24
-msgid "Status"
-msgstr "Status"
-
-#: openforms/config/templates/admin/config/overview.html:35
-msgid "Failed to validate the configuration."
-msgstr "Kon de configuratie niet valideren"
-
-#: openforms/config/templates/admin/config/overview.html:37
-msgid "Skipped"
-msgstr "Overgeslagen"
-
-#: openforms/config/templates/admin/config/theme/preview.html:9
-#: openforms/config/templates/admin/config/theme/preview.html:15
-#, python-format
-msgid "Preview theme '%(theme)s'"
-msgstr "Bekijk stijl '%(theme)s'"
-
-#: openforms/config/templates/admin/config/theme/preview.html:14
-msgid "Themes"
-msgstr "Stijlen"
-
-#: openforms/config/templates/admin/config/theme/preview.html:20
-msgid "Preview a theme"
-msgstr "Bekijk een stijl"
-
-#: openforms/config/templates/config/default_cosign_submission_confirmation.html:6
-msgid "Your request is not yet complete."
-msgstr "Je aanvraag is nog niet compleet."
-
-#: openforms/config/templates/config/default_cosign_submission_confirmation.html:7
-msgid "Cosigning required"
-msgstr "Medeondertekening nodig"
-
-#: openforms/config/templates/config/default_cosign_submission_confirmation.html:8
-msgid ""
-"You can start the cosigning process immediately by clicking the button below."
-msgstr ""
-"Je kan het mede-ondertekenen meteen starten door de onderstaande knop aan te "
-"klikken."
-
-#: openforms/config/templates/config/default_cosign_submission_confirmation.html:11
-msgid "Alternative instructions"
-msgstr "Alternatieve instructies"
-
-#: openforms/config/templates/config/default_cosign_submission_confirmation.html:12
-#, python-format
-msgid ""
-"We've sent an email with a cosign request to <a href=\"mailto:"
-"%(tt_openvariable)s cosigner_email "
-"%(tt_closevariable)s\">%(tt_openvariable)s cosigner_email "
-"%(tt_closevariable)s</a>. Once the submission has been cosigned we will "
-"start processing your request."
-msgstr ""
-"Wij hebben een e-mail gestuurd voor medeondertekening naar <a href=\"mailto:"
-"%(tt_openvariable)s cosigner_email "
-"%(tt_closevariable)s\">%(tt_openvariable)s cosigner_email "
-"%(tt_closevariable)s</a>. Als deze ondertekend is, nemen wij je aanvraag in "
-"behandeling."
-
-#: openforms/config/templates/config/default_cosign_submission_confirmation.html:17
-#, python-format
-msgid ""
-"If you need to contact us about this submission, you can use the reference "
-"<strong>%(tt_openvariable)s public_reference %(tt_closevariable)s</strong>"
-msgstr ""
-"Als je contact moet opnemen over deze aanvraag, dan kan je de referentie "
-"<strong>%(tt_openvariable)s public_reference %(tt_closevariable)s</strong> "
-"gebruiken."
-
-#: openforms/config/templatetags/privacy_policy.py:19
-msgid "privacy policy"
-msgstr "privacybeleid"
-
-#~ msgid "Analytics cookies group"
-#~ msgstr "Cookiegroep analytics"

--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -1,3 +1,5 @@
+import json
+
 from django.contrib import admin, messages
 from django.contrib.admin.templatetags.admin_list import result_headers
 from django.db.models import BooleanField, Case, Count, F, Value, When
@@ -16,6 +18,7 @@ from openforms.registrations.admin import RegistrationBackendFieldMixin
 from openforms.typing import StrOrPromise
 from openforms.utils.expressions import FirstNotBlank
 
+from ..import_export.typing import FormExportOptions
 from ..models import Category, Form, FormDefinition, FormStep
 from ..models.form import FormsExport
 from ..utils import export_form
@@ -299,6 +302,8 @@ class FormAdmin(
                 reverse("admin:forms_form_change", args=(copied_form.pk,))
             )
         if "_export" in request.POST:
+            export_options = json.loads(request.POST.get("export_options", "{}"))
+
             # Clear messages
             storage = messages.get_messages(request)
             for _msg in storage:
@@ -306,7 +311,21 @@ class FormAdmin(
 
             response = HttpResponse(content_type="application/zip")
             response["Content-Disposition"] = f"attachment;filename={obj.slug}.zip"
-            export_form(obj.pk, response=response)
+            export_form(
+                obj.pk,
+                response=response,
+                export_options=FormExportOptions(
+                    **{
+                        field_name: export_options[field_name]
+                        for field_name in (
+                            "remove_sensitive_content",
+                            "form_configuration",
+                            "additional_form_configuration",
+                        )
+                        if field_name in export_options
+                    },
+                ),
+            )
 
             response["Content-Length"] = len(response.content)
 

--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -14,14 +14,14 @@ from ordered_model.admin import OrderedInlineModelAdminMixin, OrderedTabularInli
 
 from openforms.api.utils import underscore_to_camel
 from openforms.emails.models import ConfirmationEmailTemplate
+from openforms.forms.import_export.export_form import export_form
+from openforms.forms.import_export.typing import FormExportOptions
 from openforms.registrations.admin import RegistrationBackendFieldMixin
 from openforms.typing import StrOrPromise
 from openforms.utils.expressions import FirstNotBlank
 
-from ..import_export.typing import FormExportOptions
 from ..models import Category, Form, FormDefinition, FormStep
 from ..models.form import FormsExport
-from ..utils import export_form
 from .mixins import FormioConfigMixin
 from .views import (
     DownloadExportedFormsView,

--- a/src/openforms/forms/admin/tasks.py
+++ b/src/openforms/forms/admin/tasks.py
@@ -17,12 +17,13 @@ from rest_framework.exceptions import ValidationError
 from openforms.accounts.models import User
 from openforms.celery import app
 from openforms.emails.utils import send_mail_html
+from openforms.forms.import_export.export_form import export_form
 from openforms.logging import audit_logger
 from openforms.utils.urls import build_absolute_uri
 
 from ..models import Form
 from ..models.form import FormsExport
-from ..utils import export_form, import_form
+from ..utils import import_form
 
 logger = structlog.stdlib.get_logger(__name__)
 

--- a/src/openforms/forms/admin/tasks.py
+++ b/src/openforms/forms/admin/tasks.py
@@ -18,6 +18,10 @@ from openforms.accounts.models import User
 from openforms.celery import app
 from openforms.emails.utils import send_mail_html
 from openforms.forms.import_export.export_form import export_form
+from openforms.forms.import_export.typing import (
+    FormExportOptions,
+    FormExportOptionsData,
+)
 from openforms.logging import audit_logger
 from openforms.utils.urls import build_absolute_uri
 
@@ -29,7 +33,9 @@ logger = structlog.stdlib.get_logger(__name__)
 
 
 @app.task(ignore_result=True)
-def process_forms_export(forms_uuids: list, user_id: int) -> None:
+def process_forms_export(
+    forms_uuids: list, user_id: int, export_options: FormExportOptionsData
+) -> None:
     forms = Form.objects.filter(uuid__in=forms_uuids)
 
     user = User.objects.get(id=user_id)
@@ -42,6 +48,7 @@ def process_forms_export(forms_uuids: list, user_id: int) -> None:
                 export_form(
                     form_id=form.pk,
                     archive_name=Path(temp_dir, f"form_{form.slug}.zip"),
+                    export_options=FormExportOptions(**export_options),
                 )
             )
 

--- a/src/openforms/forms/admin/views.py
+++ b/src/openforms/forms/admin/views.py
@@ -22,6 +22,10 @@ from import_export.formats.base_formats import XLSX
 from privates.storages import private_media_storage
 from rest_framework.exceptions import ValidationError
 
+from openforms.forms.import_export.typing import (
+    AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
+)
 from openforms.logging import audit_logger
 
 from ..forms import ExportStatisticsForm
@@ -33,6 +37,38 @@ from .tasks import process_forms_export, process_forms_import
 
 class ExportFormsForm(forms.Form):
     forms_uuids = SimpleArrayField(forms.UUIDField(), widget=forms.HiddenInput)
+    remove_sensitive_content = forms.BooleanField(
+        label=_("Anonymize form configuration"),
+        required=False,
+        initial=True,
+        help_text=_(
+            "Whether sensative form configuration should be anonymized during exporting."
+        ),
+    )
+    form_configuration = forms.MultipleChoiceField(
+        label=_("Form configuration"),
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        initial=[
+            FormConfigurationOptions.registration_backends,
+            FormConfigurationOptions.prefill,
+            FormConfigurationOptions.payment_backend,
+            FormConfigurationOptions.auth_backends,
+        ],
+        choices=FormConfigurationOptions.choices,
+        help_text=_(
+            "Which form configuration should be included in the export file content."
+        ),
+    )
+    additional_form_configuration = forms.MultipleChoiceField(
+        label=_("Additional form configuration"),
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        choices=AdditionalFormConfigurationOptions.choices,
+        help_text=_(
+            "Which additional form configuration should be included in the export file content."
+        ),
+    )
 
     def clean_forms_uuids(self):
         if not Form.objects.filter(uuid__in=self.cleaned_data["forms_uuids"]).exists():
@@ -55,6 +91,15 @@ class ExportFormsView(ExportImportPermissionMixin, SuccessMessageMixin, FormView
         process_forms_export.delay(
             forms_uuids=form.cleaned_data["forms_uuids"],
             user_id=self.request.user.id,
+            export_options={
+                field_name: form.cleaned_data[field_name]
+                for field_name in (
+                    "remove_sensitive_content",
+                    "form_configuration",
+                    "additional_form_configuration",
+                )
+                if field_name in form.cleaned_data
+            },
         )
         return super().form_valid(form)
 

--- a/src/openforms/forms/api/serializers/__init__.py
+++ b/src/openforms/forms/api/serializers/__init__.py
@@ -1,4 +1,4 @@
-from .form import FormExportSerializer, FormImportSerializer, FormSerializer
+from .form import FormImportSerializer, FormSerializer
 from .form_admin_message import FormAdminMessageSerializer
 from .form_definition import FormDefinitionDetailSerializer, FormDefinitionSerializer
 from .form_step import FormStepLiteralsSerializer, FormStepSerializer
@@ -11,7 +11,6 @@ __all__ = [
     "LogicComponentActionSerializer",
     "FormLogicSerializer",
     "FormSerializer",
-    "FormExportSerializer",
     "FormImportSerializer",
     "FormDefinitionSerializer",
     "FormDefinitionDetailSerializer",

--- a/src/openforms/forms/api/serializers/form.py
+++ b/src/openforms/forms/api/serializers/form.py
@@ -735,17 +735,6 @@ FormSerializer.__doc__ = FormSerializer.__doc__.format(
 )
 
 
-class FormExportSerializer(FormSerializer):
-    def get_fields(self):
-        fields = super().get_fields()
-        # for export we want to use the list of plugin-id's instead of detailed info objects
-        if "login_options" in fields:
-            del fields["login_options"]
-        if "payment_options" in fields:
-            del fields["payment_options"]
-        return fields
-
-
 class FormImportSerializer(serializers.Serializer):
     file = serializers.FileField(
         help_text=_("The file that contains the form, form definitions and form steps.")

--- a/src/openforms/forms/api/serializers/form.py
+++ b/src/openforms/forms/api/serializers/form.py
@@ -32,6 +32,10 @@ from openforms.contrib.objects_api.models import ObjectsAPIGroupConfig
 from openforms.emails.api.serializers import ConfirmationEmailTemplateSerializer
 from openforms.emails.models import ConfirmationEmailTemplate
 from openforms.formio.typing import Component
+from openforms.forms.import_export.typing import (
+    AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
+)
 from openforms.payments.api.fields import PaymentOptionsReadOnlyField
 from openforms.payments.registry import register as payment_register
 from openforms.plugins.constants import UNIQUE_ID_MAX_LENGTH
@@ -733,6 +737,29 @@ FormSerializer.__doc__ = FormSerializer.__doc__.format(
         [f"`{field}`" for field in FormSerializer._get_admin_field_names()]
     )
 )
+
+
+class FormAPIExportRequestSerializer(serializers.Serializer):
+    remove_sensitive_content = serializers.BooleanField(
+        required=False,
+        help_text=_(
+            "Whether sensative form configuration should be anonymized during exporting."
+        ),
+    )
+    form_configuration = serializers.MultipleChoiceField(
+        required=False,
+        choices=FormConfigurationOptions.choices,
+        help_text=_(
+            "Which form configuration should be included in the export file content."
+        ),
+    )
+    additional_form_configuration = serializers.MultipleChoiceField(
+        required=False,
+        choices=AdditionalFormConfigurationOptions.choices,
+        help_text=_(
+            "Which additional form configuration should be included in the export file content."
+        ),
+    )
 
 
 class FormImportSerializer(serializers.Serializer):

--- a/src/openforms/forms/api/serializers/form_definition.py
+++ b/src/openforms/forms/api/serializers/form_definition.py
@@ -66,6 +66,7 @@ class FormDefinitionConfigurationSerializer(serializers.Serializer):
 class FormDefinitionSerializer(
     PublicFieldsSerializerMixin, serializers.HyperlinkedModelSerializer
 ):
+    is_exporting: bool = False
     translations = ModelTranslationsSerializer()
     configuration = FormDefinitionConfigurationSerializer(
         label=_("Form.io configuration"),
@@ -121,9 +122,7 @@ class FormDefinitionSerializer(
         #    for the dynamic formio configuration in the context of a submission.
         # 2. The serializers/API endpoints of :module:`openforms.forms.api` for
         #    'standalone' use/introspection.
-        is_export = self.context.get("is_export", False)
-
-        if not is_export:
+        if not self.is_exporting:
             rewrite_formio_components_for_request(
                 instance.configuration_wrapper,
                 request=self.context["request"],

--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -22,6 +22,7 @@ from rest_framework.response import Response
 from openforms.api.pagination import PageNumberPagination
 from openforms.api.serializers import ExceptionSerializer, ValidationErrorSerializer
 from openforms.forms.import_export.export_form import export_form
+from openforms.forms.import_export.typing import FormExportOptions
 from openforms.translations.utils import set_language_cookie
 from openforms.utils.patches.rest_framework_nested.viewsets import NestedViewSetMixin
 from openforms.utils.urls import is_admin_request, reverse_plus
@@ -62,6 +63,7 @@ from .serializers import (
     FormVersionSerializer,
 )
 from .serializers.form import (
+    FormAPIExportRequestSerializer,
     FormImportResponseSerializer,
     FormJsonSchemaOptionsSerializer,
 )
@@ -423,7 +425,10 @@ class FormViewSet(viewsets.ModelViewSet):
         },
     )
     @action(
-        detail=True, methods=["post"], authentication_classes=(TokenAuthentication,)
+        detail=True,
+        methods=["post"],
+        authentication_classes=(TokenAuthentication,),
+        serializer_class=FormAPIExportRequestSerializer,
     )
     def export(self, request, *args, **kwargs):
         """
@@ -436,7 +441,24 @@ class FormViewSet(viewsets.ModelViewSet):
         response = HttpResponse(content_type="application/zip")
         response["Content-Disposition"] = f"attachment;filename={instance.slug}.zip"
 
-        export_form(instance.id, response=response)
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        export_form(
+            instance.id,
+            response=response,
+            export_options=FormExportOptions(
+                **{
+                    field_name: serializer.validated_data[field_name]
+                    for field_name in (
+                        "remove_sensitive_content",
+                        "form_configuration",
+                        "additional_form_configuration",
+                    )
+                    if field_name in serializer.validated_data
+                },
+            ),
+        )
 
         response["Content-Length"] = len(response.content)
         return response

--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -21,6 +21,7 @@ from rest_framework.response import Response
 
 from openforms.api.pagination import PageNumberPagination
 from openforms.api.serializers import ExceptionSerializer, ValidationErrorSerializer
+from openforms.forms.import_export.export_form import export_form
 from openforms.translations.utils import set_language_cookie
 from openforms.utils.patches.rest_framework_nested.viewsets import NestedViewSetMixin
 from openforms.utils.urls import is_admin_request, reverse_plus
@@ -34,7 +35,7 @@ from ..models import (
     FormStep,
     FormVersion,
 )
-from ..utils import export_form, import_form
+from ..utils import import_form
 from .datastructures import FormVariableWrapper
 from .documentation import get_admin_fields_markdown
 from .filters import FormDefinitionFilter, FormVariableFilter

--- a/src/openforms/forms/constants.py
+++ b/src/openforms/forms/constants.py
@@ -3,8 +3,6 @@ from collections.abc import Set
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
-EXPORT_META_KEY = "_meta"
-
 
 class LogicActionTypes(models.TextChoices):
     step_not_applicable = (

--- a/src/openforms/forms/import_export/constants.py
+++ b/src/openforms/forms/import_export/constants.py
@@ -1,0 +1,1 @@
+EXPORT_META_KEY = "_meta"

--- a/src/openforms/forms/import_export/export_form.py
+++ b/src/openforms/forms/import_export/export_form.py
@@ -1,0 +1,111 @@
+import json
+import zipfile
+from typing import Any
+
+from django.conf import settings
+from django.core.serializers.json import DjangoJSONEncoder
+from django.utils import timezone
+
+from rest_framework.test import APIRequestFactory
+
+from openforms.forms.api.serializers import (
+    FormDefinitionSerializer,
+    FormExportSerializer,
+    FormLogicSerializer,
+    FormStepSerializer,
+    FormVariableSerializer,
+)
+from openforms.forms.models import Form, FormDefinition, FormLogic, FormStep
+from openforms.variables.constants import FormVariableSources
+
+from .constants import EXPORT_META_KEY
+from .typing import FormExportOptions
+
+
+def _get_mock_request():
+    factory = APIRequestFactory()
+    first_allowed_host = (
+        settings.ALLOWED_HOSTS[0] if settings.ALLOWED_HOSTS else "testserver"
+    )
+    server_name = first_allowed_host if first_allowed_host != "*" else "testserver"
+    request = factory.get("/", SERVER_NAME=server_name)
+    request.is_mock_request = True  # pyright: ignore[reportAttributeAccessIssue]
+    return request
+
+
+def export_form(
+    form_id, archive_name=None, response=None, export_options: FormExportOptions = None
+):
+    resources = form_to_json(form_id)
+
+    outfile = response or archive_name
+    with zipfile.ZipFile(outfile, "w") as zip_file:
+        for name, data in resources.items():
+            zip_file.writestr(f"{name}.json", data)
+    return outfile
+
+
+def form_to_json(form_id: int) -> dict:
+    form = Form.objects.get(pk=form_id)
+
+    # Ignore products in the export
+    form.product = None
+
+    # Reset the submission counter
+    form.submission_counter = 0
+
+    form_steps = FormStep.objects.filter(form__pk=form_id).select_related(
+        "form_definition"
+    )
+
+    form_definitions = FormDefinition.objects.filter(
+        pk__in=form_steps.values_list("form_definition", flat=True)
+    )
+
+    form_logic = FormLogic.objects.filter(form=form)
+
+    # Export only user defined variables
+    # The component variables should be regenerated from the form definition configuration
+    # The static variables should be created for each form
+    form_variables = form.formvariable_set.filter(
+        source=FormVariableSources.user_defined
+    )
+
+    request = _get_mock_request()
+
+    forms = [FormExportSerializer(instance=form, context={"request": request}).data]
+    form_definitions = FormDefinitionSerializer(
+        instance=form_definitions,
+        many=True,
+        context={"request": request, "is_export": True},
+    ).data
+    form_steps = FormStepSerializer(
+        instance=form_steps, many=True, context={"request": request}
+    ).data
+    form_logic = FormLogicSerializer(
+        instance=form_logic, many=True, context={"request": request}
+    ).data
+    form_variables = FormVariableSerializer(
+        instance=form_variables, many=True, context={"request": request}
+    ).data
+
+    resources = {
+        "forms": to_json(forms),
+        "formSteps": to_json(form_steps),
+        "formDefinitions": to_json(form_definitions),
+        "formLogic": to_json(form_logic),
+        "formVariables": to_json(form_variables),
+        EXPORT_META_KEY: to_json(
+            {
+                "of_release": settings.RELEASE,
+                "of_git_sha": settings.GIT_SHA,
+                "created": timezone.now().isoformat(),
+            }
+        ),
+    }
+
+    return resources
+
+
+def to_json(obj: Any):
+    return json.dumps(obj, cls=DjangoJSONEncoder)

--- a/src/openforms/forms/import_export/export_form.py
+++ b/src/openforms/forms/import_export/export_form.py
@@ -34,16 +34,10 @@ def _get_mock_request():
     return request
 
 
-# @TODO make export_options required
 def export_form(
-    form_id, archive_name=None, response=None, export_options: FormExportOptions = None
+    form_id, export_options: FormExportOptions, archive_name=None, response=None
 ):
-    resources = form_to_json(
-        form_id,
-        export_options=export_options
-        if export_options is not None
-        else FormExportOptions(),
-    )
+    resources = form_to_json(form_id, export_options)
 
     outfile = response or archive_name
     with zipfile.ZipFile(outfile, "w") as zip_file:

--- a/src/openforms/forms/import_export/export_form.py
+++ b/src/openforms/forms/import_export/export_form.py
@@ -8,17 +8,17 @@ from django.utils import timezone
 
 from rest_framework.test import APIRequestFactory
 
-from openforms.forms.api.serializers import (
-    FormDefinitionSerializer,
-    FormExportSerializer,
-    FormLogicSerializer,
-    FormStepSerializer,
-    FormVariableSerializer,
-)
 from openforms.forms.models import Form, FormDefinition, FormLogic, FormStep
 from openforms.variables.constants import FormVariableSources
 
 from .constants import EXPORT_META_KEY
+from .serializers import (
+    FormDefinitionExportSerializer,
+    FormExportSerializer,
+    FormLogicExportSerializer,
+    FormStepExportSerializer,
+    FormVariableExportSerializer,
+)
 from .typing import FormExportOptions
 
 
@@ -33,10 +33,16 @@ def _get_mock_request():
     return request
 
 
+# @TODO make export_options required
 def export_form(
     form_id, archive_name=None, response=None, export_options: FormExportOptions = None
 ):
-    resources = form_to_json(form_id)
+    resources = form_to_json(
+        form_id,
+        export_options=export_options
+        if export_options is not None
+        else FormExportOptions(),
+    )
 
     outfile = response or archive_name
     with zipfile.ZipFile(outfile, "w") as zip_file:
@@ -45,7 +51,7 @@ def export_form(
     return outfile
 
 
-def form_to_json(form_id: int) -> dict:
+def form_to_json(form_id: int, export_options: FormExportOptions) -> dict:
     form = Form.objects.get(pk=form_id)
 
     # Ignore products in the export
@@ -73,20 +79,35 @@ def form_to_json(form_id: int) -> dict:
 
     request = _get_mock_request()
 
-    forms = [FormExportSerializer(instance=form, context={"request": request}).data]
-    form_definitions = FormDefinitionSerializer(
+    forms = [
+        FormExportSerializer(
+            instance=form,
+            context={"request": request, "export_options": export_options},
+        ).data
+    ]
+    form_definitions = FormDefinitionExportSerializer(
         instance=form_definitions,
         many=True,
-        context={"request": request, "is_export": True},
+        context={
+            "request": request,
+            "export_options": export_options,
+            "form": form,
+        },
     ).data
-    form_steps = FormStepSerializer(
-        instance=form_steps, many=True, context={"request": request}
+    form_steps = FormStepExportSerializer(
+        instance=form_steps,
+        many=True,
+        context={"request": request, "export_options": export_options},
     ).data
-    form_logic = FormLogicSerializer(
-        instance=form_logic, many=True, context={"request": request}
+    form_logic = FormLogicExportSerializer(
+        instance=form_logic,
+        many=True,
+        context={"request": request, "export_options": export_options},
     ).data
-    form_variables = FormVariableSerializer(
-        instance=form_variables, many=True, context={"request": request}
+    form_variables = FormVariableExportSerializer(
+        instance=form_variables,
+        many=True,
+        context={"request": request, "export_options": export_options},
     ).data
 
     resources = {

--- a/src/openforms/forms/import_export/export_form.py
+++ b/src/openforms/forms/import_export/export_form.py
@@ -20,6 +20,7 @@ from .serializers import (
     FormVariableExportSerializer,
 )
 from .typing import FormExportOptions
+from .utils import get_additional_form_configuration_data
 
 
 def _get_mock_request():
@@ -53,9 +54,6 @@ def export_form(
 
 def form_to_json(form_id: int, export_options: FormExportOptions) -> dict:
     form = Form.objects.get(pk=form_id)
-
-    # Ignore products in the export
-    form.product = None
 
     # Reset the submission counter
     form.submission_counter = 0
@@ -116,6 +114,12 @@ def form_to_json(form_id: int, export_options: FormExportOptions) -> dict:
         "formDefinitions": to_json(form_definitions),
         "formLogic": to_json(form_logic),
         "formVariables": to_json(form_variables),
+        # Include additional configuration data in the export resources, based on the form.
+        **(
+            get_additional_form_configuration_data(form, export_options)
+            if export_options is not None
+            else {}
+        ),
         EXPORT_META_KEY: to_json(
             {
                 "of_release": settings.RELEASE,

--- a/src/openforms/forms/import_export/resources/__init__.py
+++ b/src/openforms/forms/import_export/resources/__init__.py
@@ -1,0 +1,13 @@
+from .base import BaseResource
+from .product import ProductResource
+from .wms_tile_layer import WMSTileLayerResource
+from .wmts_tile_layer import WMTSTileLayerResource
+from .yivi_attribute_group import YiviAttributeGroupResource
+
+__all__ = [
+    "BaseResource",
+    "ProductResource",
+    "WMSTileLayerResource",
+    "WMTSTileLayerResource",
+    "YiviAttributeGroupResource",
+]

--- a/src/openforms/forms/import_export/resources/base.py
+++ b/src/openforms/forms/import_export/resources/base.py
@@ -1,0 +1,10 @@
+from import_export.resources import ModelResource
+
+from openforms.forms.models import Form
+
+
+class BaseResource(ModelResource):
+    def export_for_form(self, form: Form):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement export_for_form()"
+        )

--- a/src/openforms/forms/import_export/resources/product.py
+++ b/src/openforms/forms/import_export/resources/product.py
@@ -1,0 +1,13 @@
+from openforms.forms.models import Form
+from openforms.products.models import Product
+
+from .base import BaseResource
+
+
+class ProductResource(BaseResource):
+    class Meta:
+        model = Product
+        fields = ("uuid", "name", "price", "information")
+
+    def export_for_form(self, form: Form):
+        return self.export(queryset=[form.product] if form.product is not None else [])

--- a/src/openforms/forms/import_export/resources/wms_tile_layer.py
+++ b/src/openforms/forms/import_export/resources/wms_tile_layer.py
@@ -1,0 +1,28 @@
+from openforms.config.models import MapWMSTileLayer
+from openforms.forms.models import Form
+
+from .base import BaseResource
+
+
+class WMSTileLayerResource(BaseResource):
+    class Meta:
+        model = MapWMSTileLayer
+        fields = ("uuid", "name", "url")
+
+    def export_for_form(self, form: Form):
+        wms_tile_layers = []
+        for step in form.form_step_map.values():
+            for component in step.form_definition.iter_components():
+                if component["type"] == "map":
+                    wms_tile_layers.extend(
+                        overlay["uuid"]
+                        for overlay in component.get("overlays", [])
+                        if overlay["uuid"] != ""
+                    )
+
+        if len(wms_tile_layers) == 0:
+            return self.export(queryset=[])
+
+        return self.export(
+            queryset=MapWMSTileLayer.objects.filter(uuid__in=list(set(wms_tile_layers)))
+        )

--- a/src/openforms/forms/import_export/resources/wmts_tile_layer.py
+++ b/src/openforms/forms/import_export/resources/wmts_tile_layer.py
@@ -1,0 +1,26 @@
+from openforms.config.models import MapTileLayer
+from openforms.forms.models import Form
+
+from .base import BaseResource
+
+
+class WMTSTileLayerResource(BaseResource):
+    class Meta:
+        model = MapTileLayer
+        fields = ("identifier", "label", "url")
+
+    def export_for_form(self, form: Form):
+        wmts_tile_layers = []
+        for step in form.form_step_map.values():
+            for component in step.form_definition.iter_components():
+                if component["type"] == "map":
+                    wmts_tile_layers.append(component.get("tileLayerIdentifier", ""))
+
+        if len(wmts_tile_layers) == 0:
+            return self.export(queryset=[])
+
+        return self.export(
+            queryset=MapTileLayer.objects.filter(
+                identifier__in=list(set(wmts_tile_layers))
+            )
+        )

--- a/src/openforms/forms/import_export/resources/yivi_attribute_group.py
+++ b/src/openforms/forms/import_export/resources/yivi_attribute_group.py
@@ -1,0 +1,24 @@
+from openforms.authentication.contrib.yivi_oidc.models import AttributeGroup
+from openforms.forms.models import Form
+
+from .base import BaseResource
+
+
+class YiviAttributeGroupResource(BaseResource):
+    class Meta:
+        model = AttributeGroup
+        fields = ("uuid", "name", "description", "attributes")
+
+    def export_for_form(self, form: Form):
+        yivi_auth_backend = form.auth_backends.all().filter(backend="yivi_oidc").first()
+        if (
+            yivi_auth_backend is None
+            or "additional_attributes_groups" not in yivi_auth_backend.options
+        ):
+            return self.export(queryset=[])
+
+        return self.export(
+            queryset=AttributeGroup.objects.filter(
+                uuid__in=yivi_auth_backend.options["additional_attributes_groups"]
+            )
+        )

--- a/src/openforms/forms/import_export/serializers/__init__.py
+++ b/src/openforms/forms/import_export/serializers/__init__.py
@@ -1,0 +1,13 @@
+from .form import FormExportSerializer
+from .form_definition import FormDefinitionExportSerializer
+from .form_logic import FormLogicExportSerializer
+from .form_step import FormStepExportSerializer
+from .form_variable import FormVariableExportSerializer
+
+__all__ = [
+    "FormExportSerializer",
+    "FormDefinitionExportSerializer",
+    "FormLogicExportSerializer",
+    "FormStepExportSerializer",
+    "FormVariableExportSerializer",
+]

--- a/src/openforms/forms/import_export/serializers/base.py
+++ b/src/openforms/forms/import_export/serializers/base.py
@@ -1,0 +1,24 @@
+from rest_framework import serializers
+
+from openforms.forms.import_export.typing import FormExportOptions
+from openforms.typing import JSONObject
+
+
+class BaseExportSerializer(serializers.Serializer):
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        if (
+            export_options := self.get_export_options()
+        ) is not None and export_options.remove_sensitive_content:
+            representation = self.remove_sensitive_content(instance, representation)
+
+        return representation
+
+    def remove_sensitive_content(
+        self, instance, representation: JSONObject
+    ) -> JSONObject:
+        return representation
+
+    def get_export_options(self) -> FormExportOptions | None:
+        return self.context.get("export_options", None)

--- a/src/openforms/forms/import_export/serializers/base.py
+++ b/src/openforms/forms/import_export/serializers/base.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from openforms.forms.import_export.typing import (
+    AdditionalFormConfigurationCleanup,
     FormConfigurationCleanup,
     FormExportOptions,
 )
@@ -9,6 +10,9 @@ from openforms.typing import JSONObject
 
 class BaseExportSerializer(serializers.Serializer):
     excluded_form_configuration_cleanup: list[FormConfigurationCleanup] = ()
+    excluded_additional_form_configuration_cleanup: list[
+        AdditionalFormConfigurationCleanup
+    ] = ()
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)
@@ -19,6 +23,9 @@ class BaseExportSerializer(serializers.Serializer):
             representation = self.remove_sensitive_content(instance, representation)
 
         representation = self.remove_excluded_form_configuration(representation)
+        representation = self.remove_excluded_additional_form_configuration(
+            representation
+        )
 
         return representation
 
@@ -37,6 +44,21 @@ class BaseExportSerializer(serializers.Serializer):
         )
 
         for config in self.excluded_form_configuration_cleanup:
+            if config.option not in selected_options:
+                config.cleanup(representation)
+
+        return representation
+
+    def remove_excluded_additional_form_configuration(
+        self, representation: JSONObject
+    ) -> JSONObject:
+        selected_options = (
+            set(export_options.additional_form_configuration)
+            if (export_options := self.get_export_options()) is not None
+            else set()
+        )
+
+        for config in self.excluded_additional_form_configuration_cleanup:
             if config.option not in selected_options:
                 config.cleanup(representation)
 

--- a/src/openforms/forms/import_export/serializers/base.py
+++ b/src/openforms/forms/import_export/serializers/base.py
@@ -1,10 +1,15 @@
 from rest_framework import serializers
 
-from openforms.forms.import_export.typing import FormExportOptions
+from openforms.forms.import_export.typing import (
+    FormConfigurationCleanup,
+    FormExportOptions,
+)
 from openforms.typing import JSONObject
 
 
 class BaseExportSerializer(serializers.Serializer):
+    excluded_form_configuration_cleanup: list[FormConfigurationCleanup] = ()
+
     def to_representation(self, instance):
         representation = super().to_representation(instance)
 
@@ -13,11 +18,28 @@ class BaseExportSerializer(serializers.Serializer):
         ) is not None and export_options.remove_sensitive_content:
             representation = self.remove_sensitive_content(instance, representation)
 
+        representation = self.remove_excluded_form_configuration(representation)
+
         return representation
 
     def remove_sensitive_content(
         self, instance, representation: JSONObject
     ) -> JSONObject:
+        return representation
+
+    def remove_excluded_form_configuration(
+        self, representation: JSONObject
+    ) -> JSONObject:
+        selected_options = (
+            set(export_options.form_configuration)
+            if (export_options := self.get_export_options()) is not None
+            else set()
+        )
+
+        for config in self.excluded_form_configuration_cleanup:
+            if config.option not in selected_options:
+                config.cleanup(representation)
+
         return representation
 
     def get_export_options(self) -> FormExportOptions | None:

--- a/src/openforms/forms/import_export/serializers/base.py
+++ b/src/openforms/forms/import_export/serializers/base.py
@@ -1,3 +1,6 @@
+from collections.abc import Sequence
+from typing import ClassVar
+
 from rest_framework import serializers
 
 from openforms.forms.import_export.typing import (
@@ -9,10 +12,19 @@ from openforms.typing import JSONObject
 
 
 class BaseExportSerializer(serializers.Serializer):
-    excluded_form_configuration_cleanup: list[FormConfigurationCleanup] = ()
-    excluded_additional_form_configuration_cleanup: list[
-        AdditionalFormConfigurationCleanup
+    excluded_form_configuration_cleanup: ClassVar[
+        Sequence[FormConfigurationCleanup]
     ] = ()
+    excluded_additional_form_configuration_cleanup: ClassVar[
+        Sequence[AdditionalFormConfigurationCleanup]
+    ] = ()
+    save_export_fields: ClassVar[Sequence[str]] = ()
+    """
+    Fields that never contain sensitive information.
+
+    When exporting with the option ``remove_sensitive_content=True``, only these fields
+    will be exported.
+    """
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)
@@ -32,7 +44,14 @@ class BaseExportSerializer(serializers.Serializer):
     def remove_sensitive_content(
         self, instance, representation: JSONObject
     ) -> JSONObject:
-        return representation
+        """
+        Remove all fields that are not in the save_export_fields list.
+        """
+        return {
+            key: field
+            for key, field in representation.items()
+            if key in self.save_export_fields
+        }
 
     def remove_excluded_form_configuration(
         self, representation: JSONObject

--- a/src/openforms/forms/import_export/serializers/form.py
+++ b/src/openforms/forms/import_export/serializers/form.py
@@ -1,0 +1,25 @@
+from openforms.forms.api.serializers import FormSerializer
+
+from .base import BaseExportSerializer
+
+
+class FormExportSerializer(FormSerializer, BaseExportSerializer):
+    def get_fields(self):
+        fields = super().get_fields()
+        # for export we want to use the list of plugin-id's instead of detailed info objects
+        if "login_options" in fields:
+            del fields["login_options"]
+        if "payment_options" in fields:
+            del fields["payment_options"]
+        return fields
+
+    def remove_sensitive_content(self, instance, representation):
+        representation = super().remove_sensitive_content(instance, representation)
+        representation["internal_remarks"] = ""
+
+        for registration in representation.get("registration_backends", []):
+            if registration["backend"] == "email":
+                registration["options"]["to_emails"] = []
+                registration["options"]["payment_emails"] = []
+
+        return representation

--- a/src/openforms/forms/import_export/serializers/form.py
+++ b/src/openforms/forms/import_export/serializers/form.py
@@ -1,9 +1,42 @@
 from openforms.forms.api.serializers import FormSerializer
+from openforms.forms.import_export.typing import (
+    FormConfigurationCleanup,
+    FormConfigurationOptions,
+)
+from openforms.typing import JSONObject
 
 from .base import BaseExportSerializer
 
 
+def exclude_registration_backends(representation: JSONObject):
+    representation["registration_backends"] = []
+
+
+def exclude_payment_backend(representation: JSONObject):
+    representation["payment_backend"] = ""
+    representation["payment_backend_options"] = {}
+
+
+def exclude_auth_backends(representation: JSONObject):
+    representation["auth_backends"] = []
+
+
 class FormExportSerializer(FormSerializer, BaseExportSerializer):
+    excluded_form_configuration_cleanup = (
+        FormConfigurationCleanup(
+            option=FormConfigurationOptions.registration_backends,
+            cleanup=exclude_registration_backends,
+        ),
+        FormConfigurationCleanup(
+            option=FormConfigurationOptions.payment_backend,
+            cleanup=exclude_payment_backend,
+        ),
+        FormConfigurationCleanup(
+            option=FormConfigurationOptions.auth_backends,
+            cleanup=exclude_auth_backends,
+        ),
+    )
+
     def get_fields(self):
         fields = super().get_fields()
         # for export we want to use the list of plugin-id's instead of detailed info objects

--- a/src/openforms/forms/import_export/serializers/form.py
+++ b/src/openforms/forms/import_export/serializers/form.py
@@ -1,4 +1,5 @@
 from openforms.forms.api.serializers import FormSerializer
+from openforms.forms.api.serializers.form import FormRegistrationBackendSerializer
 from openforms.forms.import_export.typing import (
     AdditionalFormConfigurationCleanup,
     AdditionalFormConfigurationOptions,
@@ -33,6 +34,26 @@ def exclude_auth_backends(representation: JSONObject):
     representation["auth_backends"] = []
 
 
+class FormRegistrationBackendExportSerializer(
+    FormRegistrationBackendSerializer, BaseExportSerializer
+):
+    save_export_fields = (
+        "key",
+        "name",
+        "backend",
+        "options",
+    )
+
+    def remove_sensitive_content(self, instance, representation):
+        representation = super().remove_sensitive_content(instance, representation)
+
+        if representation["backend"] == "email":
+            representation["options"]["to_emails"] = []
+            representation["options"]["payment_emails"] = []
+
+        return representation
+
+
 class FormExportSerializer(FormSerializer, BaseExportSerializer):
     excluded_additional_form_configuration_cleanup = (
         AdditionalFormConfigurationCleanup(
@@ -58,6 +79,70 @@ class FormExportSerializer(FormSerializer, BaseExportSerializer):
             cleanup=exclude_auth_backends,
         ),
     )
+    registration_backends = FormRegistrationBackendExportSerializer(
+        many=True, required=False
+    )
+    save_export_fields = (
+        "uuid",
+        "name",
+        "internal_name",
+        "login_required",
+        "translation_enabled",
+        "registration_backends",
+        "auth_backends",
+        "login_options",
+        "auto_login_authentication_backend",
+        "payment_required",
+        "payment_backend",
+        "payment_backend_options",
+        "payment_options",
+        "price_variable_key",
+        "appointment_options",
+        "literals",
+        "begin_text",
+        "previous_text",
+        "change_text",
+        "confirm_text",
+        "product",
+        "slug",
+        "url",
+        "type",
+        "category",
+        "theme",
+        "steps",
+        "show_progress_indicator",
+        "show_summary_progress",
+        "maintenance_mode",
+        "active",
+        "activate_on",
+        "deactivate_on",
+        "is_deleted",
+        "submission_confirmation_template",
+        "introduction_page_content",
+        "explanation_template",
+        "submission_allowed",
+        "submission_limit",
+        "submission_counter",
+        "submission_limit_reached",
+        "suspension_allowed",
+        "ask_privacy_consent",
+        "ask_statement_of_truth",
+        "submissions_removal_options",
+        "confirmation_email_template",
+        "send_confirmation_email",
+        "display_main_website_link",
+        "include_confirmation_page_content_in_pdf",
+        "required_fields_with_asterisk",
+        "communication_preferences_portal_url",
+        "translations",
+        "resume_link_lifetime",
+        "hide_non_applicable_steps",
+        "cosign_login_options",
+        "cosign_has_link_in_email",
+        "submission_statements_configuration",
+        "submission_report_download_link_title",
+        "brp_personen_request_options",
+    )
 
     def get_fields(self):
         fields = super().get_fields()
@@ -67,14 +152,3 @@ class FormExportSerializer(FormSerializer, BaseExportSerializer):
         if "payment_options" in fields:
             del fields["payment_options"]
         return fields
-
-    def remove_sensitive_content(self, instance, representation):
-        representation = super().remove_sensitive_content(instance, representation)
-        representation["internal_remarks"] = ""
-
-        for registration in representation.get("registration_backends", []):
-            if registration["backend"] == "email":
-                registration["options"]["to_emails"] = []
-                registration["options"]["payment_emails"] = []
-
-        return representation

--- a/src/openforms/forms/import_export/serializers/form.py
+++ b/src/openforms/forms/import_export/serializers/form.py
@@ -1,11 +1,23 @@
 from openforms.forms.api.serializers import FormSerializer
 from openforms.forms.import_export.typing import (
+    AdditionalFormConfigurationCleanup,
+    AdditionalFormConfigurationOptions,
     FormConfigurationCleanup,
     FormConfigurationOptions,
 )
 from openforms.typing import JSONObject
 
 from .base import BaseExportSerializer
+
+
+def clear_product(representation: JSONObject):
+    representation["product"] = None
+
+
+def clear_yivi_attribute_groups(representation: JSONObject):
+    for auth in representation.get("auth_backends", []):
+        if auth["backend"] == "yivi_oidc":
+            auth["options"]["additional_attributes_groups"] = []
 
 
 def exclude_registration_backends(representation: JSONObject):
@@ -22,6 +34,16 @@ def exclude_auth_backends(representation: JSONObject):
 
 
 class FormExportSerializer(FormSerializer, BaseExportSerializer):
+    excluded_additional_form_configuration_cleanup = (
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.product,
+            cleanup=clear_product,
+        ),
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.yivi_attribute_groups,
+            cleanup=clear_yivi_attribute_groups,
+        ),
+    )
     excluded_form_configuration_cleanup = (
         FormConfigurationCleanup(
             option=FormConfigurationOptions.registration_backends,

--- a/src/openforms/forms/import_export/serializers/form_definition.py
+++ b/src/openforms/forms/import_export/serializers/form_definition.py
@@ -1,11 +1,32 @@
 from openforms.formio.utils import iter_components
 from openforms.forms.api.serializers import FormDefinitionSerializer
+from openforms.forms.import_export.typing import (
+    FormConfigurationCleanup,
+    FormConfigurationOptions,
+)
+from openforms.prefill.constants import IdentifierRoles
+from openforms.typing import JSONObject
 
 from .base import BaseExportSerializer
 
 
+def remove_prefill_from_component_configuration(representation: JSONObject):
+    for component in representation.get("configuration", {}).get("components", []):
+        if "prefill" not in component:
+            return
+        component["prefill"]["plugin"] = ""
+        component["prefill"]["attribute"] = ""
+        component["prefill"]["identifier_role"] = IdentifierRoles.main
+
+
 class FormDefinitionExportSerializer(FormDefinitionSerializer, BaseExportSerializer):
     is_exporting = True
+    excluded_form_configuration_cleanup = (
+        FormConfigurationCleanup(
+            option=FormConfigurationOptions.prefill,
+            cleanup=remove_prefill_from_component_configuration,
+        ),
+    )
 
     def remove_sensitive_content(self, instance, representation):
         representation = super().remove_sensitive_content(instance, representation)

--- a/src/openforms/forms/import_export/serializers/form_definition.py
+++ b/src/openforms/forms/import_export/serializers/form_definition.py
@@ -1,6 +1,8 @@
 from openforms.formio.utils import iter_components
 from openforms.forms.api.serializers import FormDefinitionSerializer
 from openforms.forms.import_export.typing import (
+    AdditionalFormConfigurationCleanup,
+    AdditionalFormConfigurationOptions,
     FormConfigurationCleanup,
     FormConfigurationOptions,
 )
@@ -8,6 +10,24 @@ from openforms.prefill.constants import IdentifierRoles
 from openforms.typing import JSONObject
 
 from .base import BaseExportSerializer
+
+
+def clear_wms_tile_layers(representation: JSONObject):
+    for component in representation.get("configuration", {}).get("components", []):
+        if component["type"] != "map":
+            continue
+
+        for overlay in component.get("overlays", []):
+            overlay["uuid"] = ""
+            overlay["layers"] = []
+
+
+def clear_wmts_tile_layers(representation: JSONObject):
+    for component in representation.get("configuration", {}).get("components", []):
+        if component["type"] != "map" or "tileLayerIdentifier" not in component:
+            continue
+
+        component["tileLayerIdentifier"] = ""
 
 
 def remove_prefill_from_component_configuration(representation: JSONObject):
@@ -21,6 +41,16 @@ def remove_prefill_from_component_configuration(representation: JSONObject):
 
 class FormDefinitionExportSerializer(FormDefinitionSerializer, BaseExportSerializer):
     is_exporting = True
+    excluded_additional_form_configuration_cleanup = (
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.wms_tile_layers,
+            cleanup=clear_wms_tile_layers,
+        ),
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.wmts_tile_layers,
+            cleanup=clear_wmts_tile_layers,
+        ),
+    )
     excluded_form_configuration_cleanup = (
         FormConfigurationCleanup(
             option=FormConfigurationOptions.prefill,

--- a/src/openforms/forms/import_export/serializers/form_definition.py
+++ b/src/openforms/forms/import_export/serializers/form_definition.py
@@ -1,0 +1,27 @@
+from openforms.formio.utils import iter_components
+from openforms.forms.api.serializers import FormDefinitionSerializer
+
+from .base import BaseExportSerializer
+
+
+class FormDefinitionExportSerializer(FormDefinitionSerializer, BaseExportSerializer):
+    is_exporting = True
+
+    def remove_sensitive_content(self, instance, representation):
+        representation = super().remove_sensitive_content(instance, representation)
+
+        if (form := self.context.get("form", None)) is None:
+            return representation
+
+        sensitive_variables = [
+            registration.options["to_emails_from_variable"]
+            for registration in form.registration_backends.all()
+            if registration.backend == "email"
+            and "to_emails_from_variable" in registration.options
+        ]
+
+        for component in iter_components(representation.get("configuration", {})):
+            if component["key"] in sensitive_variables:
+                component["defaultValue"] = ""
+
+        return representation

--- a/src/openforms/forms/import_export/serializers/form_definition.py
+++ b/src/openforms/forms/import_export/serializers/form_definition.py
@@ -57,6 +57,17 @@ class FormDefinitionExportSerializer(FormDefinitionSerializer, BaseExportSeriali
             cleanup=remove_prefill_from_component_configuration,
         ),
     )
+    save_export_fields = (
+        "url",
+        "uuid",
+        "name",
+        "internal_name",
+        "slug",
+        "configuration",
+        "login_required",
+        "is_reusable",
+        "translations",
+    )
 
     def remove_sensitive_content(self, instance, representation):
         representation = super().remove_sensitive_content(instance, representation)

--- a/src/openforms/forms/import_export/serializers/form_logic.py
+++ b/src/openforms/forms/import_export/serializers/form_logic.py
@@ -1,0 +1,25 @@
+from openforms.forms.api.serializers import FormLogicSerializer
+
+from .base import BaseExportSerializer
+
+
+class FormLogicExportSerializer(FormLogicSerializer, BaseExportSerializer):
+    def remove_sensitive_content(self, instance, representation):
+        representation = super().remove_sensitive_content(instance, representation)
+        form = instance.form
+
+        sensitive_variables = (
+            registration.options["to_emails_from_variable"]
+            for registration in form.registration_backends.all()
+            if registration.backend == "email"
+            and "to_emails_from_variable" in registration.options
+        )
+
+        for action in representation["actions"]:
+            if (
+                action["action"]["type"] == "variable"
+                and action["variable"] in sensitive_variables
+            ):
+                action["action"]["value"] = ""
+
+        return representation

--- a/src/openforms/forms/import_export/serializers/form_logic.py
+++ b/src/openforms/forms/import_export/serializers/form_logic.py
@@ -4,6 +4,18 @@ from .base import BaseExportSerializer
 
 
 class FormLogicExportSerializer(FormLogicSerializer, BaseExportSerializer):
+    save_export_fields = (
+        "uuid",
+        "url",
+        "form",
+        "json_logic_trigger",
+        "description",
+        "order",
+        "actions",
+        "is_advanced",
+        "form_steps",
+    )
+
     def remove_sensitive_content(self, instance, representation):
         representation = super().remove_sensitive_content(instance, representation)
         form = instance.form

--- a/src/openforms/forms/import_export/serializers/form_step.py
+++ b/src/openforms/forms/import_export/serializers/form_step.py
@@ -1,0 +1,7 @@
+from openforms.forms.api.serializers import FormStepSerializer
+
+from .base import BaseExportSerializer
+
+
+class FormStepExportSerializer(FormStepSerializer, BaseExportSerializer):
+    pass

--- a/src/openforms/forms/import_export/serializers/form_step.py
+++ b/src/openforms/forms/import_export/serializers/form_step.py
@@ -4,4 +4,21 @@ from .base import BaseExportSerializer
 
 
 class FormStepExportSerializer(FormStepSerializer, BaseExportSerializer):
-    pass
+    save_export_fields = (
+        "uuid",
+        "index",
+        "slug",
+        "configuration",
+        "form_definition",
+        "name",
+        "internal_name",
+        "url",
+        "is_applicable",
+        "login_required",
+        "is_reusable",
+        "literals",
+        "previous_text",
+        "save_text",
+        "next_text",
+        "translations",
+    )

--- a/src/openforms/forms/import_export/serializers/form_variable.py
+++ b/src/openforms/forms/import_export/serializers/form_variable.py
@@ -1,9 +1,29 @@
 from openforms.forms.api.serializers import FormVariableSerializer
+from openforms.forms.import_export.typing import (
+    FormConfigurationCleanup,
+    FormConfigurationOptions,
+)
+from openforms.prefill.constants import IdentifierRoles
+from openforms.typing import JSONObject
 
 from .base import BaseExportSerializer
 
 
+def remove_prefill_from_variable(representation: JSONObject):
+    representation["prefill_plugin"] = ""
+    representation["prefill_attribute"] = ""
+    representation["prefill_identifier_role"] = IdentifierRoles.main
+    representation["prefill_options"] = {}
+
+
 class FormVariableExportSerializer(FormVariableSerializer, BaseExportSerializer):
+    excluded_form_configuration_cleanup = (
+        FormConfigurationCleanup(
+            option=FormConfigurationOptions.prefill,
+            cleanup=remove_prefill_from_variable,
+        ),
+    )
+
     def remove_sensitive_content(self, instance, representation):
         representation = super().remove_sensitive_content(instance, representation)
         form = instance.form

--- a/src/openforms/forms/import_export/serializers/form_variable.py
+++ b/src/openforms/forms/import_export/serializers/form_variable.py
@@ -1,0 +1,21 @@
+from openforms.forms.api.serializers import FormVariableSerializer
+
+from .base import BaseExportSerializer
+
+
+class FormVariableExportSerializer(FormVariableSerializer, BaseExportSerializer):
+    def remove_sensitive_content(self, instance, representation):
+        representation = super().remove_sensitive_content(instance, representation)
+        form = instance.form
+
+        for registration in form.registration_backends.all():
+            if (
+                registration.backend == "email"
+                and "to_emails_from_variable" in registration.options
+                and registration.options["to_emails_from_variable"]
+                == representation["key"]
+            ):
+                representation["initial_value"] = ""
+                return representation
+
+        return representation

--- a/src/openforms/forms/import_export/serializers/form_variable.py
+++ b/src/openforms/forms/import_export/serializers/form_variable.py
@@ -23,6 +23,22 @@ class FormVariableExportSerializer(FormVariableSerializer, BaseExportSerializer)
             cleanup=remove_prefill_from_variable,
         ),
     )
+    save_export_fields = (
+        "form",
+        "form_definition",
+        "name",
+        "key",
+        "source",
+        "service_fetch_configuration",
+        "prefill_plugin",
+        "prefill_attribute",
+        "prefill_identifier_role",
+        "prefill_options",
+        "data_type",
+        "data_format",
+        "is_sensitive_data",
+        "initial_value",
+    )
 
     def remove_sensitive_content(self, instance, representation):
         representation = super().remove_sensitive_content(instance, representation)

--- a/src/openforms/forms/import_export/typing.py
+++ b/src/openforms/forms/import_export/typing.py
@@ -38,6 +38,12 @@ class FormExportOptions:
 
 
 @dataclass(frozen=True)
+class AdditionalFormConfigurationCleanup:
+    option: AdditionalFormConfigurationOptions
+    cleanup: Callable[[JSONObject], None]
+
+
+@dataclass(frozen=True)
 class FormConfigurationCleanup:
     option: FormConfigurationOptions
     cleanup: Callable[[JSONObject], None]

--- a/src/openforms/forms/import_export/typing.py
+++ b/src/openforms/forms/import_export/typing.py
@@ -1,7 +1,10 @@
+from collections.abc import Callable
 from dataclasses import dataclass, field
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+
+from openforms.typing import JSONObject
 
 
 class FormConfigurationOptions(models.TextChoices):
@@ -32,3 +35,9 @@ class FormExportOptions:
     additional_form_configuration: list[AdditionalFormConfigurationOptions] = field(
         default_factory=list
     )
+
+
+@dataclass(frozen=True)
+class FormConfigurationCleanup:
+    option: FormConfigurationOptions
+    cleanup: Callable[[JSONObject], None]

--- a/src/openforms/forms/import_export/typing.py
+++ b/src/openforms/forms/import_export/typing.py
@@ -1,5 +1,6 @@
 from collections.abc import Callable
 from dataclasses import dataclass, field
+from typing import TypedDict
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
@@ -19,6 +20,12 @@ class AdditionalFormConfigurationOptions(models.TextChoices):
     wms_tile_layers = "wmsTileLayers", _("WMS-tile layers")
     wmts_tile_layers = "wmtsTileLayers", _("Background tile layers")
     yivi_attribute_groups = "yiviAttributeGroups", _("Yivi attribute groups")
+
+
+class FormExportOptionsData(TypedDict, total=False):
+    remove_sensitive_content: bool
+    form_configuration: list[FormConfigurationOptions]
+    additional_form_configuration: list[AdditionalFormConfigurationOptions]
 
 
 @dataclass(slots=True)

--- a/src/openforms/forms/import_export/typing.py
+++ b/src/openforms/forms/import_export/typing.py
@@ -1,0 +1,34 @@
+from dataclasses import dataclass, field
+
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class FormConfigurationOptions(models.TextChoices):
+    registration_backends = "registrationBackends", _("Registration backends")
+    prefill = "prefill", _("Prefill")
+    payment_backend = "paymentBackend", _("Payment backend")
+    auth_backends = "authBackends", _("Authentication backends")
+
+
+class AdditionalFormConfigurationOptions(models.TextChoices):
+    product = "product", _("Product")
+    wms_tile_layers = "wmsTileLayers", _("WMS-tile layers")
+    wmts_tile_layers = "wmtsTileLayers", _("Background tile layers")
+    yivi_attribute_groups = "yiviAttributeGroups", _("Yivi attribute groups")
+
+
+@dataclass(slots=True)
+class FormExportOptions:
+    remove_sensitive_content: bool = True
+    form_configuration: list[FormConfigurationOptions] = field(
+        default_factory=lambda: [
+            FormConfigurationOptions.registration_backends,
+            FormConfigurationOptions.prefill,
+            FormConfigurationOptions.payment_backend,
+            FormConfigurationOptions.auth_backends,
+        ]
+    )
+    additional_form_configuration: list[AdditionalFormConfigurationOptions] = field(
+        default_factory=list
+    )

--- a/src/openforms/forms/import_export/utils.py
+++ b/src/openforms/forms/import_export/utils.py
@@ -1,0 +1,69 @@
+from dataclasses import dataclass
+
+from openforms.forms.models import Form
+from openforms.typing import JSONObject
+
+from .resources import (
+    BaseResource,
+    ProductResource,
+    WMSTileLayerResource,
+    WMTSTileLayerResource,
+    YiviAttributeGroupResource,
+)
+from .typing import AdditionalFormConfigurationOptions, FormExportOptions
+
+
+@dataclass(frozen=True)
+class ExportResourceConfig:
+    resource: type[BaseResource]
+    output_name: str
+
+
+ADDITIONAL_FORM_CONFIGURATION_RESOURCES: dict[
+    AdditionalFormConfigurationOptions,
+    ExportResourceConfig,
+] = {
+    AdditionalFormConfigurationOptions.product: ExportResourceConfig(
+        resource=ProductResource,
+        output_name="product",
+    ),
+    AdditionalFormConfigurationOptions.wms_tile_layers: ExportResourceConfig(
+        resource=WMSTileLayerResource,
+        output_name="wmsTileLayers",
+    ),
+    AdditionalFormConfigurationOptions.wmts_tile_layers: ExportResourceConfig(
+        resource=WMTSTileLayerResource,
+        output_name="wmtsTileLayers",
+    ),
+    AdditionalFormConfigurationOptions.yivi_attribute_groups: ExportResourceConfig(
+        resource=YiviAttributeGroupResource,
+        output_name="yiviAttributeGroups",
+    ),
+}
+
+
+def get_additional_form_configuration_data(
+    form: Form, export_options: FormExportOptions
+) -> JSONObject:
+    """
+    Create a dictionary of additional form configuration data for the given form.
+
+    The keys are the names for the export files, and the values are the JSON data
+    representing the resource data. This should be used in the form export process, in
+    connection with `remove_excluded_additional_configuration_from_form`.
+    """
+    resources = {}
+
+    selected_options = set(export_options.additional_form_configuration)
+    unknown_options = selected_options - set(ADDITIONAL_FORM_CONFIGURATION_RESOURCES)
+
+    if unknown_options:
+        raise ValueError(
+            f"Invalid additional form configuration option(s): {unknown_options}"
+        )
+
+    for option, config in ADDITIONAL_FORM_CONFIGURATION_RESOURCES.items():
+        if option in selected_options:
+            resources[config.output_name] = config.resource().export_for_form(form).json
+
+    return resources

--- a/src/openforms/forms/models/form_version.py
+++ b/src/openforms/forms/models/form_version.py
@@ -21,7 +21,7 @@ class FormVersionManager(models.Manager):
         Create a new ``FormVersion`` record for a given form.
         """
         # circular dependencies
-        from ..utils import form_to_json
+        from openforms.forms.import_export.export_form import form_to_json
 
         form_json = form_to_json(form.id)
         if not description:

--- a/src/openforms/forms/models/form_version.py
+++ b/src/openforms/forms/models/form_version.py
@@ -22,8 +22,30 @@ class FormVersionManager(models.Manager):
         """
         # circular dependencies
         from openforms.forms.import_export.export_form import form_to_json
+        from openforms.forms.import_export.typing import (
+            AdditionalFormConfigurationOptions,
+            FormConfigurationOptions,
+            FormExportOptions,
+        )
 
-        form_json = form_to_json(form.id)
+        form_json = form_to_json(
+            form.id,
+            export_options=FormExportOptions(
+                form_configuration=[
+                    FormConfigurationOptions.registration_backends,
+                    FormConfigurationOptions.prefill,
+                    FormConfigurationOptions.payment_backend,
+                    FormConfigurationOptions.auth_backends,
+                ],
+                additional_form_configuration=[
+                    AdditionalFormConfigurationOptions.product,
+                    AdditionalFormConfigurationOptions.wms_tile_layers,
+                    AdditionalFormConfigurationOptions.wmts_tile_layers,
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                ],
+                remove_sensitive_content=False,
+            ),
+        )
         if not description:
             version_number = self.filter(form=form).count() + 1
             description = _("Version {number}").format(number=version_number)

--- a/src/openforms/forms/templates/admin/forms/form/export.html
+++ b/src/openforms/forms/templates/admin/forms/form/export.html
@@ -2,6 +2,7 @@
 {% load static i18n django_admin_index %}
 
 {% block extrastyle %}{{ block.super }}
+<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
 <link rel="stylesheet" href="{% static "admin/css/admin-index.css" %}">
 {% endblock %}
 
@@ -20,25 +21,55 @@
 {% block content %}
     <h1>{% trans 'Export forms' %}</h1>
     <div id="content-main">
-        <div>
-            {% blocktranslate %}
-            Once your request has been processed, you will be sent an email (at the address configured in your admin
-            profile) containing a link where you can download a zip file with all the exported forms.
-            {% endblocktranslate %}
-            <br/><br/>
-        </div>
         <form action="{% url 'admin:forms_export' %}" method="post">
+            {% csrf_token %}
+
+            {% for hidden in form.hidden_fields %}
+                {{ hidden }}
+            {% endfor %}
+
             <div>
                 <fieldset class="module aligned">
-                    {% csrf_token %}
+                    <div class="description">
+                        {% blocktrans trimmed %}
+                            <p>
+                                Here you can control how the previously selected forms will be
+                                exported. Using these options, sensitive information can be
+                                anonymized, certain form configuration can be left out, and
+                                additional information can be included.
+                            </p>
+                            <p>
+                                These export options will be used for each form that will be exported.
+                            </p>
+                            <p>
+                                After you've clicked the "Export" button, the forms will be
+                                exported in the background. <br/>
+                                Once your request has been processed, you will be sent an email
+                                (at the address configured in your admin profile) containing a link
+                                where you can download a zip file with all the exported forms.
+                            </p>
+                        {% endblocktrans %}
+                    </div>
 
-                    {% for hidden in form.hidden_fields %}
-                        {{ hidden }}
+                    {% for field in form.visible_fields %}
+                        <div class="form-row {% if field.errors %} errors{% endif %}">
+                            {{ field.errors }}
+                            <div class="flex-container {% if field.field.widget.input_type == 'checkbox' and field|length == 1 %}checkbox-row{% endif %} {% if field.errors %}errors{% endif %}">
+                                {{ field.label_tag }}
+                                {{ field }}
+                            </div>
+
+                            {% if field.help_text %}
+                                <div class="help" {% if field.id_for_label %} id="{{ field.id_for_label }}_helptext"{% endif %}>
+                                    <div>{{ field.help_text|safe }}</div>
+                                </div>
+                            {% endif %}
+                        </div>
                     {% endfor %}
                 </fieldset>
 
                 <div class="submit-row">
-                    <input type="submit" value="{% trans 'Export' %}">
+                    <input type="submit" class="default" value="{% trans 'Export' %}">
                 </div>
             </div>
         </form>

--- a/src/openforms/forms/tests/admin/test_form.py
+++ b/src/openforms/forms/tests/admin/test_form.py
@@ -17,11 +17,11 @@ from openforms.accounts.tests.factories import SuperUserFactory, UserFactory
 from openforms.authentication.contrib.digid.constants import DIGID_DEFAULT_LOA
 from openforms.config.models import GlobalConfiguration, RichTextColor
 from openforms.emails.tests.factories import ConfirmationEmailTemplateFactory
+from openforms.forms.import_export.constants import EXPORT_META_KEY
 from openforms.forms.tests.factories import FormLogicFactory
 from openforms.utils.admin import SubmitActions
 
 from ...admin.form import FormAdmin
-from ...constants import EXPORT_META_KEY
 from ...models import Form, FormDefinition, FormStep, FormVariable
 from ...tests.factories import FormDefinitionFactory, FormFactory, FormStepFactory
 from .mixins import FormListAjaxMixin

--- a/src/openforms/forms/tests/admin/test_form.py
+++ b/src/openforms/forms/tests/admin/test_form.py
@@ -14,11 +14,32 @@ from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 
 from openforms.accounts.tests.factories import SuperUserFactory, UserFactory
+from openforms.authentication.constants import AuthAttribute
 from openforms.authentication.contrib.digid.constants import DIGID_DEFAULT_LOA
+from openforms.authentication.tests.factories import AttributeGroupFactory
 from openforms.config.models import GlobalConfiguration, RichTextColor
+from openforms.config.tests.factories import (
+    MapTileLayerFactory,
+    MapWMSTileLayerFactory,
+    ThemeFactory,
+)
+from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
 from openforms.emails.tests.factories import ConfirmationEmailTemplateFactory
 from openforms.forms.import_export.constants import EXPORT_META_KEY
-from openforms.forms.tests.factories import FormLogicFactory
+from openforms.forms.import_export.typing import (
+    AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
+)
+from openforms.forms.tests.factories import (
+    CategoryFactory,
+    FormLogicFactory,
+    FormVariableFactory,
+)
+from openforms.payments.contrib.worldline.tests.factories import (
+    WorldlineMerchantFactory,
+)
+from openforms.prefill.constants import IdentifierRoles
+from openforms.products.tests.factories import ProductFactory
 from openforms.utils.admin import SubmitActions
 
 from ...admin.form import FormAdmin
@@ -83,6 +104,725 @@ class FormAdminImportExportTests(WebTest):
 
         form_steps = json.loads(zf.read("formSteps.json"))
         self.assertEqual(len(form_steps), 0)
+
+    def test_form_admin_export_remove_all_sensitive_data(self):
+        self.client.force_login(self.user)
+
+        form = FormFactory.create(
+            internal_remarks="Some internal remark that should be removed",
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["submission@company.com"],
+                "to_emails_from_variable": "variable_with_sensitive_data",
+                "payment_emails": ["payment@company.com"],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            user_defined=True,
+            key="variable_with_sensitive_data",
+            initial_value="personal@company.com",
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "variable_with_sensitive_data",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        admin_url = reverse("admin:forms_form_change", args=(form.pk,))
+
+        response = self.client.post(
+            admin_url,
+            data={
+                "_export": "Export",
+                "export_options": json.dumps(
+                    {
+                        "remove_sensitive_content": True,
+                        "form_configuration": [
+                            FormConfigurationOptions.registration_backends,
+                        ],
+                    }
+                ),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "application/zip")
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        form_logic = json.loads(zf.read("formLogic.json"))
+        form_variables = json.loads(zf.read("formVariables.json"))
+
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(len(form_logic), 1)
+        self.assertEqual(len(form_variables), 2)
+
+        # Internal remarks should be removed
+        self.assertEqual(forms[0]["internal_remarks"], "")
+
+        # E-mail addresses assigned in the registration backend should be cleared
+        # The variable assigned in the registration backend should be kept
+        self.assertEqual(len(forms[0]["registration_backends"]), 1)
+        registration_backend = forms[0]["registration_backends"][0]
+
+        self.assertEqual(registration_backend["options"]["to_emails"], [])
+        self.assertEqual(
+            registration_backend["options"]["to_emails_from_variable"],
+            "variable_with_sensitive_data",
+        )
+        self.assertEqual(
+            registration_backend["options"]["payment_emails"],
+            [],
+        )
+
+        # The initial data of the user-defined variable used by the e-mail
+        # registration backend should be cleared
+        sensitive_variable = next(
+            variable
+            for variable in form_variables
+            if variable["key"] == "variable_with_sensitive_data"
+        )
+        self.assertEqual(sensitive_variable["initial_value"], "")
+
+        # The logic rule that assigns the value of the sensitive user-defined
+        # variable is cleared
+        self.assertEqual(len(form_logic[0]["actions"]), 1)
+        self.assertEqual(
+            form_logic[0]["actions"][0]["variable"], "variable_with_sensitive_data"
+        )
+        self.assertEqual(
+            form_logic[0]["actions"][0]["action"],
+            {"type": "variable", "value": ""},
+        )
+
+    def test_form_admin_export_keep_all_sensitive_data(self):
+        self.client.force_login(self.user)
+
+        form = FormFactory.create(
+            internal_remarks="Some internal remark that should be kept",
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["submission@company.com"],
+                "to_emails_from_variable": "variable_with_sensitive_data",
+                "payment_emails": ["payment@company.com"],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            user_defined=True,
+            key="variable_with_sensitive_data",
+            initial_value="personal@company.com",
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "variable_with_sensitive_data",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        admin_url = reverse("admin:forms_form_change", args=(form.pk,))
+
+        response = self.client.post(
+            admin_url,
+            data={
+                "_export": "Export",
+                "export_options": json.dumps(
+                    {
+                        "remove_sensitive_content": False,
+                        "form_configuration": [
+                            FormConfigurationOptions.registration_backends,
+                        ],
+                    }
+                ),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "application/zip")
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        form_logic = json.loads(zf.read("formLogic.json"))
+        form_variables = json.loads(zf.read("formVariables.json"))
+
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(len(form_logic), 1)
+        self.assertEqual(len(form_variables), 2)
+
+        # Internal remarks should be left untouched
+        self.assertEqual(
+            forms[0]["internal_remarks"], "Some internal remark that should be kept"
+        )
+
+        # E-mail addresses and variable assigned in the registration backend should be
+        # kept.
+        self.assertEqual(len(forms[0]["registration_backends"]), 1)
+        registration_backend = forms[0]["registration_backends"][0]
+
+        self.assertEqual(
+            registration_backend["options"]["to_emails"], ["submission@company.com"]
+        )
+        self.assertEqual(
+            registration_backend["options"]["to_emails_from_variable"],
+            "variable_with_sensitive_data",
+        )
+        self.assertEqual(
+            registration_backend["options"]["payment_emails"],
+            ["payment@company.com"],
+        )
+
+        # The initial data of the user-defined variable used by the e-mail
+        # registration backend should be kept
+        sensitive_variable = next(
+            variable
+            for variable in form_variables
+            if variable["key"] == "variable_with_sensitive_data"
+        )
+        self.assertEqual(sensitive_variable["initial_value"], "personal@company.com")
+
+        # The logic rule that assigns the value of the sensitive user-defined
+        # variable is kept
+        self.assertEqual(len(form_logic[0]["actions"]), 1)
+        self.assertEqual(
+            form_logic[0]["actions"][0]["variable"], "variable_with_sensitive_data"
+        )
+        self.assertEqual(
+            form_logic[0]["actions"][0]["action"],
+            {"type": "variable", "value": "internal@company.com"},
+        )
+
+    def test_form_admin_export_include_all_form_configuration(self):
+        self.client.force_login(self.user)
+
+        product = ProductFactory.create()
+        merchant = WorldlineMerchantFactory.create()
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            identifier="test-objects-api-group"
+        )
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            authentication_backend="digid",
+            payment_backend="worldline",
+            payment_backend_options={"merchant": merchant.pspid},
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["abc@xyz.com"],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "prefill": {
+                            "plugin": "demo",
+                            "attribute": "random_number",
+                            "identifier_role": IdentifierRoles.authorizee,
+                        },
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_demo_prefill",
+            user_defined=True,
+            prefill_plugin="demo",
+            prefill_attribute="random_string",
+            prefill_identifier_role=IdentifierRoles.authorizee,
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_objects_api_prefill",
+            user_defined=True,
+            prefill_plugin="objects_api",
+            prefill_options={
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        admin_url = reverse("admin:forms_form_change", args=(form.pk,))
+
+        response = self.client.post(
+            admin_url,
+            data={
+                "_export": "Export",
+                "export_options": json.dumps(
+                    {
+                        # Keep sensitive data to keep the email registration config complete
+                        "remove_sensitive_content": False,
+                        "form_configuration": [
+                            FormConfigurationOptions.registration_backends,
+                            FormConfigurationOptions.prefill,
+                            FormConfigurationOptions.payment_backend,
+                        ],
+                    }
+                ),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "application/zip")
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        self.assertEqual(len(forms), 1)
+
+        # Registration backend should be in exportdata
+        self.assertEqual(len(forms[0]["registration_backends"]), 1)
+        registration_backend = forms[0]["registration_backends"][0]
+        self.assertEqual(registration_backend["backend"], "email")
+        self.assertEqual(registration_backend["options"]["to_emails"], ["abc@xyz.com"])
+
+        # Payment backend should be in exportdata
+        self.assertEqual(forms[0]["payment_backend"], "worldline")
+        self.assertEqual(
+            forms[0]["payment_backend_options"], {"merchant": merchant.pspid}
+        )
+
+        form_variables = json.loads(zf.read("formVariables.json"))
+        form_definitions = json.loads(zf.read("formDefinitions.json"))
+
+        self.assertEqual(len(form_variables), 2)
+        self.assertEqual(len(form_definitions), 1)
+
+        # Both variables should have their prefill data
+        self.assertEqual(form_variables[0]["prefill_plugin"], "demo")
+        self.assertEqual(form_variables[0]["prefill_attribute"], "random_string")
+        self.assertEqual(form_variables[0]["prefill_identifier_role"], "authorizee")
+
+        self.assertEqual(form_variables[1]["prefill_plugin"], "objects_api")
+        self.assertEqual(
+            form_variables[1]["prefill_options"],
+            {
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        # The component prefill data should be kept
+        self.assertEqual(len(form_definitions[0]["configuration"]["components"]), 1)
+        component_definition = form_definitions[0]["configuration"]["components"][0]
+        self.assertEqual(component_definition["prefill"]["plugin"], "demo")
+        self.assertEqual(component_definition["prefill"]["attribute"], "random_number")
+        self.assertEqual(
+            component_definition["prefill"]["identifier_role"], "authorizee"
+        )
+
+    def test_form_admin_export_exclude_all_form_configuration(self):
+        self.client.force_login(self.user)
+
+        product = ProductFactory.create()
+        merchant = WorldlineMerchantFactory.create()
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            identifier="test-objects-api-group"
+        )
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            authentication_backend="digid",
+            payment_backend="worldline",
+            payment_backend_options={"merchant": merchant.pspid},
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["abc@xyz.com"],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "prefill": {
+                            "plugin": "demo",
+                            "attribute": "random_number",
+                            "identifier_role": "authorised_person",
+                        },
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_demo_prefill",
+            user_defined=True,
+            prefill_plugin="demo",
+            prefill_attribute="random_string",
+            prefill_identifier_role="authorised_person",
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_objects_api_prefill",
+            user_defined=True,
+            prefill_plugin="objects_api",
+            prefill_options={
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        admin_url = reverse("admin:forms_form_change", args=(form.pk,))
+
+        response = self.client.post(
+            admin_url,
+            data={
+                "_export": "Export",
+                "export_options": json.dumps(
+                    {
+                        "form_configuration": [],
+                    }
+                ),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "application/zip")
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        self.assertEqual(len(forms), 1)
+
+        # Registration backend should not be in exportdata
+        self.assertEqual(forms[0]["registration_backends"], [])
+
+        # Payment backend should not be in exportdata
+        self.assertEqual(forms[0]["payment_backend"], "")
+        self.assertEqual(forms[0]["payment_backend_options"], {})
+
+        form_variables = json.loads(zf.read("formVariables.json"))
+        form_definitions = json.loads(zf.read("formDefinitions.json"))
+
+        self.assertEqual(len(form_variables), 2)
+        self.assertEqual(len(form_definitions), 1)
+
+        # Both variables should have empty prefill data
+        self.assertEqual(form_variables[0]["prefill_plugin"], "")
+        self.assertEqual(form_variables[0]["prefill_attribute"], "")
+        self.assertEqual(form_variables[0]["prefill_identifier_role"], "main")
+        self.assertEqual(form_variables[0]["prefill_options"], {})
+
+        self.assertEqual(form_variables[1]["prefill_plugin"], "")
+        self.assertEqual(form_variables[1]["prefill_attribute"], "")
+        self.assertEqual(form_variables[1]["prefill_identifier_role"], "main")
+        self.assertEqual(form_variables[1]["prefill_options"], {})
+
+        # The component prefill data should be cleared
+        self.assertEqual(len(form_definitions[0]["configuration"]["components"]), 1)
+        component_definition = form_definitions[0]["configuration"]["components"][0]
+        self.assertEqual(component_definition["prefill"]["plugin"], "")
+        self.assertEqual(component_definition["prefill"]["attribute"], "")
+        self.assertEqual(component_definition["prefill"]["identifier_role"], "main")
+
+    def test_form_admin_export_including_all_additional_form_configuration(self):
+        self.client.force_login(self.user)
+
+        product = ProductFactory.create()
+        theme = ThemeFactory.create()
+        category = CategoryFactory.create()
+
+        wmts_tile_layer = MapTileLayerFactory.create()
+        wms_tile_layer = MapWMSTileLayerFactory.create()
+
+        yivi_attribute_group = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+
+        # Define form with all additional form configuration
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            theme=theme,
+            category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [yivi_attribute_group.uuid],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmts_tile_layer.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wms_tile_layer.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        admin_url = reverse("admin:forms_form_change", args=(form.pk,))
+
+        response = self.client.post(
+            admin_url,
+            data={
+                "_export": "Export",
+                "export_options": json.dumps(
+                    {
+                        "additional_form_configuration": [
+                            AdditionalFormConfigurationOptions.product,
+                            AdditionalFormConfigurationOptions.wms_tile_layers,
+                            AdditionalFormConfigurationOptions.wmts_tile_layers,
+                            AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                        ]
+                    }
+                ),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "application/zip")
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                "product.json",
+                "wmsTileLayers.json",
+                "wmtsTileLayers.json",
+                "yiviAttributeGroups.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        exported_product = json.loads(zf.read("product.json"))
+        self.assertEqual(len(exported_product), 1)
+        self.assertEqual(
+            exported_product,
+            [
+                {
+                    "uuid": str(product.uuid),
+                    "name": product.name,
+                    "price": str(product.price).replace(".", ","),
+                    "information": product.information,
+                }
+            ],
+        )
+
+        exported_wms_tile_layers = json.loads(zf.read("wmsTileLayers.json"))
+        self.assertEqual(len(exported_wms_tile_layers), 1)
+        self.assertEqual(
+            exported_wms_tile_layers,
+            [
+                {
+                    "uuid": str(wms_tile_layer.uuid),
+                    "name": wms_tile_layer.name,
+                    "url": wms_tile_layer.url,
+                },
+            ],
+        )
+
+        exported_wmts_tile_layers = json.loads(zf.read("wmtsTileLayers.json"))
+        self.assertEqual(len(exported_wmts_tile_layers), 1)
+        self.assertEqual(
+            exported_wmts_tile_layers,
+            [
+                {
+                    "identifier": wmts_tile_layer.identifier,
+                    "label": wmts_tile_layer.label,
+                    "url": wmts_tile_layer.url,
+                },
+            ],
+        )
+
+        exported_yivi_attribute_groups = json.loads(zf.read("yiviAttributeGroups.json"))
+        self.assertEqual(len(exported_yivi_attribute_groups), 1)
+        self.assertEqual(
+            exported_yivi_attribute_groups,
+            [
+                {
+                    "uuid": str(yivi_attribute_group.uuid),
+                    "name": yivi_attribute_group.name,
+                    "description": yivi_attribute_group.description,
+                    "attributes": ",".join(yivi_attribute_group.attributes),
+                },
+            ],
+        )
+
+    def test_form_admin_export_excluding_all_additional_form_configuration(self):
+        self.client.force_login(self.user)
+
+        product = ProductFactory.create()
+        theme = ThemeFactory.create(design_token_values={"key": "token"})
+        category = CategoryFactory.create()
+
+        wmts_tile_layer = MapTileLayerFactory.create()
+        wms_tile_layer = MapWMSTileLayerFactory.create()
+
+        yivi_attribute_group = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+
+        # Define form with all additional form configuration
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            theme=theme,
+            category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [yivi_attribute_group.uuid],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmts_tile_layer.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wms_tile_layer.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        admin_url = reverse("admin:forms_form_change", args=(form.pk,))
+
+        response = self.client.post(
+            admin_url,
+            data={
+                "_export": "Export",
+                "export_options": json.dumps({"additional_form_configuration": []}),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "application/zip")
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        exported_forms = json.loads(zf.read("forms.json"))
+        self.assertEqual(len(exported_forms), 1)
+
+        # The product reference on the form is removed, theme and category are kept
+        self.assertIsNone(exported_forms[0]["product"])
+        self.assertIsNotNone(exported_forms[0]["theme"])
+        self.assertIsNotNone(exported_forms[0]["category"])
 
     @override_settings(LANGUAGE_CODE="en")
     def test_form_admin_import_button(self):

--- a/src/openforms/forms/tests/admin/test_form.py
+++ b/src/openforms/forms/tests/admin/test_form.py
@@ -177,7 +177,7 @@ class FormAdminImportExportTests(WebTest):
         self.assertEqual(len(form_variables), 2)
 
         # Internal remarks should be removed
-        self.assertEqual(forms[0]["internal_remarks"], "")
+        self.assertIsNone(forms[0].get("internal_remarks"))
 
         # E-mail addresses assigned in the registration backend should be cleared
         # The variable assigned in the registration backend should be kept

--- a/src/openforms/forms/tests/admin/test_tasks.py
+++ b/src/openforms/forms/tests/admin/test_tasks.py
@@ -31,6 +31,7 @@ class ExportFormsTaskTests(TestCase):
         process_forms_export(
             forms_uuids=[form1.uuid, form2.uuid],
             user_id=user.id,
+            export_options={},
         )
 
         # Test that the forms export model was created with the right data
@@ -81,6 +82,7 @@ class ImportFormsTaskTests(TestCase):
         process_forms_export(
             forms_uuids=[form1.uuid, form2.uuid],
             user_id=user.id,
+            export_options={},
         )
 
         cls.form_export = FormsExport.objects.get()

--- a/src/openforms/forms/tests/admin/test_views.py
+++ b/src/openforms/forms/tests/admin/test_views.py
@@ -225,6 +225,7 @@ class TestImportView(WebTest):
         process_forms_export(
             forms_uuids=[form1.uuid, form2.uuid],
             user_id=user.id,
+            export_options={},
         )
 
         form_export = FormsExport.objects.get()

--- a/src/openforms/forms/tests/admin/test_views.py
+++ b/src/openforms/forms/tests/admin/test_views.py
@@ -91,7 +91,20 @@ class TestExportFormsView(WebTest):
         self.assertRedirects(
             submission_response, reverse("admin:forms_form_changelist")
         )
-        m.assert_called_with(forms_uuids=[form.uuid], user_id=user.id)
+        m.assert_called_with(
+            forms_uuids=[form.uuid],
+            user_id=user.id,
+            export_options={
+                "remove_sensitive_content": True,
+                "form_configuration": [
+                    "registrationBackends",
+                    "prefill",
+                    "paymentBackend",
+                    "authBackends",
+                ],
+                "additional_form_configuration": [],
+            },
+        )
 
         submission_response = submission_response.follow()
         messages = list(submission_response.context.get("messages"))

--- a/src/openforms/forms/tests/factories.py
+++ b/src/openforms/forms/tests/factories.py
@@ -4,13 +4,13 @@ import factory.fuzzy
 
 from openforms.authentication.registry import register as authentication_registry
 from openforms.forms.constants import LogicActionTypes
+from openforms.forms.import_export.export_form import form_to_json
 from openforms.products.tests.factories import ProductFactory
 from openforms.registrations.registry import register as registration_registry
 from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 
 from ..constants import FormTypeChoices, SubmissionAllowedChoices
 from ..models import Form, FormDefinition, FormStep, FormVariable
-from ..utils import form_to_json
 
 
 def authentication_plugins():

--- a/src/openforms/forms/tests/factories.py
+++ b/src/openforms/forms/tests/factories.py
@@ -3,14 +3,21 @@ import random
 import factory.fuzzy
 
 from openforms.authentication.registry import register as authentication_registry
-from openforms.forms.constants import LogicActionTypes
+from openforms.forms.constants import (
+    FormTypeChoices,
+    LogicActionTypes,
+    SubmissionAllowedChoices,
+)
 from openforms.forms.import_export.export_form import form_to_json
+from openforms.forms.import_export.typing import (
+    AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
+    FormExportOptions,
+)
+from openforms.forms.models import Form, FormDefinition, FormStep, FormVariable
 from openforms.products.tests.factories import ProductFactory
 from openforms.registrations.registry import register as registration_registry
 from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
-
-from ..constants import FormTypeChoices, SubmissionAllowedChoices
-from ..models import Form, FormDefinition, FormStep, FormVariable
 
 
 def authentication_plugins():
@@ -249,7 +256,24 @@ class FormVersionFactory(factory.django.DjangoModelFactory):
 
     @factory.post_generation
     def post(obj, create, extracted, **kwargs):
-        json_form = form_to_json(obj.form.id)
+        json_form = form_to_json(
+            obj.form.id,
+            export_options=FormExportOptions(
+                form_configuration=[
+                    FormConfigurationOptions.registration_backends,
+                    FormConfigurationOptions.prefill,
+                    FormConfigurationOptions.payment_backend,
+                    FormConfigurationOptions.auth_backends,
+                ],
+                additional_form_configuration=[
+                    AdditionalFormConfigurationOptions.product,
+                    AdditionalFormConfigurationOptions.wms_tile_layers,
+                    AdditionalFormConfigurationOptions.wmts_tile_layers,
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                ],
+                remove_sensitive_content=False,
+            ),
+        )
         obj.export_blob = json_form
         obj.save()
 

--- a/src/openforms/forms/tests/import_export/test_resources.py
+++ b/src/openforms/forms/tests/import_export/test_resources.py
@@ -1,0 +1,269 @@
+from django.test import TestCase
+
+from openforms.authentication.tests.factories import AttributeGroupFactory
+from openforms.config.tests.factories import (
+    MapTileLayerFactory,
+    MapWMSTileLayerFactory,
+)
+from openforms.forms.import_export.resources import (
+    ProductResource,
+    WMSTileLayerResource,
+    WMTSTileLayerResource,
+    YiviAttributeGroupResource,
+)
+from openforms.forms.tests.factories import FormFactory
+from openforms.products.tests.factories import ProductFactory
+
+
+class ProductResourceTests(TestCase):
+    def test_export_for_form(self):
+        product = ProductFactory.create()
+        form = FormFactory.create(product=product)
+
+        dataset = ProductResource().export_for_form(form).dict
+
+        self.assertEqual(len(dataset), 1)
+        self.assertEqual(dataset[0]["uuid"], str(product.uuid))
+        self.assertEqual(dataset[0]["name"], product.name)
+        self.assertEqual(
+            dataset[0]["price"],
+            str(product.price).replace(".", ","),
+        )
+        self.assertEqual(dataset[0]["information"], product.information)
+
+    def test_export_for_form_without_product(self):
+        form = FormFactory.create(product=None)
+
+        dataset = ProductResource().export_for_form(form).dict
+
+        self.assertEqual(len(dataset), 0)
+
+
+class WMSTileLayerResourceTests(TestCase):
+    def test_export_for_form(self):
+        wms_tile_layer1 = MapWMSTileLayerFactory.create()
+        wms_tile_layer2 = MapWMSTileLayerFactory.create()
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wms_tile_layer1.uuid),
+                                "label": "Overlay 1",
+                                "layers": ["layer1"],
+                            },
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wms_tile_layer2.uuid),
+                                "label": "Overlay 2",
+                                "layers": ["layer2"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        dataset = WMSTileLayerResource().export_for_form(form).dict
+
+        self.assertEqual(len(dataset), 2)
+
+        self.assertEqual(dataset[0]["uuid"], str(wms_tile_layer1.uuid))
+        self.assertEqual(dataset[0]["name"], wms_tile_layer1.name)
+        self.assertEqual(dataset[0]["url"], wms_tile_layer1.url)
+
+        self.assertEqual(dataset[1]["uuid"], str(wms_tile_layer2.uuid))
+        self.assertEqual(dataset[1]["name"], wms_tile_layer2.name)
+        self.assertEqual(dataset[1]["url"], wms_tile_layer2.url)
+
+    def test_export_for_form_with_broken_overlay(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "overlays": [
+                            # This is some weird configuration without the UUID, but
+                            # technically valid.
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": "",
+                                "label": "Overlay 1",
+                                "layers": ["layer1"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        dataset = WMSTileLayerResource().export_for_form(form).dict
+
+        self.assertEqual(len(dataset), 0)
+
+    def test_export_for_form_without_overlays(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                    },
+                ],
+            },
+        )
+
+        dataset = WMSTileLayerResource().export_for_form(form).dict
+
+        self.assertEqual(len(dataset), 0)
+
+
+class WMTSTileLayerResourceTests(TestCase):
+    def test_export_for_form(self):
+        wmts_tile_layer = MapTileLayerFactory.create()
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmts_tile_layer.identifier,
+                    },
+                ],
+            },
+        )
+
+        dataset = WMTSTileLayerResource().export_for_form(form).dict
+
+        self.assertEqual(len(dataset), 1)
+
+        self.assertEqual(dataset[0]["identifier"], wmts_tile_layer.identifier)
+        self.assertEqual(dataset[0]["label"], wmts_tile_layer.label)
+        self.assertEqual(dataset[0]["url"], wmts_tile_layer.url)
+
+    def test_export_for_form_with_empty_tile_layer_identifier(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": "",
+                    },
+                ],
+            },
+        )
+
+        dataset = WMTSTileLayerResource().export_for_form(form).dict
+
+        self.assertEqual(len(dataset), 0)
+
+    def test_export_for_form_without_tile_layer_identifier(self):
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                    },
+                ],
+            },
+        )
+
+        dataset = WMTSTileLayerResource().export_for_form(form).dict
+
+        self.assertEqual(len(dataset), 0)
+
+
+class YiviAttributeGroupResourceTests(TestCase):
+    def test_export_for_form(self):
+        yivi_attribute_group = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+        form = FormFactory.create(
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "additional_attributes_groups": [yivi_attribute_group.uuid],
+            },
+        )
+
+        dataset = YiviAttributeGroupResource().export_for_form(form).dict
+
+        self.assertEqual(len(dataset), 1)
+
+        self.assertEqual(dataset[0]["uuid"], str(yivi_attribute_group.uuid))
+        self.assertEqual(dataset[0]["name"], yivi_attribute_group.name)
+        self.assertEqual(dataset[0]["description"], yivi_attribute_group.description)
+        self.assertEqual(
+            dataset[0]["attributes"], ",".join(yivi_attribute_group.attributes)
+        )
+
+    def test_export_for_form_without_resource(self):
+        form = FormFactory.create(authentication_backend="yivi_oidc")
+
+        dataset = YiviAttributeGroupResource().export_for_form(form).dict
+
+        self.assertEqual(len(dataset), 0)
+
+    def test_export_for_form_without_yivi_auth_backend(self):
+        form = FormFactory.create(authentication_backend="demo")
+
+        dataset = YiviAttributeGroupResource().export_for_form(form).dict
+
+        self.assertEqual(len(dataset), 0)

--- a/src/openforms/forms/tests/test_api_import_export.py
+++ b/src/openforms/forms/tests/test_api_import_export.py
@@ -13,10 +13,11 @@ from rest_framework.test import APITestCase
 
 from openforms.accounts.tests.factories import TokenFactory, UserFactory
 from openforms.appointments.models import AppointmentsConfig
+from openforms.forms.import_export.constants import EXPORT_META_KEY
 from openforms.variables.constants import FormVariableSources
 
 from ...emails.tests.factories import ConfirmationEmailTemplateFactory
-from ..constants import EXPORT_META_KEY, FormTypeChoices
+from ..constants import FormTypeChoices
 from ..models import Form, FormDefinition, FormStep
 from .factories import (
     FormDefinitionFactory,

--- a/src/openforms/forms/tests/test_api_import_export.py
+++ b/src/openforms/forms/tests/test_api_import_export.py
@@ -13,15 +13,34 @@ from rest_framework.test import APITestCase
 
 from openforms.accounts.tests.factories import TokenFactory, UserFactory
 from openforms.appointments.models import AppointmentsConfig
+from openforms.authentication.constants import AuthAttribute
+from openforms.authentication.tests.factories import AttributeGroupFactory
+from openforms.config.tests.factories import (
+    MapTileLayerFactory,
+    MapWMSTileLayerFactory,
+    ThemeFactory,
+)
+from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
 from openforms.forms.import_export.constants import EXPORT_META_KEY
+from openforms.forms.import_export.typing import (
+    AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
+)
+from openforms.payments.contrib.worldline.tests.factories import (
+    WorldlineMerchantFactory,
+)
+from openforms.prefill.constants import IdentifierRoles
+from openforms.products.tests.factories import ProductFactory
 from openforms.variables.constants import FormVariableSources
 
 from ...emails.tests.factories import ConfirmationEmailTemplateFactory
 from ..constants import FormTypeChoices
 from ..models import Form, FormDefinition, FormStep
 from .factories import (
+    CategoryFactory,
     FormDefinitionFactory,
     FormFactory,
+    FormLogicFactory,
     FormRegistrationBackendFactory,
     FormStepFactory,
     FormVariableFactory,
@@ -134,6 +153,744 @@ class ImportExportAPITests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_form_export_invalid_export_options(self):
+        self.user.user_permissions.add(Permission.objects.get(codename="change_form"))
+        self.user.is_staff = True
+        self.user.save()
+
+        form = FormFactory.create()
+
+        url = reverse("api:form-export", args=(form.uuid,))
+        response = self.client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            # Invalid value for the remove_sensitive_content option
+            data={"remove_sensitive_content": "whatever"},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_form_export_remove_all_sensitive_data(self):
+        self.user.user_permissions.add(Permission.objects.get(codename="change_form"))
+        self.user.is_staff = True
+        self.user.save()
+
+        form = FormFactory.create(
+            internal_remarks="Some internal remark that should be removed",
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["submission@company.com"],
+                "to_emails_from_variable": "variable_with_sensitive_data",
+                "payment_emails": ["payment@company.com"],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            user_defined=True,
+            key="variable_with_sensitive_data",
+            initial_value="personal@company.com",
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "variable_with_sensitive_data",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        url = reverse("api:form-export", args=(form.uuid,))
+        response = self.client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            data={
+                "remove_sensitive_content": True,
+                "form_configuration": [
+                    FormConfigurationOptions.registration_backends,
+                ],
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        form_logic = json.loads(zf.read("formLogic.json"))
+        form_variables = json.loads(zf.read("formVariables.json"))
+
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(len(form_logic), 1)
+        self.assertEqual(len(form_variables), 2)
+
+        # Internal remarks should be removed
+        self.assertIsNone(forms[0].get("internal_remarks"))
+
+        # E-mail addresses assigned in the registration backend should be cleared
+        # The variable assigned in the registration backend should be kept
+        self.assertEqual(len(forms[0]["registration_backends"]), 1)
+        registration_backend = forms[0]["registration_backends"][0]
+
+        self.assertEqual(registration_backend["options"]["to_emails"], [])
+        self.assertEqual(
+            registration_backend["options"]["to_emails_from_variable"],
+            "variable_with_sensitive_data",
+        )
+        self.assertEqual(
+            registration_backend["options"]["payment_emails"],
+            [],
+        )
+
+        # The initial data of the user-defined variable used by the e-mail
+        # registration backend should be cleared
+        sensitive_variable = next(
+            variable
+            for variable in form_variables
+            if variable["key"] == "variable_with_sensitive_data"
+        )
+        self.assertEqual(sensitive_variable["initial_value"], "")
+
+        # The logic rule that assigns the value of the sensitive user-defined
+        # variable is cleared
+        self.assertEqual(len(form_logic[0]["actions"]), 1)
+        self.assertEqual(
+            form_logic[0]["actions"][0]["variable"], "variable_with_sensitive_data"
+        )
+        self.assertEqual(
+            form_logic[0]["actions"][0]["action"],
+            {"type": "variable", "value": ""},
+        )
+
+    def test_form_export_keep_all_sensitive_data(self):
+        self.user.user_permissions.add(Permission.objects.get(codename="change_form"))
+        self.user.is_staff = True
+        self.user.save()
+
+        form = FormFactory.create(
+            internal_remarks="Some internal remark that should be kept",
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["submission@company.com"],
+                "to_emails_from_variable": "variable_with_sensitive_data",
+                "payment_emails": ["payment@company.com"],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            user_defined=True,
+            key="variable_with_sensitive_data",
+            initial_value="personal@company.com",
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "variable_with_sensitive_data",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        url = reverse("api:form-export", args=(form.uuid,))
+        response = self.client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            data={
+                "remove_sensitive_content": False,
+                "form_configuration": [
+                    FormConfigurationOptions.registration_backends,
+                ],
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        form_logic = json.loads(zf.read("formLogic.json"))
+        form_variables = json.loads(zf.read("formVariables.json"))
+
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(len(form_logic), 1)
+        self.assertEqual(len(form_variables), 2)
+
+        # Internal remarks should be left untouched
+        self.assertEqual(
+            forms[0]["internal_remarks"], "Some internal remark that should be kept"
+        )
+
+        # E-mail addresses and variable assigned in the registration backend should be
+        # kept.
+        self.assertEqual(len(forms[0]["registration_backends"]), 1)
+        registration_backend = forms[0]["registration_backends"][0]
+
+        self.assertEqual(
+            registration_backend["options"]["to_emails"], ["submission@company.com"]
+        )
+        self.assertEqual(
+            registration_backend["options"]["to_emails_from_variable"],
+            "variable_with_sensitive_data",
+        )
+        self.assertEqual(
+            registration_backend["options"]["payment_emails"],
+            ["payment@company.com"],
+        )
+
+        # The initial data of the user-defined variable used by the e-mail
+        # registration backend should be kept
+        sensitive_variable = next(
+            variable
+            for variable in form_variables
+            if variable["key"] == "variable_with_sensitive_data"
+        )
+        self.assertEqual(sensitive_variable["initial_value"], "personal@company.com")
+
+        # The logic rule that assigns the value of the sensitive user-defined
+        # variable is kept
+        self.assertEqual(len(form_logic[0]["actions"]), 1)
+        self.assertEqual(
+            form_logic[0]["actions"][0]["variable"], "variable_with_sensitive_data"
+        )
+        self.assertEqual(
+            form_logic[0]["actions"][0]["action"],
+            {"type": "variable", "value": "internal@company.com"},
+        )
+
+    def test_form_export_include_all_form_configuration(self):
+        self.user.user_permissions.add(Permission.objects.get(codename="change_form"))
+        self.user.is_staff = True
+        self.user.save()
+
+        product = ProductFactory.create()
+        merchant = WorldlineMerchantFactory.create()
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            identifier="test-objects-api-group"
+        )
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            authentication_backend="digid",
+            payment_backend="worldline",
+            payment_backend_options={"merchant": merchant.pspid},
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["abc@xyz.com"],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "prefill": {
+                            "plugin": "demo",
+                            "attribute": "random_number",
+                            "identifier_role": IdentifierRoles.authorizee,
+                        },
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_demo_prefill",
+            user_defined=True,
+            prefill_plugin="demo",
+            prefill_attribute="random_string",
+            prefill_identifier_role=IdentifierRoles.authorizee,
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_objects_api_prefill",
+            user_defined=True,
+            prefill_plugin="objects_api",
+            prefill_options={
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        url = reverse("api:form-export", args=(form.uuid,))
+        response = self.client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            data={
+                # Keep sensitive data to keep the email registration config complete
+                "remove_sensitive_content": False,
+                "form_configuration": [
+                    FormConfigurationOptions.registration_backends,
+                    FormConfigurationOptions.prefill,
+                    FormConfigurationOptions.payment_backend,
+                    FormConfigurationOptions.auth_backends,
+                ],
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        self.assertEqual(len(forms), 1)
+
+        # Registration backend should be in exportdata
+        self.assertEqual(len(forms[0]["registration_backends"]), 1)
+        registration_backend = forms[0]["registration_backends"][0]
+        self.assertEqual(registration_backend["backend"], "email")
+        self.assertEqual(registration_backend["options"]["to_emails"], ["abc@xyz.com"])
+
+        self.assertEqual(len(forms[0]["auth_backends"]), 1)
+        self.assertEqual(
+            forms[0]["auth_backends"][0],
+            {
+                "backend": "digid",
+                "options": {},
+            },
+        )
+
+        # Payment backend should be in exportdata
+        self.assertEqual(forms[0]["payment_backend"], "worldline")
+        self.assertEqual(
+            forms[0]["payment_backend_options"], {"merchant": merchant.pspid}
+        )
+
+        form_variables = json.loads(zf.read("formVariables.json"))
+        form_definitions = json.loads(zf.read("formDefinitions.json"))
+
+        self.assertEqual(len(form_variables), 2)
+        self.assertEqual(len(form_definitions), 1)
+
+        demo_variable = next(
+            var for var in form_variables if var["prefill_plugin"] == "demo"
+        )
+        objects_api_variable = next(
+            var for var in form_variables if var["prefill_plugin"] == "objects_api"
+        )
+
+        # Validate prefill data of the demo plugin variable
+        self.assertEqual(demo_variable["prefill_attribute"], "random_string")
+        self.assertEqual(demo_variable["prefill_identifier_role"], "authorizee")
+
+        # Validate prefill data of the objects_api plugin variable
+        self.assertEqual(objects_api_variable["prefill_plugin"], "objects_api")
+        self.assertEqual(
+            objects_api_variable["prefill_options"],
+            {
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        # The component prefill data should be kept
+        self.assertEqual(len(form_definitions[0]["configuration"]["components"]), 1)
+        component_definition = form_definitions[0]["configuration"]["components"][0]
+        self.assertEqual(component_definition["prefill"]["plugin"], "demo")
+        self.assertEqual(component_definition["prefill"]["attribute"], "random_number")
+        self.assertEqual(
+            component_definition["prefill"]["identifier_role"], "authorizee"
+        )
+
+    def test_form_export_exclude_all_form_configuration(self):
+        self.user.user_permissions.add(Permission.objects.get(codename="change_form"))
+        self.user.is_staff = True
+        self.user.save()
+
+        product = ProductFactory.create()
+        merchant = WorldlineMerchantFactory.create()
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            identifier="test-objects-api-group"
+        )
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            authentication_backend="digid",
+            payment_backend="worldline",
+            payment_backend_options={"merchant": merchant.pspid},
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["abc@xyz.com"],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "prefill": {
+                            "plugin": "demo",
+                            "attribute": "random_number",
+                            "identifier_role": "authorised_person",
+                        },
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_demo_prefill",
+            user_defined=True,
+            prefill_plugin="demo",
+            prefill_attribute="random_string",
+            prefill_identifier_role="authorised_person",
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_objects_api_prefill",
+            user_defined=True,
+            prefill_plugin="objects_api",
+            prefill_options={
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        url = reverse("api:form-export", args=(form.uuid,))
+        response = self.client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            data={
+                "form_configuration": [],
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        self.assertEqual(len(forms), 1)
+
+        # Registration backend should not be in exportdata
+        self.assertEqual(forms[0]["registration_backends"], [])
+
+        # Payment backend should not be in exportdata
+        self.assertEqual(forms[0]["payment_backend"], "")
+        self.assertEqual(forms[0]["payment_backend_options"], {})
+
+        form_variables = json.loads(zf.read("formVariables.json"))
+        form_definitions = json.loads(zf.read("formDefinitions.json"))
+
+        self.assertEqual(len(form_variables), 2)
+        self.assertEqual(len(form_definitions), 1)
+
+        # Both variables should have empty prefill data
+        self.assertEqual(form_variables[0]["prefill_plugin"], "")
+        self.assertEqual(form_variables[0]["prefill_attribute"], "")
+        self.assertEqual(form_variables[0]["prefill_identifier_role"], "main")
+        self.assertEqual(form_variables[0]["prefill_options"], {})
+
+        self.assertEqual(form_variables[1]["prefill_plugin"], "")
+        self.assertEqual(form_variables[1]["prefill_attribute"], "")
+        self.assertEqual(form_variables[1]["prefill_identifier_role"], "main")
+        self.assertEqual(form_variables[1]["prefill_options"], {})
+
+        # The component prefill data should be cleared
+        self.assertEqual(len(form_definitions[0]["configuration"]["components"]), 1)
+        component_definition = form_definitions[0]["configuration"]["components"][0]
+        self.assertEqual(component_definition["prefill"]["plugin"], "")
+        self.assertEqual(component_definition["prefill"]["attribute"], "")
+        self.assertEqual(component_definition["prefill"]["identifier_role"], "main")
+
+    def test_form_export_including_all_additional_form_configuration(self):
+        self.user.user_permissions.add(Permission.objects.get(codename="change_form"))
+        self.user.is_staff = True
+        self.user.save()
+
+        product = ProductFactory.create()
+        theme = ThemeFactory.create()
+        category = CategoryFactory.create()
+
+        wmts_tile_layer = MapTileLayerFactory.create()
+        wms_tile_layer = MapWMSTileLayerFactory.create()
+
+        yivi_attribute_group = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+
+        # Define form with all additional form configuration
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            theme=theme,
+            category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [yivi_attribute_group.uuid],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmts_tile_layer.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wms_tile_layer.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        url = reverse("api:form-export", args=(form.uuid,))
+        response = self.client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            data={
+                "additional_form_configuration": [
+                    AdditionalFormConfigurationOptions.product,
+                    AdditionalFormConfigurationOptions.wms_tile_layers,
+                    AdditionalFormConfigurationOptions.wmts_tile_layers,
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                ]
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                "product.json",
+                "wmsTileLayers.json",
+                "wmtsTileLayers.json",
+                "yiviAttributeGroups.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        exported_product = json.loads(zf.read("product.json"))
+        self.assertEqual(len(exported_product), 1)
+        self.assertEqual(
+            exported_product,
+            [
+                {
+                    "uuid": str(product.uuid),
+                    "name": product.name,
+                    "price": str(product.price).replace(".", ","),
+                    "information": product.information,
+                }
+            ],
+        )
+
+        exported_wms_tile_layers = json.loads(zf.read("wmsTileLayers.json"))
+        self.assertEqual(len(exported_wms_tile_layers), 1)
+        self.assertEqual(
+            exported_wms_tile_layers,
+            [
+                {
+                    "uuid": str(wms_tile_layer.uuid),
+                    "name": wms_tile_layer.name,
+                    "url": wms_tile_layer.url,
+                },
+            ],
+        )
+
+        exported_wmts_tile_layers = json.loads(zf.read("wmtsTileLayers.json"))
+        self.assertEqual(len(exported_wmts_tile_layers), 1)
+        self.assertEqual(
+            exported_wmts_tile_layers,
+            [
+                {
+                    "identifier": wmts_tile_layer.identifier,
+                    "label": wmts_tile_layer.label,
+                    "url": wmts_tile_layer.url,
+                },
+            ],
+        )
+
+        exported_yivi_attribute_groups = json.loads(zf.read("yiviAttributeGroups.json"))
+        self.assertEqual(len(exported_yivi_attribute_groups), 1)
+        self.assertEqual(
+            exported_yivi_attribute_groups,
+            [
+                {
+                    "uuid": str(yivi_attribute_group.uuid),
+                    "name": yivi_attribute_group.name,
+                    "description": yivi_attribute_group.description,
+                    "attributes": ",".join(yivi_attribute_group.attributes),
+                },
+            ],
+        )
+
+    def test_form_export_excluding_all_additional_form_configuration(self):
+        self.user.user_permissions.add(Permission.objects.get(codename="change_form"))
+        self.user.is_staff = True
+        self.user.save()
+
+        product = ProductFactory.create()
+        theme = ThemeFactory.create(design_token_values={"key": "token"})
+        category = CategoryFactory.create()
+
+        wmts_tile_layer = MapTileLayerFactory.create()
+        wms_tile_layer = MapWMSTileLayerFactory.create()
+
+        yivi_attribute_group = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+
+        # Define form with all additional form configuration
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            theme=theme,
+            category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [yivi_attribute_group.uuid],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmts_tile_layer.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wms_tile_layer.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        url = reverse("api:form-export", args=(form.uuid,))
+        response = self.client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            data={"additional_form_configuration": []},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        exported_forms = json.loads(zf.read("forms.json"))
+        self.assertEqual(len(exported_forms), 1)
+
+        # The product reference on the form is removed, theme and category are kept
+        self.assertIsNone(exported_forms[0]["product"])
+        self.assertIsNotNone(exported_forms[0]["theme"])
+        self.assertIsNotNone(exported_forms[0]["category"])
 
     def test_form_import(self):
         # export, delete, import roundtrip

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -20,6 +20,8 @@ from openforms.config.tests.factories import ThemeFactory
 from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
 from openforms.emails.models import ConfirmationEmailTemplate
 from openforms.emails.tests.factories import ConfirmationEmailTemplateFactory
+from openforms.forms.import_export.constants import EXPORT_META_KEY
+from openforms.forms.import_export.export_form import export_form, form_to_json
 from openforms.payments.contrib.worldline.tests.factories import (
     WorldlineMerchantFactory,
 )
@@ -57,7 +59,6 @@ from openforms.variables.constants import FormVariableDataTypes, FormVariableSou
 from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
 
 from ...authentication.tests.factories import AttributeGroupFactory
-from ..constants import EXPORT_META_KEY
 from ..disable_next_import_conversion import add_form_step_uuid_to_disable_next_actions
 from ..models import (
     Form,
@@ -68,7 +69,7 @@ from ..models import (
     FormStep,
     FormVariable,
 )
-from ..utils import export_form, form_to_json, import_form
+from ..utils import import_form
 from .factories import (
     CategoryFactory,
     FormDefinitionFactory,

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -408,7 +408,7 @@ class ImportExportTests(TempdirMixin, TestCase):
             self.assertEqual(len(form_variables), 2)
 
             # Internal remarks should be removed
-            self.assertEqual(forms[0]["internal_remarks"], "")
+            self.assertIsNone(forms[0].get("internal_remarks"))
 
             # E-mail addresses assigned in the registration backend should be cleared
             # The variable assigned in the registration backend should be kept

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -141,7 +141,9 @@ class ImportExportTests(TempdirMixin, TestCase):
             form=form, source=FormVariableSources.user_defined, key="test-user-defined"
         )
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk, archive_name=self.filepath, export_options=FormExportOptions()
+        )
 
         with zipfile.ZipFile(self.filepath, "r") as f:
             self.assertEqual(
@@ -228,7 +230,9 @@ class ImportExportTests(TempdirMixin, TestCase):
         )
         FormStepFactory.create(form=form, form_definition=form_definition)
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk, archive_name=self.filepath, export_options=FormExportOptions()
+        )
 
         with zipfile.ZipFile(self.filepath, "r") as f:
             self.assertEqual(
@@ -1325,7 +1329,9 @@ class ImportExportTests(TempdirMixin, TestCase):
         form_definition = FormDefinitionFactory.create()
         FormStepFactory.create(form=form, form_definition=form_definition)
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk, archive_name=self.filepath, export_options=FormExportOptions()
+        )
 
         form_definition.slug = "modified"
         form_definition.save()
@@ -1352,7 +1358,9 @@ class ImportExportTests(TempdirMixin, TestCase):
         FormStepFactory.create(form=form, form_definition=form_definition)
         FormLogicFactory.create(form=form)
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk, archive_name=self.filepath, export_options=FormExportOptions()
+        )
 
         import_form(import_file=self.filepath)
 
@@ -1392,7 +1400,9 @@ class ImportExportTests(TempdirMixin, TestCase):
             form_logic.pk,
         )
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk, archive_name=self.filepath, export_options=FormExportOptions()
+        )
 
         old_form_slug = form.slug
         form.slug = "modified"
@@ -1479,7 +1489,9 @@ class ImportExportTests(TempdirMixin, TestCase):
             form_logic.pk,
         )
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk, archive_name=self.filepath, export_options=FormExportOptions()
+        )
 
         old_form_slug = form.slug
         form.slug = "modified"
@@ -1563,7 +1575,9 @@ class ImportExportTests(TempdirMixin, TestCase):
         )
         FormStepFactory.create(form=form, form_definition=form_definition)
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk, archive_name=self.filepath, export_options=FormExportOptions()
+        )
 
         import_form(import_file=self.filepath)
 
@@ -1592,7 +1606,9 @@ class ImportExportTests(TempdirMixin, TestCase):
         """
         category = CategoryFactory.create()
         form = FormFactory.create(category=category)
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk, archive_name=self.filepath, export_options=FormExportOptions()
+        )
         # delete the data to mimic an environment where category/form don't exist
         form.delete()
         category.delete()
@@ -1669,11 +1685,13 @@ class ImportExportTests(TempdirMixin, TestCase):
             next_text_en="Some next step text translation",
         )
 
-        original_json = form_to_json(form.pk)
+        original_json = form_to_json(form.pk, export_options=FormExportOptions())
 
         # roundtrip
         with translation.override("en"):
-            export_form(form.pk, archive_name=self.filepath)
+            export_form(
+                form.pk, archive_name=self.filepath, export_options=FormExportOptions()
+            )
         # language switched back to default
         form.delete()
         form_definition.delete()
@@ -1919,7 +1937,7 @@ class ImportExportTests(TempdirMixin, TestCase):
             formstep__form_definition__configuration={"components": [component]},
         )
 
-        export_data = form_to_json(form.pk)
+        export_data = form_to_json(form.pk, export_options=FormExportOptions())
 
         self.assertIsInstance(export_data, dict)
 
@@ -1945,7 +1963,9 @@ class ImportExportTests(TempdirMixin, TestCase):
                 ]
             },
         )
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk, archive_name=self.filepath, export_options=FormExportOptions()
+        )
 
         converters = {"textfield": {"add_foo": add_foo}}
         with patch("openforms.forms.utils.CONVERTERS", new=converters):
@@ -1961,7 +1981,9 @@ class ImportExportTests(TempdirMixin, TestCase):
     def test_rountrip_form_with_theme_override(self):
         theme = ThemeFactory.create()
         form = FormFactory.create(generate_minimal_setup=True, theme=theme)
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk, archive_name=self.filepath, export_options=FormExportOptions()
+        )
 
         # run the import again
         import_form(import_file=self.filepath)
@@ -2234,7 +2256,9 @@ class ImportExportTests(TempdirMixin, TestCase):
                 ]
             },
         )
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk, archive_name=self.filepath, export_options=FormExportOptions()
+        )
         import_form(import_file=self.filepath)
 
         imported_form = Form.objects.exclude(pk=form.pk).get()

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -753,10 +753,51 @@ class ImportExportTests(TempdirMixin, TestCase):
         product = ProductFactory.create()
         theme = ThemeFactory.create()
         category = CategoryFactory.create()
+
+        yiviAttributeGroup1 = AttributeGroupFactory.create()
+        yiviAttributeGroup2 = AttributeGroupFactory.create()
+
+        wmtsTileLayer = MapTileLayerFactory.create()
+        wmsTileLayer = MapWMSTileLayerFactory.create()
+
         form = FormFactory.create(
+            generate_minimal_setup=True,
             product=product,
             theme=theme,
             category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [
+                    yiviAttributeGroup1.uuid,
+                    yiviAttributeGroup2.uuid,
+                ],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmtsTileLayer.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wmsTileLayer.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                ],
+            },
         )
 
         # The export is made without any additional_form_configuration
@@ -783,6 +824,7 @@ class ImportExportTests(TempdirMixin, TestCase):
             )
 
             forms = json.loads(f.read("forms.json"))
+            formDefinitions = json.loads(f.read("formDefinitions.json"))
 
             self.assertEqual(len(forms), 1)
 
@@ -791,6 +833,44 @@ class ImportExportTests(TempdirMixin, TestCase):
             # Assert theme and category are in exportdata
             self.assertIsNotNone(forms[0]["theme"])
             self.assertIsNotNone(forms[0]["category"])
+
+            # Assert Yivi authentication_backend is in exportdata, but without
+            # additional_attributes_groups
+            self.assertEqual(len(forms[0]["auth_backends"]), 1)
+            auth_backend = forms[0]["auth_backends"][0]
+            self.assertEqual(auth_backend["backend"], "yivi_oidc")
+            self.assertEqual(
+                auth_backend["options"]["additional_attributes_groups"], []
+            )
+            # Assert that the authentication_options on the actual form object are kept
+            self.assertIn(
+                str(yiviAttributeGroup1.uuid),
+                form.auth_backends.first().options["additional_attributes_groups"],
+            )
+            self.assertIn(
+                str(yiviAttributeGroup2.uuid),
+                form.auth_backends.first().options["additional_attributes_groups"],
+            )
+
+            # Assert that the WMS and WMTS tile layers are removed from the exportdata
+            self.assertEqual(len(formDefinitions), 1)
+            self.assertEqual(len(formDefinitions[0]["configuration"]["components"]), 1)
+            component_definition = formDefinitions[0]["configuration"]["components"][0]
+
+            self.assertEqual(component_definition["type"], "map")
+            self.assertEqual(component_definition["tileLayerIdentifier"], "")
+            self.assertEqual(len(component_definition["overlays"]), 1)
+            self.assertEqual(component_definition["overlays"][0]["uuid"], "")
+            self.assertEqual(component_definition["overlays"][0]["layers"], [])
+            # Assert that the actual form definition still contains the WMS and WMTS tile layers
+            fd = form.formstep_set.get().form_definition
+            self.assertEqual(
+                fd.configuration["components"][0]["tileLayerIdentifier"],
+                wmtsTileLayer.identifier,
+            )
+            overlay = fd.configuration["components"][0]["overlays"][0]
+            self.assertEqual(overlay["uuid"], str(wmsTileLayer.uuid))
+            self.assertEqual(overlay["layers"], ["pand", "verblijfsobject"])
 
     def test_export_with_all_additional_form_configuration_included(self):
         product = ProductFactory.create()
@@ -911,6 +991,7 @@ class ImportExportTests(TempdirMixin, TestCase):
             )
 
             forms = json.loads(f.read("forms.json"))
+            formDefinitions = json.loads(f.read("formDefinitions.json"))
             product_export = json.loads(f.read("product.json"))
             wms_tile_layers_export = json.loads(f.read("wmsTileLayers.json"))
             wmts_tile_layers_export = json.loads(f.read("wmtsTileLayers.json"))
@@ -924,6 +1005,40 @@ class ImportExportTests(TempdirMixin, TestCase):
             self.assertIsNotNone(forms[0]["product"])
             self.assertIsNotNone(forms[0]["theme"])
             self.assertIsNotNone(forms[0]["category"])
+
+            # Assert Yivi authentication_backend is in exportdata with
+            # additional_attributes_groups
+            self.assertEqual(len(forms[0]["auth_backends"]), 1)
+            auth_backend = forms[0]["auth_backends"][0]
+            self.assertEqual(auth_backend["backend"], "yivi_oidc")
+            self.assertIn(
+                str(yiviAttributeGroup1.uuid),
+                auth_backend["options"]["additional_attributes_groups"],
+            )
+            self.assertIn(
+                str(yiviAttributeGroup2.uuid),
+                auth_backend["options"]["additional_attributes_groups"],
+            )
+
+            # Assert WMS and WMTS tile layers are in exportdata
+            self.assertEqual(len(formDefinitions), 1)
+            self.assertEqual(len(formDefinitions[0]["configuration"]["components"]), 2)
+            component1 = formDefinitions[0]["configuration"]["components"][0]
+            component2 = formDefinitions[0]["configuration"]["components"][1]
+
+            self.assertEqual(component1["tileLayerIdentifier"], wmtsMap1.identifier)
+            self.assertEqual(len(component1["overlays"]), 1)
+            self.assertEqual(component1["overlays"][0]["uuid"], str(wmsMap1.uuid))
+            self.assertEqual(
+                component1["overlays"][0]["layers"], ["pand", "verblijfsobject"]
+            )
+
+            self.assertEqual(component2["tileLayerIdentifier"], wmtsMap2.identifier)
+            self.assertEqual(len(component2["overlays"]), 2)
+            self.assertEqual(component2["overlays"][0]["uuid"], str(wmsMap2.uuid))
+            self.assertEqual(component2["overlays"][0]["layers"], ["EL.GridCoverage"])
+            self.assertEqual(component2["overlays"][1]["uuid"], str(wmsMap3.uuid))
+            self.assertEqual(component2["overlays"][1]["layers"], ["lgn-actueel"])
 
             # Validate the export file contents
             self.assertEqual(
@@ -1001,6 +1116,24 @@ class ImportExportTests(TempdirMixin, TestCase):
                 },
                 yivi_attribute_groups_export,
             )
+
+    def test_export_with_unknown_additional_form_configuration_option(self):
+        form = FormFactory.create()
+
+        # Pass some unknown option to the export
+        with self.assertRaises(ValueError) as error:
+            export_form(
+                form.pk,
+                archive_name=self.filepath,
+                export_options=FormExportOptions(
+                    additional_form_configuration=["some_unknown_option"],
+                ),
+            )
+
+        self.assertEqual(
+            error.exception.args[0],
+            "Invalid additional form configuration option(s): {'some_unknown_option'}",
+        )
 
     def test_import(self):
         product = ProductFactory.create()

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -514,6 +514,86 @@ class ImportExportTests(TempdirMixin, TestCase):
             component_definition = form_definitions[0]["configuration"]["components"][0]
             self.assertEqual(component_definition["defaultValue"], "")
 
+    def test_export_with_anonymize_option_anonymizes_nested_component_variable(self):
+        # Setting up a form with sensitive data in:
+        # - component variable initial value
+        # - component variable in logic rule
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            registration_backend="email",
+            registration_backend_options={"to_emails_from_variable": "textfield"},
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "fieldset",
+                        "label": "Fieldset",
+                        "type": "fieldset",
+                        "components": [
+                            {
+                                "key": "textfield",
+                                "type": "textfield",
+                                "label": "Textfield",
+                                "defaultValue": "personal@me.com",
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "textfield",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=True,
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+            form_logic = json.loads(f.read("formLogic.json"))
+            form_variables = json.loads(f.read("formVariables.json"))
+            form_definitions = json.loads(f.read("formDefinitions.json"))
+
+            self.assertEqual(len(forms), 1)
+            self.assertEqual(len(form_logic), 1)
+            self.assertEqual(len(form_variables), 1)
+            self.assertEqual(len(form_definitions), 1)
+
+            self.assertEqual(len(forms[0]["registration_backends"]), 1)
+            registration_backend = forms[0]["registration_backends"][0]
+
+            self.assertEqual(
+                registration_backend["options"]["to_emails_from_variable"],
+                "textfield",
+            )
+
+            # The logic rule that assigns the value of the component variable is cleared
+            self.assertEqual(len(form_logic[0]["actions"]), 1)
+            self.assertEqual(form_logic[0]["actions"][0]["variable"], "textfield")
+            self.assertEqual(
+                form_logic[0]["actions"][0]["action"],
+                {"type": "variable", "value": ""},
+            )
+
+            # The default value of the component variable used in the e-mail registration
+            # is cleared
+            self.assertEqual(len(form_definitions[0]["configuration"]["components"]), 1)
+            fieldset = form_definitions[0]["configuration"]["components"][0]
+            self.assertEqual(len(fieldset["components"]), 1)
+            self.assertEqual(fieldset["components"][0]["defaultValue"], "")
+
     def test_export_with_exclude_registration_backends_option(self):
         form = FormFactory.create(
             registration_backend="email",
@@ -1538,7 +1618,9 @@ class ImportExportTests(TempdirMixin, TestCase):
         self.assertEqual(form_step.next_text, "Untranslated next step text")
 
         # inspect the exported data structure, configs etc.
-        imported_json = form_to_json(imported_form.pk)
+        imported_json = form_to_json(
+            imported_form.pk, export_options=FormExportOptions()
+        )
         expected_differences = {
             "forms": [
                 "uuid",  # import gets assigned a new one

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -1208,7 +1208,19 @@ class ImportExportTests(TempdirMixin, TestCase):
             form_logic.pk,
         )
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=[
+                    FormConfigurationOptions.registration_backends,
+                    FormConfigurationOptions.prefill,
+                    FormConfigurationOptions.auth_backends,
+                    FormConfigurationOptions.payment_backend,
+                ],
+            ),
+        )
 
         # attempt to break ForeignKey constraint
         far_fetched.delete()
@@ -2768,7 +2780,14 @@ class ImportExportTests(TempdirMixin, TestCase):
             },
         )
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=[FormConfigurationOptions.registration_backends],
+            ),
+        )
         import_form(import_file=self.filepath)
 
         updated_form = Form.objects.last()
@@ -2925,7 +2944,14 @@ class ImportExportTests(TempdirMixin, TestCase):
             is_advanced=True,
         )
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=[FormConfigurationOptions.prefill],
+            ),
+        )
 
         # Import form
         import_form(import_file=self.filepath)
@@ -3026,7 +3052,14 @@ class ExportObjectsAPITests(TempdirMixin, TestCase):
             },
         )
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=[FormConfigurationOptions.registration_backends],
+            ),
+        )
 
         with zipfile.ZipFile(self.filepath, "r") as f:
             self.assertEqual(
@@ -3532,7 +3565,14 @@ class ImportObjectsAPITests(TempdirMixin, OFVCRMixin, TestCase):
                 "files": [],
             },
         )
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=[FormConfigurationOptions.registration_backends],
+            ),
+        )
         form.delete()
 
         import_form(import_file=self.filepath)
@@ -3778,7 +3818,14 @@ class ImportZGWAPITests(TempdirMixin, OFVCRMixin, TestCase):
                 "files": [],
             },
         )
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=[FormConfigurationOptions.registration_backends],
+            ),
+        )
         form.delete()
 
         import_form(import_file=self.filepath)
@@ -3905,7 +3952,14 @@ class ImportStUFZDSTests(TempdirMixin, TestCase):
                 "files": [],
             },
         )
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=[FormConfigurationOptions.registration_backends],
+            ),
+        )
         form.delete()
 
         import_form(import_file=self.filepath)

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -14,17 +14,29 @@ from digid_eherkenning.choices import AssuranceLevels, DigiDAssuranceLevels
 from freezegun import freeze_time
 from rest_framework.exceptions import ValidationError
 
+from openforms.authentication.constants import AuthAttribute
+from openforms.authentication.tests.factories import AttributeGroupFactory
 from openforms.config.constants import UploadFileType
 from openforms.config.models import GlobalConfiguration
-from openforms.config.tests.factories import ThemeFactory
+from openforms.config.tests.factories import (
+    MapTileLayerFactory,
+    MapWMSTileLayerFactory,
+    ThemeFactory,
+)
 from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
 from openforms.emails.models import ConfirmationEmailTemplate
 from openforms.emails.tests.factories import ConfirmationEmailTemplateFactory
 from openforms.forms.import_export.constants import EXPORT_META_KEY
 from openforms.forms.import_export.export_form import export_form, form_to_json
+from openforms.forms.import_export.typing import (
+    AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
+    FormExportOptions,
+)
 from openforms.payments.contrib.worldline.tests.factories import (
     WorldlineMerchantFactory,
 )
+from openforms.prefill.constants import IdentifierRoles
 from openforms.products.tests.factories import ProductFactory
 from openforms.registrations.contrib.objects_api.config import (
     ObjectsAPIOptionsSerializer,
@@ -58,7 +70,6 @@ from openforms.utils.tests.vcr import OFVCRMixin
 from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
 
-from ...authentication.tests.factories import AttributeGroupFactory
 from ..disable_next_import_conversion import add_form_step_uuid_to_disable_next_actions
 from ..models import (
     Form,
@@ -243,6 +254,672 @@ class ImportExportTests(TempdirMixin, TestCase):
             self.assertEqual(
                 form_definitions[0]["configuration"],
                 form_definition.configuration,
+            )
+
+    def test_export_without_anonymize_option_keeps_all_sensitive_data(self):
+        # Setting up a form with sensitive data in:
+        # - form internal remarks
+        # - user defined variable initial value
+        # - user defined variable in logic rule
+        # - e-mail address in e-mail registration to_emails
+        # - e-mail address in e-mail registration payment_emails
+        form = FormFactory.create(
+            internal_remarks="Some internal remark that should be kept",
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["submission@company.com"],
+                "to_emails_from_variable": "variable_with_sensitive_data",
+                "payment_emails": ["payment@company.com"],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            user_defined=True,
+            key="variable_with_sensitive_data",
+            initial_value="personal@company.com",
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "variable_with_sensitive_data",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=[FormConfigurationOptions.registration_backends],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+            form_logic = json.loads(f.read("formLogic.json"))
+            form_variables = json.loads(f.read("formVariables.json"))
+
+            self.assertEqual(len(forms), 1)
+            self.assertEqual(len(form_logic), 1)
+            self.assertEqual(len(form_variables), 2)
+
+            # Internal remarks should be kept
+            self.assertEqual(
+                forms[0]["internal_remarks"], "Some internal remark that should be kept"
+            )
+
+            # E-mail addresses and variable assigned to registration backend should be
+            # kept
+            self.assertEqual(len(forms[0]["registration_backends"]), 1)
+            registration_backend = forms[0]["registration_backends"][0]
+            self.assertEqual(
+                registration_backend["options"]["to_emails"], ["submission@company.com"]
+            )
+            self.assertEqual(
+                registration_backend["options"]["to_emails_from_variable"],
+                "variable_with_sensitive_data",
+            )
+            self.assertEqual(
+                registration_backend["options"]["payment_emails"],
+                ["payment@company.com"],
+            )
+
+            # The initial data of the user-defined variable used by the e-mail
+            # registration backend should be kept
+            sensitive_variable = next(
+                variable
+                for variable in form_variables
+                if variable["key"] == "variable_with_sensitive_data"
+            )
+            self.assertEqual(
+                sensitive_variable["initial_value"], "personal@company.com"
+            )
+
+            # The logic rule that assigns the value of the sensitive user-defined
+            # variable is kept
+            self.assertEqual(len(form_logic[0]["actions"]), 1)
+            self.assertEqual(
+                form_logic[0]["actions"][0]["variable"], "variable_with_sensitive_data"
+            )
+            self.assertEqual(
+                form_logic[0]["actions"][0]["action"],
+                {"type": "variable", "value": "internal@company.com"},
+            )
+
+    def test_export_with_anonymize_option_removes_all_sensitive_data(self):
+        # Setting up a form with sensitive data in:
+        # - form internal remarks
+        # - user defined variable initial value
+        # - user defined variable in logic rule
+        # - e-mail address in e-mail registration to_emails
+        # - e-mail address in e-mail registration payment_emails
+        form = FormFactory.create(
+            internal_remarks="Some internal remark that should be removed",
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["submission@company.com"],
+                "to_emails_from_variable": "variable_with_sensitive_data",
+                "payment_emails": ["payment@company.com"],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            user_defined=True,
+            key="variable_with_sensitive_data",
+            initial_value="personal@company.com",
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "variable_with_sensitive_data",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=True,
+                form_configuration=[FormConfigurationOptions.registration_backends],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+            form_logic = json.loads(f.read("formLogic.json"))
+            form_variables = json.loads(f.read("formVariables.json"))
+
+            self.assertEqual(len(forms), 1)
+            self.assertEqual(len(form_logic), 1)
+            self.assertEqual(len(form_variables), 2)
+
+            # Internal remarks should be removed
+            self.assertEqual(forms[0]["internal_remarks"], "")
+
+            # E-mail addresses assigned in the registration backend should be cleared
+            # The variable assigned in the registration backend should be kept
+            self.assertEqual(len(forms[0]["registration_backends"]), 1)
+            registration_backend = forms[0]["registration_backends"][0]
+
+            self.assertEqual(registration_backend["options"]["to_emails"], [])
+            self.assertEqual(
+                registration_backend["options"]["to_emails_from_variable"],
+                "variable_with_sensitive_data",
+            )
+            self.assertEqual(
+                registration_backend["options"]["payment_emails"],
+                [],
+            )
+
+            # The initial data of the user-defined variable used by the e-mail
+            # registration backend should be cleared
+            sensitive_variable = next(
+                variable
+                for variable in form_variables
+                if variable["key"] == "variable_with_sensitive_data"
+            )
+            self.assertEqual(sensitive_variable["initial_value"], "")
+
+            # The logic rule that assigns the value of the sensitive user-defined
+            # variable is cleared
+            self.assertEqual(len(form_logic[0]["actions"]), 1)
+            self.assertEqual(
+                form_logic[0]["actions"][0]["variable"], "variable_with_sensitive_data"
+            )
+            self.assertEqual(
+                form_logic[0]["actions"][0]["action"],
+                {"type": "variable", "value": ""},
+            )
+
+    def test_export_with_anonymize_option_anonymizes_component_variable(self):
+        # Setting up a form with sensitive data in:
+        # - component variable initial value
+        # - component variable in logic rule
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            registration_backend="email",
+            registration_backend_options={"to_emails_from_variable": "textfield"},
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "defaultValue": "personal@me.com",
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "textfield",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=True,
+                form_configuration=[FormConfigurationOptions.registration_backends],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+            form_logic = json.loads(f.read("formLogic.json"))
+            form_variables = json.loads(f.read("formVariables.json"))
+            form_definitions = json.loads(f.read("formDefinitions.json"))
+
+            self.assertEqual(len(forms), 1)
+            self.assertEqual(len(form_logic), 1)
+            self.assertEqual(len(form_variables), 1)
+            self.assertEqual(len(form_definitions), 1)
+
+            self.assertEqual(len(forms[0]["registration_backends"]), 1)
+            registration_backend = forms[0]["registration_backends"][0]
+
+            self.assertEqual(
+                registration_backend["options"]["to_emails_from_variable"],
+                "textfield",
+            )
+
+            # The logic rule that assigns the value of the component variable is cleared
+            self.assertEqual(len(form_logic[0]["actions"]), 1)
+            self.assertEqual(form_logic[0]["actions"][0]["variable"], "textfield")
+            self.assertEqual(
+                form_logic[0]["actions"][0]["action"],
+                {"type": "variable", "value": ""},
+            )
+
+            # The default value of the component variable used in the e-mail registration
+            # is cleared
+            self.assertEqual(len(form_definitions[0]["configuration"]["components"]), 1)
+            component_definition = form_definitions[0]["configuration"]["components"][0]
+            self.assertEqual(component_definition["defaultValue"], "")
+
+    def test_export_with_exclude_registration_backends_option(self):
+        form = FormFactory.create(
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["abc@xyz.com"],
+            },
+        )
+
+        # The export is made without registrationBackends in the form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                form_configuration=[],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+
+            self.assertEqual(len(forms), 1)
+            # Registration backends should not be in exportdata
+            self.assertEqual(len(forms[0]["registration_backends"]), 0)
+
+    def test_export_with_exclude_prefill_option(self):
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            identifier="test-objects-api-group"
+        )
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "prefill": {
+                            "plugin": "demo",
+                            "attribute": "random_number",
+                            "identifier_role": IdentifierRoles.authorizee,
+                        },
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_demo_prefill",
+            user_defined=True,
+            prefill_plugin="demo",
+            prefill_attribute="random_string",
+            prefill_identifier_role=IdentifierRoles.authorizee,
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_objects_api_prefill",
+            user_defined=True,
+            prefill_plugin="objects_api",
+            prefill_options={
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=True,
+                form_configuration=[FormConfigurationOptions.registration_backends],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+            form_variables = json.loads(f.read("formVariables.json"))
+            form_definitions = json.loads(f.read("formDefinitions.json"))
+
+            self.assertEqual(len(forms), 1)
+            self.assertEqual(len(form_variables), 2)
+            self.assertEqual(len(form_definitions), 1)
+
+            # Both variables should have empty prefill data
+            self.assertEqual(form_variables[0]["prefill_plugin"], "")
+            self.assertEqual(form_variables[0]["prefill_attribute"], "")
+            self.assertEqual(form_variables[0]["prefill_identifier_role"], "main")
+            self.assertEqual(form_variables[0]["prefill_options"], {})
+
+            self.assertEqual(form_variables[1]["prefill_plugin"], "")
+            self.assertEqual(form_variables[1]["prefill_attribute"], "")
+            self.assertEqual(form_variables[1]["prefill_identifier_role"], "main")
+            self.assertEqual(form_variables[1]["prefill_options"], {})
+
+            # The component prefill data should be cleared
+            self.assertEqual(len(form_definitions[0]["configuration"]["components"]), 1)
+            component_definition = form_definitions[0]["configuration"]["components"][0]
+            self.assertEqual(component_definition["prefill"]["plugin"], "")
+            self.assertEqual(component_definition["prefill"]["attribute"], "")
+            self.assertEqual(component_definition["prefill"]["identifier_role"], "main")
+
+    def test_export_with_exclude_payment_backend(self):
+        product = ProductFactory.create()
+        merchant = WorldlineMerchantFactory.create()
+        form = FormFactory.create(
+            product=product,
+            authentication_backend="digid",
+            payment_backend="worldline",
+            payment_backend_options={"merchant": merchant.pspid},
+        )
+
+        # The export is made without paymentBackend in the form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                form_configuration=[],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+
+            self.assertEqual(len(forms), 1)
+            # Payment backend should not be in exportdata
+            self.assertEqual(forms[0]["payment_backend"], "")
+            self.assertEqual(forms[0]["payment_backend_options"], {})
+
+    def test_export_with_exclude_auth_backends(self):
+        form = FormFactory.create(
+            authentication_backend="digid",
+        )
+
+        # The export is made without paymentBackend in the form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                form_configuration=[],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+
+            self.assertEqual(len(forms), 1)
+            # Payment backend should not be in exportdata
+            self.assertEqual(forms[0]["payment_backend"], "")
+            self.assertEqual(forms[0]["payment_backend_options"], {})
+
+    def test_export_with_all_additional_form_configuration_excluded(self):
+        product = ProductFactory.create()
+        theme = ThemeFactory.create()
+        category = CategoryFactory.create()
+        form = FormFactory.create(
+            product=product,
+            theme=theme,
+            category=category,
+        )
+
+        # The export is made without any additional_form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                additional_form_configuration=[],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            # None of the additional form configuration files should be in the exportdata
+            self.assertEqual(
+                f.namelist(),
+                [
+                    "forms.json",
+                    "formSteps.json",
+                    "formDefinitions.json",
+                    "formLogic.json",
+                    "formVariables.json",
+                    f"{EXPORT_META_KEY}.json",
+                ],
+            )
+
+            forms = json.loads(f.read("forms.json"))
+
+            self.assertEqual(len(forms), 1)
+
+            # Assert product is not in exportdata
+            self.assertEqual(forms[0]["product"], None)
+            # Assert theme and category are in exportdata
+            self.assertIsNotNone(forms[0]["theme"])
+            self.assertIsNotNone(forms[0]["category"])
+
+    def test_export_with_all_additional_form_configuration_included(self):
+        product = ProductFactory.create()
+        theme = ThemeFactory.create()
+        category = CategoryFactory.create()
+
+        wmtsMap1 = MapTileLayerFactory.create()
+        wmtsMap2 = MapTileLayerFactory.create()
+        wmsMap1 = MapWMSTileLayerFactory.create()
+        wmsMap2 = MapWMSTileLayerFactory.create()
+        wmsMap3 = MapWMSTileLayerFactory.create()
+
+        yiviAttributeGroup1 = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+        yiviAttributeGroup2 = AttributeGroupFactory.create(attributes=["email_address"])
+
+        # Define form with all additional form configuration
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            theme=theme,
+            category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [
+                    # The uuids of the `personal` and `mail` attributegroups
+                    yiviAttributeGroup1.uuid,
+                    yiviAttributeGroup2.uuid,
+                ],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map 1",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmtsMap1.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wmsMap1.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                    {
+                        "label": "Map 2",
+                        "key": "map2",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmtsMap2.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wmsMap2.uuid),
+                                "label": "height",
+                                "layers": ["EL.GridCoverage"],
+                            },
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wmsMap3.uuid),
+                                "label": "LGN",
+                                "layers": ["lgn-actueel"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        # The export is made with all additional_form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                additional_form_configuration=[
+                    AdditionalFormConfigurationOptions.product,
+                    AdditionalFormConfigurationOptions.wms_tile_layers,
+                    AdditionalFormConfigurationOptions.wmts_tile_layers,
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                ],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            # All of the additional form configuration files should be in the exportdata
+            self.assertEqual(
+                f.namelist(),
+                [
+                    "forms.json",
+                    "formSteps.json",
+                    "formDefinitions.json",
+                    "formLogic.json",
+                    "formVariables.json",
+                    "product.json",
+                    "wmsTileLayers.json",
+                    "wmtsTileLayers.json",
+                    "yiviAttributeGroups.json",
+                    f"{EXPORT_META_KEY}.json",
+                ],
+            )
+
+            forms = json.loads(f.read("forms.json"))
+            product_export = json.loads(f.read("product.json"))
+            wms_tile_layers_export = json.loads(f.read("wmsTileLayers.json"))
+            wmts_tile_layers_export = json.loads(f.read("wmtsTileLayers.json"))
+            yivi_attribute_groups_export = json.loads(
+                f.read("yiviAttributeGroups.json")
+            )
+
+            self.assertEqual(len(forms), 1)
+
+            # Assert product, theme and catagory are in exportdata
+            self.assertIsNotNone(forms[0]["product"])
+            self.assertIsNotNone(forms[0]["theme"])
+            self.assertIsNotNone(forms[0]["category"])
+
+            # Validate the export file contents
+            self.assertEqual(
+                product_export,
+                [
+                    {
+                        "uuid": str(product.uuid),
+                        "name": product.name,
+                        "price": str(product.price).replace(".", ","),
+                        "information": product.information,
+                    }
+                ],
+            )
+
+            self.assertEqual(len(wms_tile_layers_export), 3)
+            self.assertIn(
+                {
+                    "uuid": str(wmsMap1.uuid),
+                    "name": wmsMap1.name,
+                    "url": wmsMap1.url,
+                },
+                wms_tile_layers_export,
+            )
+            self.assertIn(
+                {
+                    "uuid": str(wmsMap2.uuid),
+                    "name": wmsMap2.name,
+                    "url": wmsMap2.url,
+                },
+                wms_tile_layers_export,
+            )
+            self.assertIn(
+                {
+                    "uuid": str(wmsMap3.uuid),
+                    "name": wmsMap3.name,
+                    "url": wmsMap3.url,
+                },
+                wms_tile_layers_export,
+            )
+
+            self.assertEqual(len(wmts_tile_layers_export), 2)
+            self.assertIn(
+                {
+                    "identifier": wmtsMap1.identifier,
+                    "label": wmtsMap1.label,
+                    "url": wmtsMap1.url,
+                },
+                wmts_tile_layers_export,
+            )
+            self.assertIn(
+                {
+                    "identifier": wmtsMap2.identifier,
+                    "label": wmtsMap2.label,
+                    "url": wmtsMap2.url,
+                },
+                wmts_tile_layers_export,
+            )
+
+            self.assertEqual(len(yivi_attribute_groups_export), 2)
+            self.assertIn(
+                {
+                    "uuid": str(yiviAttributeGroup1.uuid),
+                    "name": yiviAttributeGroup1.name,
+                    "description": yiviAttributeGroup1.description,
+                    "attributes": ",".join(yiviAttributeGroup1.attributes),
+                },
+                yivi_attribute_groups_export,
+            )
+            self.assertIn(
+                {
+                    "uuid": str(yiviAttributeGroup2.uuid),
+                    "name": yiviAttributeGroup2.name,
+                    "description": yiviAttributeGroup2.description,
+                    "attributes": ",".join(yiviAttributeGroup2.attributes),
+                },
+                yivi_attribute_groups_export,
             )
 
     def test_import(self):

--- a/src/openforms/forms/tests/test_management.py
+++ b/src/openforms/forms/tests/test_management.py
@@ -25,6 +25,7 @@ class DeleteFormExportFilesTest(TestCase):
             process_forms_export(
                 forms_uuids=[form1.uuid, form2.uuid],
                 user_id=user.id,
+                export_options={},
             )
 
         forms_export = FormsExport.objects.get()

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -9,7 +9,6 @@ from uuid import uuid4
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
 from django.db import transaction
-from django.utils import timezone
 from django.utils.translation import override
 
 import structlog
@@ -19,7 +18,6 @@ from rest_framework.test import APIRequestFactory
 from openforms.formio.migration_converters import CONVERTERS, DEFINITION_CONVERTERS
 from openforms.formio.utils import iter_components
 from openforms.forms.constants import FormTypeChoices
-from openforms.import_export.typing import FormExportOptions
 from openforms.registrations.contrib.objects_api.constants import (
     PLUGIN_IDENTIFIER as OBJECTS_API_PLUGIN_IDENTIFIER,
 )
@@ -30,18 +28,16 @@ from openforms.registrations.contrib.zgw_apis.plugin import (
     PLUGIN_IDENTIFIER as ZGW_APIS_PLUGIN_IDENTIFIER,
 )
 from openforms.typing import JSONObject
-from openforms.variables.constants import FormVariableSources
 
 from .api.datastructures import FormVariableWrapper
 from .api.serializers import (
     FormDefinitionSerializer,
-    FormExportSerializer,
     FormLogicSerializer,
     FormSerializer,
     FormStepSerializer,
     FormVariableSerializer,
 )
-from .constants import EXPORT_META_KEY, LogicActionTypes
+from .constants import LogicActionTypes
 from .models import Form, FormDefinition, FormLogic, FormStep, FormVariable
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -77,80 +73,6 @@ def _get_mock_request():
 
 def to_json(obj: Any):
     return json.dumps(obj, cls=DjangoJSONEncoder)
-
-
-def form_to_json(form_id: int) -> dict:
-    form = Form.objects.get(pk=form_id)
-
-    # Ignore products in the export
-    form.product = None
-
-    # Reset the submission counter
-    form.submission_counter = 0
-
-    form_steps = FormStep.objects.filter(form__pk=form_id).select_related(
-        "form_definition"
-    )
-
-    form_definitions = FormDefinition.objects.filter(
-        pk__in=form_steps.values_list("form_definition", flat=True)
-    )
-
-    form_logic = FormLogic.objects.filter(form=form)
-
-    # Export only user defined variables
-    # The component variables should be regenerated from the form definition configuration
-    # The static variables should be created for each form
-    form_variables = form.formvariable_set.filter(
-        source=FormVariableSources.user_defined
-    )
-
-    request = _get_mock_request()
-
-    forms = [FormExportSerializer(instance=form, context={"request": request}).data]
-    form_definitions = FormDefinitionSerializer(
-        instance=form_definitions,
-        many=True,
-        context={"request": request, "is_export": True},
-    ).data
-    form_steps = FormStepSerializer(
-        instance=form_steps, many=True, context={"request": request}
-    ).data
-    form_logic = FormLogicSerializer(
-        instance=form_logic, many=True, context={"request": request}
-    ).data
-    form_variables = FormVariableSerializer(
-        instance=form_variables, many=True, context={"request": request}
-    ).data
-
-    resources = {
-        "forms": to_json(forms),
-        "formSteps": to_json(form_steps),
-        "formDefinitions": to_json(form_definitions),
-        "formLogic": to_json(form_logic),
-        "formVariables": to_json(form_variables),
-        EXPORT_META_KEY: to_json(
-            {
-                "of_release": settings.RELEASE,
-                "of_git_sha": settings.GIT_SHA,
-                "created": timezone.now().isoformat(),
-            }
-        ),
-    }
-
-    return resources
-
-
-def export_form(
-    form_id, archive_name=None, response=None, export_options: FormExportOptions = None
-):
-    resources = form_to_json(form_id)
-
-    outfile = response or archive_name
-    with zipfile.ZipFile(outfile, "w") as zip_file:
-        for name, data in resources.items():
-            zip_file.writestr(f"{name}.json", data)
-    return outfile
 
 
 @transaction.atomic

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -19,6 +19,7 @@ from rest_framework.test import APIRequestFactory
 from openforms.formio.migration_converters import CONVERTERS, DEFINITION_CONVERTERS
 from openforms.formio.utils import iter_components
 from openforms.forms.constants import FormTypeChoices
+from openforms.import_export.typing import FormExportOptions
 from openforms.registrations.contrib.objects_api.constants import (
     PLUGIN_IDENTIFIER as OBJECTS_API_PLUGIN_IDENTIFIER,
 )
@@ -140,7 +141,9 @@ def form_to_json(form_id: int) -> dict:
     return resources
 
 
-def export_form(form_id, archive_name=None, response=None):
+def export_form(
+    form_id, archive_name=None, response=None, export_options: FormExportOptions = None
+):
     resources = form_to_json(form_id)
 
     outfile = response or archive_name

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -87,6 +87,12 @@
       "value": "Mark the form step as applicable"
     }
   ],
+  "/GRLBW": [
+    {
+      "type": 0,
+      "value": "Export file content"
+    }
+  ],
   "/XbK4W": [
     {
       "type": 0,
@@ -175,6 +181,12 @@
     {
       "type": 0,
       "value": "Receives confirmation email"
+    }
+  ],
+  "0PB1XV": [
+    {
+      "type": 0,
+      "value": "WMS tile layers"
     }
   ],
   "0PhQl9": [
@@ -283,6 +295,12 @@
     {
       "type": 0,
       "value": "The 'rsin' attribute for the Catalogus resource in the Catalogi API."
+    }
+  ],
+  "1cMfAA": [
+    {
+      "type": 0,
+      "value": "Product"
     }
   ],
   "1fD+K4": [
@@ -1979,6 +1997,12 @@
       "value": "Button labels"
     }
   ],
+  "E3pztQ": [
+    {
+      "type": 0,
+      "value": "Whether sensative form configuration should be anonymized during exporting."
+    }
+  ],
   "E5FZz/": [
     {
       "type": 0,
@@ -2393,6 +2417,12 @@
       "value": "Derive city"
     }
   ],
+  "H51Ms+": [
+    {
+      "type": 0,
+      "value": "Export form"
+    }
+  ],
   "H6VxhG": [
     {
       "type": 0,
@@ -2433,6 +2463,12 @@
     {
       "type": 0,
       "value": "Amount of days errored submissions of this form will remain before being removed. Leave blank to use value in General Configuration."
+    }
+  ],
+  "HKwvbG": [
+    {
+      "type": 0,
+      "value": "Which form configuration should be included in the export file content."
     }
   ],
   "HNoGb8": [
@@ -3131,6 +3167,12 @@
       "value": "Overlays"
     }
   ],
+  "OH+T6k": [
+    {
+      "type": 0,
+      "value": "Payment provider"
+    }
+  ],
   "OX8wxE": [
     {
       "type": 0,
@@ -3143,6 +3185,12 @@
     {
       "type": 0,
       "value": ". Extend your session if you wish to continue."
+    }
+  ],
+  "OaS7Pf": [
+    {
+      "type": 0,
+      "value": "Export options"
     }
   ],
   "OaeVI8": [
@@ -3535,6 +3583,12 @@
     {
       "type": 0,
       "value": "When this is checked, the filetypes configured in the global settings will be used."
+    }
+  ],
+  "S2Wv2u": [
+    {
+      "type": 0,
+      "value": "Form configuration"
     }
   ],
   "S4Lvvs": [
@@ -4311,6 +4365,12 @@
       "value": "Content of the registration email message (as html)."
     }
   ],
+  "Z4/E9e": [
+    {
+      "type": 0,
+      "value": "Authentication backends"
+    }
+  ],
   "Z8f4hI": [
     {
       "type": 0,
@@ -4769,6 +4829,12 @@
       "value": "(complex value)"
     }
   ],
+  "cIfwUm": [
+    {
+      "type": 0,
+      "value": "Background tile layers"
+    }
+  ],
   "cJnAgZ": [
     {
       "type": 0,
@@ -5155,6 +5221,12 @@
       "value": "Loading..."
     }
   ],
+  "eBHgYL": [
+    {
+      "type": 0,
+      "value": "Additional form configuration"
+    }
+  ],
   "eC2etA": [
     {
       "type": 0,
@@ -5189,6 +5261,12 @@
     {
       "type": 0,
       "value": "'Save row' text"
+    }
+  ],
+  "eVpjb6": [
+    {
+      "type": 0,
+      "value": "Anonymize form configuration"
     }
   ],
   "ee4oWr": [
@@ -5673,6 +5751,12 @@
       "value": "Label"
     }
   ],
+  "iAFlLD": [
+    {
+      "type": 0,
+      "value": "Registration backends"
+    }
+  ],
   "iNmPDd": [
     {
       "type": 0,
@@ -6071,6 +6155,12 @@
       "value": "Value"
     }
   ],
+  "lIwiA/": [
+    {
+      "type": 0,
+      "value": "Prefill"
+    }
+  ],
   "lKijv2": [
     {
       "type": 0,
@@ -6293,6 +6383,12 @@
     {
       "type": 0,
       "value": "The sum of column sizes may not exceed 12."
+    }
+  ],
+  "n55FhL": [
+    {
+      "type": 0,
+      "value": "Security"
     }
   ],
   "n9T2Oy": [
@@ -7405,6 +7501,12 @@
       "value": "Specify the attribute holding the pre-fill data."
     }
   ],
+  "w2UNV6": [
+    {
+      "type": 0,
+      "value": "Yivi attribute groups"
+    }
+  ],
   "w4e4jx": [
     {
       "type": 0,
@@ -7481,6 +7583,12 @@
     {
       "type": 0,
       "value": "API group"
+    }
+  ],
+  "wdvWi/": [
+    {
+      "type": 0,
+      "value": "Which additional form configuration should be included in the export file content."
     }
   ],
   "wnTTZr": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -87,6 +87,12 @@
       "value": "markeer de formulierstap als van toepassing"
     }
   ],
+  "/GRLBW": [
+    {
+      "type": 0,
+      "value": "Inhoud van het exportbestand"
+    }
+  ],
   "/XbK4W": [
     {
       "type": 0,
@@ -175,6 +181,12 @@
     {
       "type": 0,
       "value": "Ontvangt bevestigingsmail"
+    }
+  ],
+  "0PB1XV": [
+    {
+      "type": 0,
+      "value": "WMS-kaartlagen"
     }
   ],
   "0PhQl9": [
@@ -283,6 +295,12 @@
     {
       "type": 0,
       "value": "Het 'rsin'-attribuut van de catalogus-entiteit in de Catalogi API."
+    }
+  ],
+  "1cMfAA": [
+    {
+      "type": 0,
+      "value": "Product"
     }
   ],
   "1fD+K4": [
@@ -1966,6 +1984,12 @@
       "value": "Knopteksten"
     }
   ],
+  "E3pztQ": [
+    {
+      "type": 0,
+      "value": "Anonimiseer gevoelige formulierinstellingen bij het exporteren."
+    }
+  ],
   "E5FZz/": [
     {
       "type": 0,
@@ -2380,6 +2404,12 @@
       "value": "Stad afleiden"
     }
   ],
+  "H51Ms+": [
+    {
+      "type": 0,
+      "value": "Formulier exporteren"
+    }
+  ],
   "H6VxhG": [
     {
       "type": 0,
@@ -2420,6 +2450,12 @@
     {
       "type": 0,
       "value": "Aantal dagen dat een niet voltooide inzendingen (door fouten in de afhandeling) bewaard blijft. Laat leeg om de waarde van de algemene configuratie te gebruiken."
+    }
+  ],
+  "HKwvbG": [
+    {
+      "type": 0,
+      "value": "Welke formulierinstellingen mee geëxporteerd worden."
     }
   ],
   "HNoGb8": [
@@ -3118,6 +3154,12 @@
       "value": "Kaartlagen"
     }
   ],
+  "OH+T6k": [
+    {
+      "type": 0,
+      "value": "Betaalprovider"
+    }
+  ],
   "OX8wxE": [
     {
       "type": 0,
@@ -3130,6 +3172,12 @@
     {
       "type": 0,
       "value": ". Verleng uw sessie indien u wenst door te gaan."
+    }
+  ],
+  "OaS7Pf": [
+    {
+      "type": 0,
+      "value": "Formulier exportopties"
     }
   ],
   "OaeVI8": [
@@ -3518,6 +3566,12 @@
     {
       "type": 0,
       "value": "Indien ingeschakeld, gebruik dan de algemene instellingen voor toegestane bestandstypen."
+    }
+  ],
+  "S2Wv2u": [
+    {
+      "type": 0,
+      "value": "Formulierinstellingen"
     }
   ],
   "S4Lvvs": [
@@ -4294,6 +4348,12 @@
       "value": "Inhoud van de registratiemail (HTML)."
     }
   ],
+  "Z4/E9e": [
+    {
+      "type": 0,
+      "value": "Authenticatie plugins"
+    }
+  ],
   "Z8f4hI": [
     {
       "type": 0,
@@ -4757,6 +4817,12 @@
       "value": "(complexe waarde)"
     }
   ],
+  "cIfwUm": [
+    {
+      "type": 0,
+      "value": "Kaartachtergrondlagen"
+    }
+  ],
   "cJnAgZ": [
     {
       "type": 0,
@@ -5143,6 +5209,12 @@
       "value": "Aan het laden..."
     }
   ],
+  "eBHgYL": [
+    {
+      "type": 0,
+      "value": "Aanvullende formulierinstellingen"
+    }
+  ],
   "eC2etA": [
     {
       "type": 0,
@@ -5177,6 +5249,12 @@
     {
       "type": 0,
       "value": "'Groep bewaren'-tekst"
+    }
+  ],
+  "eVpjb6": [
+    {
+      "type": 0,
+      "value": "Anonimiseer formulierinstellingen"
     }
   ],
   "ee4oWr": [
@@ -5661,6 +5739,12 @@
       "value": "Label"
     }
   ],
+  "iAFlLD": [
+    {
+      "type": 0,
+      "value": "Registratie backends"
+    }
+  ],
   "iNmPDd": [
     {
       "type": 0,
@@ -6059,6 +6143,12 @@
       "value": "Waarde"
     }
   ],
+  "lIwiA/": [
+    {
+      "type": 0,
+      "value": "Prefill"
+    }
+  ],
   "lKijv2": [
     {
       "type": 0,
@@ -6281,6 +6371,12 @@
     {
       "type": 0,
       "value": "De som van de kolombreedtes mag niet meer dan 12 zijn."
+    }
+  ],
+  "n55FhL": [
+    {
+      "type": 0,
+      "value": "Beveiliging"
     }
   ],
   "n9T2Oy": [
@@ -7389,6 +7485,12 @@
       "value": "Geef het attribuut op wat de prefill-gegevens bevat."
     }
   ],
+  "w2UNV6": [
+    {
+      "type": 0,
+      "value": "Yivi attribuut groepen"
+    }
+  ],
   "w4e4jx": [
     {
       "type": 0,
@@ -7465,6 +7567,12 @@
     {
       "type": 0,
       "value": "API-groep"
+    }
+  ],
+  "wdvWi/": [
+    {
+      "type": 0,
+      "value": "Welke aanvullende formulierinstellingen mee geëxporteerd worden."
     }
   ],
   "wnTTZr": [

--- a/src/openforms/js/components/admin/form_design/Context.js
+++ b/src/openforms/js/components/admin/form_design/Context.js
@@ -9,7 +9,14 @@ const FeatureFlagsContext = React.createContext({
 FeatureFlagsContext.displayName = 'FeatureFlagsContext';
 
 const FormContext = React.createContext({
-  form: {url: '', uuid: '', type: 'regular'},
+  form: {
+    url: '',
+    uuid: '',
+    type: 'regular',
+    authBackends: [],
+    paymentBackend: [],
+    product: '',
+  },
   components: {},
   formSteps: [],
   formDefinitions: [],

--- a/src/openforms/js/components/admin/form_design/FormSubmit.js
+++ b/src/openforms/js/components/admin/form_design/FormSubmit.js
@@ -1,7 +1,9 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
 
+import ExportOptionsModal from 'components/admin/form_export/ExportOptionsModal';
+import {serializeExportOptions} from 'components/admin/form_export/utils';
 import ActionButton from 'components/admin/forms/ActionButton';
 import SubmitRow from 'components/admin/forms/SubmitRow';
 
@@ -19,6 +21,10 @@ const CopyAction = () => {
 };
 
 const ExportAction = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const exportButtonRef = useRef(null);
+  const exportOptionsRef = useRef(null);
+
   const intl = useIntl();
   const btnText = intl.formatMessage({
     defaultMessage: 'Export',
@@ -28,7 +34,27 @@ const ExportAction = () => {
     defaultMessage: 'Export this form',
     description: 'Export form button title',
   });
-  return <ActionButton name="_export" text={btnText} title={btnTitle} />;
+
+  return (
+    <>
+      <input ref={exportButtonRef} type="submit" name="_export" hidden />
+      <input ref={exportOptionsRef} type="hidden" name="export_options" />
+      <ActionButton
+        text={btnText}
+        title={btnTitle}
+        type="button"
+        onClick={() => setIsModalOpen(true)}
+      />
+      <ExportOptionsModal
+        isOpen={isModalOpen}
+        onSubmit={exportOptions => {
+          exportOptionsRef.current.value = JSON.stringify(serializeExportOptions(exportOptions));
+          exportButtonRef.current.click();
+        }}
+        onCloseModal={() => setIsModalOpen(false)}
+      />
+    </>
+  );
 };
 
 const FormSubmit = ({onSubmit, displayActions = false}) => (

--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -1267,6 +1267,8 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
             uuid: state.form.uuid,
             type: state.form.type,
             authBackends: state.form.authBackends,
+            paymentBackend: state.form.paymentBackend,
+            product: state.form.product,
           },
           components: availableComponents,
           formSteps: state.formSteps,
@@ -1496,6 +1498,8 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
             </TabPanel>
           )}
         </Tabs>
+
+        <FormSubmit onSubmit={onSubmit} displayActions={!state.newForm} />
       </FormContext.Provider>
 
       <ConfirmationModal
@@ -1507,7 +1511,6 @@ const FormCreationForm = ({formUuid, formUrl, formHistoryUrl, outgoingRequestsUr
           />
         }
       />
-      <FormSubmit onSubmit={onSubmit} displayActions={!state.newForm} />
     </ValidationErrorsProvider>
   );
 };

--- a/src/openforms/js/components/admin/form_export/AdditionalFormConfigurationField.js
+++ b/src/openforms/js/components/admin/form_export/AdditionalFormConfigurationField.js
@@ -1,0 +1,77 @@
+import {useField} from 'formik';
+import React from 'react';
+import {FormattedMessage, defineMessages} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import {Checkbox} from 'components/admin/forms/Inputs';
+
+import {useAdditionalFormConfigurationOptions} from './useExportOptions';
+
+export const FIELD_LABELS = defineMessages({
+  product: {
+    description: 'Label for additionalFormConfiguration product input',
+    defaultMessage: 'Product',
+  },
+  wmsTileLayers: {
+    description: 'Label for additionalFormConfiguration wmsTileLayers input',
+    defaultMessage: 'WMS tile layers',
+  },
+  wmtsTileLayers: {
+    description: 'Label for additionalFormConfiguration wmtsTileLayers input',
+    defaultMessage: 'Background tile layers',
+  },
+  yiviAttributeGroups: {
+    description: 'Label for additionalFormConfiguration yiviAttributeGroups input',
+    defaultMessage: 'Yivi attribute groups',
+  },
+});
+
+const AdditionalFormConfigurationField = () => {
+  const options = useAdditionalFormConfigurationOptions();
+  const [fieldProps, , fieldHelpers] = useField('additionalFormConfiguration');
+  const {value: selected} = fieldProps;
+  const {setValue} = fieldHelpers;
+
+  return (
+    <Field
+      name="additionalFormConfiguration"
+      label={
+        <FormattedMessage
+          defaultMessage="Additional form configuration"
+          description="Form import/export options 'additionalFormConfiguration' field label"
+        />
+      }
+      helpText={
+        <FormattedMessage
+          defaultMessage="Which additional form configuration should be included in the export file content."
+          description="Form import/export options 'additionalFormConfiguration' field help text"
+        />
+      }
+    >
+      <ul>
+        {options.map(option => (
+          <li key={option}>
+            <Checkbox
+              name={option}
+              value={option}
+              label={
+                option in FIELD_LABELS ? <FormattedMessage {...FIELD_LABELS[option]} /> : option
+              }
+              onChange={() => {
+                if (selected.includes(option)) {
+                  setValue(selected.filter(value => value !== option));
+                } else {
+                  setValue([...selected, option]);
+                }
+              }}
+              checked={selected.includes(option)}
+              noVCheckbox
+            />
+          </li>
+        ))}
+      </ul>
+    </Field>
+  );
+};
+
+export default AdditionalFormConfigurationField;

--- a/src/openforms/js/components/admin/form_export/ExportOptionsModal.js
+++ b/src/openforms/js/components/admin/form_export/ExportOptionsModal.js
@@ -1,0 +1,114 @@
+import {Formik} from 'formik';
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+
+import {SubmitAction} from 'components/admin/forms/ActionButton';
+import Fieldset from 'components/admin/forms/Fieldset';
+import FormRow from 'components/admin/forms/FormRow';
+import SubmitRow from 'components/admin/forms/SubmitRow';
+import {FormModal} from 'components/admin/modals';
+
+import AdditionalFormConfigurationField from './AdditionalFormConfigurationField';
+import FormConfigurationField from './FormConfigurationField';
+import RemoveSensitiveContentField from './RemoveSensitiveContentField';
+import {
+  useAdditionalFormConfigurationOptions,
+  useFormConfigurationOptions,
+} from './useExportOptions';
+
+const ExportOptionsModal = ({isOpen, onSubmit, onCloseModal}) => {
+  const intl = useIntl();
+  const formConfigurationOptions = useFormConfigurationOptions();
+  const additionalFormConfigurationOptions = useAdditionalFormConfigurationOptions();
+
+  const hasFormConfigurationOptions = formConfigurationOptions.length > 0;
+  const hasAdditionalFormConfigurationOptions = additionalFormConfigurationOptions.length > 0;
+
+  return (
+    <FormModal
+      isOpen={isOpen}
+      title={
+        <FormattedMessage
+          defaultMessage="Export options"
+          description="Form export options modal title"
+        />
+      }
+      closeModal={onCloseModal}
+      extraModifiers={['large']}
+    >
+      <Formik
+        initialValues={{
+          removeSensitiveContent: true,
+          formConfiguration: formConfigurationOptions,
+          additionalFormConfiguration: [],
+        }}
+        onSubmit={(values, actions) => {
+          onSubmit(values);
+          actions.setSubmitting(false);
+          onCloseModal();
+        }}
+      >
+        {({handleSubmit}) => (
+          <>
+            <Fieldset
+              title={
+                <FormattedMessage
+                  defaultMessage="Security"
+                  description="Form export 'security' options fieldset title"
+                />
+              }
+            >
+              <FormRow>
+                <RemoveSensitiveContentField name="removeSensitiveContent" />
+              </FormRow>
+            </Fieldset>
+
+            {hasFormConfigurationOptions || hasAdditionalFormConfigurationOptions ? (
+              <Fieldset
+                title={
+                  <FormattedMessage
+                    defaultMessage="Export file content"
+                    description="Form export 'export file content' options fieldset title"
+                  />
+                }
+              >
+                {hasFormConfigurationOptions && (
+                  <FormRow>
+                    <FormConfigurationField name="formConfiguration" />
+                  </FormRow>
+                )}
+                {hasAdditionalFormConfigurationOptions && (
+                  <FormRow>
+                    <AdditionalFormConfigurationField name="additionalFormConfiguration" />
+                  </FormRow>
+                )}
+              </Fieldset>
+            ) : null}
+
+            <SubmitRow isDefault>
+              <SubmitAction
+                text={intl.formatMessage({
+                  defaultMessage: 'Export form',
+                  description: 'Form export options modal submit button text',
+                })}
+                onClick={event => {
+                  event.preventDefault();
+                  handleSubmit(event);
+                }}
+              />
+            </SubmitRow>
+          </>
+        )}
+      </Formik>
+    </FormModal>
+  );
+};
+
+ExportOptionsModal.prototype = {
+  isOpen: PropTypes.bool.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  onCloseModal: PropTypes.func.isRequired,
+};
+
+export default ExportOptionsModal;

--- a/src/openforms/js/components/admin/form_export/ExportOptionsModal.stories.js
+++ b/src/openforms/js/components/admin/form_export/ExportOptionsModal.stories.js
@@ -1,0 +1,198 @@
+import {expect, fn, userEvent, within} from 'storybook/test';
+
+import {FormDecorator} from 'components/admin/form_design/story-decorators';
+import {VARIABLE_SOURCES} from 'components/admin/form_design/variables/constants';
+
+import ExportOptionsModal from './ExportOptionsModal';
+
+export default {
+  title: 'Admin / Form export options modal',
+  component: ExportOptionsModal,
+  decorators: [FormDecorator],
+  args: {
+    isOpen: true,
+    onSubmit: fn(),
+    onCloseModal: fn(),
+    registrationBackends: [
+      {
+        backend: 'objects_api',
+        key: 'objects_api_1',
+        name: 'Example Objects API reg.',
+        options: {},
+      },
+    ],
+    availableFormVariables: [
+      {
+        form: 'bar',
+        formDefinition: 'foo',
+        name: 'Name',
+        key: 'key',
+        source: VARIABLE_SOURCES.userDefined,
+        prefillPlugin: 'demo',
+      },
+    ],
+    form: {
+      authBackends: [
+        {
+          backend: 'yivi_oidc',
+          options: {
+            additionalAttributesGroups: ['be5e0bd1-d3be-4004-b37b-a4ce1bc68664'],
+          },
+        },
+      ],
+      paymentBackend: 'demo',
+      category: 'http://localhost/api/v2/public/categories/be5e0bd1-d3be-4004-b37b-a4ce1bc68664',
+      product: 'http://localhost/api/v2/products/be5e0bd1-d3be-4004-b37b-a4ce1bc68664',
+      theme: 'http://localhost/api/v2/themes/be5e0bd1-d3be-4004-b37b-a4ce1bc68664',
+    },
+    availableComponents: [
+      {
+        type: 'map',
+        id: 'map',
+        key: 'map',
+        label: 'Map field',
+        tileLayerIdentifier: 'map-background-identifier',
+        overlays: [
+          {
+            label: 'Overlay 1',
+            uuid: 'be5e0bd1-d3be-4004-b37b-a4ce1bc68664',
+          },
+        ],
+      },
+    ],
+  },
+};
+
+export const Default = {
+  play: async ({canvasElement, step, args}) => {
+    const canvas = within(canvasElement);
+    const exportButton = canvas.getByRole('button', {name: 'Formulier exporteren'});
+
+    const sensitiveContentField = canvas.getByLabelText('Anonimiseer formulierinstellingen');
+
+    const registrationBackendsInput = canvas.getByLabelText('Registratie backends');
+    const prefillInput = canvas.getByLabelText('Prefill');
+    const paymentBackendInput = canvas.getByLabelText('Betaalprovider');
+    const authBackendsInput = canvas.getByLabelText('Authenticatie plugins');
+
+    const productInput = canvas.getByLabelText('Product');
+    const wmsTileLayersInput = canvas.getByLabelText('WMS-kaartlagen');
+    const wmtsTileLayersInput = canvas.getByLabelText('Kaartachtergrondlagen');
+    const yiviAttributeGroupsInput = canvas.getByLabelText('Yivi attribuut groepen');
+
+    await step('Initial state', () => {
+      // All inputs should be visible
+      expect(sensitiveContentField).toBeVisible();
+
+      expect(registrationBackendsInput).toBeVisible();
+      expect(prefillInput).toBeVisible();
+      expect(paymentBackendInput).toBeVisible();
+      expect(authBackendsInput).toBeVisible();
+
+      expect(productInput).toBeVisible();
+      expect(wmsTileLayersInput).toBeVisible();
+      expect(wmtsTileLayersInput).toBeVisible();
+      expect(yiviAttributeGroupsInput).toBeVisible();
+
+      // The sensitive content field and form data inputs should be checked
+      expect(sensitiveContentField).toBeChecked();
+      expect(registrationBackendsInput).toBeChecked();
+      expect(prefillInput).toBeChecked();
+      expect(paymentBackendInput).toBeChecked();
+      expect(authBackendsInput).toBeChecked();
+
+      // The additional form data inputs should be unchecked
+      expect(productInput).not.toBeChecked();
+      expect(wmsTileLayersInput).not.toBeChecked();
+      expect(wmtsTileLayersInput).not.toBeChecked();
+      expect(yiviAttributeGroupsInput).not.toBeChecked();
+    });
+
+    await step('Make selection state', async () => {
+      await userEvent.click(sensitiveContentField);
+      expect(sensitiveContentField).not.toBeChecked();
+
+      await userEvent.click(registrationBackendsInput);
+      await userEvent.click(paymentBackendInput);
+      expect(registrationBackendsInput).not.toBeChecked();
+      expect(paymentBackendInput).not.toBeChecked();
+
+      await userEvent.click(wmsTileLayersInput);
+      await userEvent.click(wmtsTileLayersInput);
+      await userEvent.click(yiviAttributeGroupsInput);
+      expect(wmsTileLayersInput).toBeChecked();
+      expect(wmtsTileLayersInput).toBeChecked();
+      expect(yiviAttributeGroupsInput).toBeChecked();
+    });
+
+    await step('Confirm export', async () => {
+      await userEvent.click(exportButton);
+      expect(args.onSubmit).toHaveBeenCalledWith({
+        removeSensitiveContent: false,
+        formConfiguration: ['prefill', 'authBackends'],
+        additionalFormConfiguration: ['wmsTileLayers', 'wmtsTileLayers', 'yiviAttributeGroups'],
+      });
+    });
+  },
+};
+
+export const WithoutRegistrationBackends = {
+  args: {
+    registrationBackends: [],
+  },
+  play: async ({canvasElement, args}) => {
+    const canvas = within(canvasElement);
+    const exportButton = canvas.getByRole('button', {name: 'Formulier exporteren'});
+
+    const registrationBackendsInput = canvas.queryByLabelText('Registratie backends');
+    expect(registrationBackendsInput).not.toBeInTheDocument();
+
+    await userEvent.click(exportButton);
+    expect(args.onSubmit).toHaveBeenCalledWith({
+      removeSensitiveContent: true,
+      formConfiguration: ['prefill', 'paymentBackend', 'authBackends'],
+      additionalFormConfiguration: [],
+    });
+  },
+};
+
+export const WithOnlyRemoveSensitiveDataOption = {
+  args: {
+    registrationBackends: [],
+    availableFormVariables: [
+      {
+        form: 'bar',
+        formDefinition: 'foo',
+        name: 'Name',
+        key: 'key',
+        source: VARIABLE_SOURCES.userDefined,
+      },
+    ],
+    form: {
+      authBackends: [],
+      paymentBackend: '',
+      category: '',
+      product: '',
+      theme: '',
+    },
+    availableComponents: [
+      {
+        type: 'textfield',
+        id: 'textfield',
+        key: 'textfield',
+        label: 'Textfield',
+      },
+    ],
+  },
+  play: async ({canvasElement, args}) => {
+    const canvas = within(canvasElement);
+    const exportButton = canvas.getByRole('button', {name: 'Formulier exporteren'});
+
+    await userEvent.click(exportButton);
+    expect(args.onSubmit).toHaveBeenCalledWith({
+      removeSensitiveContent: true,
+      formConfiguration: [],
+      additionalFormConfiguration: [],
+    });
+  },
+};

--- a/src/openforms/js/components/admin/form_export/FormConfigurationField.js
+++ b/src/openforms/js/components/admin/form_export/FormConfigurationField.js
@@ -1,0 +1,77 @@
+import {useField} from 'formik';
+import React from 'react';
+import {FormattedMessage, defineMessages} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import {Checkbox} from 'components/admin/forms/Inputs';
+
+import {useFormConfigurationOptions} from './useExportOptions';
+
+export const FIELD_LABELS = defineMessages({
+  registrationBackends: {
+    description: 'Label for formConfiguration registrationBackends input',
+    defaultMessage: 'Registration backends',
+  },
+  prefill: {
+    description: 'Label for formConfiguration prefill input',
+    defaultMessage: 'Prefill',
+  },
+  paymentBackend: {
+    description: 'Label for formConfiguration paymentBackend input',
+    defaultMessage: 'Payment provider',
+  },
+  authBackends: {
+    description: 'Label for formConfiguration authBackends input',
+    defaultMessage: 'Authentication backends',
+  },
+});
+
+const FormConfigurationField = () => {
+  const options = useFormConfigurationOptions();
+  const [fieldProps, , fieldHelpers] = useField('formConfiguration');
+  const {value: selected} = fieldProps;
+  const {setValue} = fieldHelpers;
+
+  return (
+    <Field
+      name="formConfiguration"
+      label={
+        <FormattedMessage
+          defaultMessage="Form configuration"
+          description="Form import/export options 'formConfiguration' field label"
+        />
+      }
+      helpText={
+        <FormattedMessage
+          defaultMessage="Which form configuration should be included in the export file content."
+          description="Form import/export options 'formConfiguration' field help text"
+        />
+      }
+    >
+      <ul>
+        {options.map(option => (
+          <li key={option}>
+            <Checkbox
+              name={option}
+              value={option}
+              label={
+                option in FIELD_LABELS ? <FormattedMessage {...FIELD_LABELS[option]} /> : option
+              }
+              onChange={() => {
+                if (selected.includes(option)) {
+                  setValue(selected.filter(value => value !== option));
+                } else {
+                  setValue([...selected, option]);
+                }
+              }}
+              checked={selected?.includes(option)}
+              noVCheckbox
+            />
+          </li>
+        ))}
+      </ul>
+    </Field>
+  );
+};
+
+export default FormConfigurationField;

--- a/src/openforms/js/components/admin/form_export/RemoveSensitiveContentField.js
+++ b/src/openforms/js/components/admin/form_export/RemoveSensitiveContentField.js
@@ -1,0 +1,33 @@
+import {useField} from 'formik';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import {Checkbox} from 'components/admin/forms/Inputs';
+
+const RemoveSensitiveContentField = () => {
+  const [fieldProps, , fieldHelpers] = useField('removeSensitiveContent');
+  const {value} = fieldProps;
+  const {setValue} = fieldHelpers;
+
+  return (
+    <Checkbox
+      name="removeSensitiveContent"
+      label={
+        <FormattedMessage
+          defaultMessage="Anonymize form configuration"
+          description="Form export options 'removeSensitiveContent' field label"
+        />
+      }
+      helpText={
+        <FormattedMessage
+          defaultMessage="Whether sensative form configuration should be anonymized during exporting."
+          description="Form export options 'removeSensitiveContent' help text"
+        />
+      }
+      checked={value}
+      onChange={() => setValue(!value)}
+    />
+  );
+};
+
+export default RemoveSensitiveContentField;

--- a/src/openforms/js/components/admin/form_export/useExportOptions.js
+++ b/src/openforms/js/components/admin/form_export/useExportOptions.js
@@ -1,0 +1,62 @@
+import {useContext} from 'react';
+
+import {FormContext} from 'components/admin/form_design/Context';
+
+/**
+ * Get a list of options that should be included in the form configuration. These options
+ * represent key parts of the form configuration.
+ *
+ * The options are based on the form configuration. For example, if the form doesn't have
+ * any registration backends, then the registration backends option is not included.
+ *
+ * @returns {String[]}
+ */
+export const useFormConfigurationOptions = () => {
+  const {registrationBackends, form, formVariables} = useContext(FormContext);
+  const {authBackends, paymentBackend} = form;
+
+  const hasRegistrationBackends = registrationBackends.length > 0;
+  const hasAuthBackends = authBackends.length > 0;
+  const hasPaymentProvider = paymentBackend.length > 0;
+  const hasPrefill = formVariables.some(variable => !!variable.prefillPlugin);
+
+  return [
+    hasRegistrationBackends ? 'registrationBackends' : undefined,
+    hasPrefill ? 'prefill' : undefined,
+    hasPaymentProvider ? 'paymentBackend' : undefined,
+    hasAuthBackends ? 'authBackends' : undefined,
+  ].filter(Boolean);
+};
+
+/**
+ * Get a list of options that should be included in the additional form configuration.
+ * These options represent additional/supporting parts of the form configuration.
+ *
+ * The options are based on the form configuration. For example, if the form doesn't have
+ * a theme configured, then the theme option is not included.
+ *
+ * @returns {String[]}
+ */
+export const useAdditionalFormConfigurationOptions = () => {
+  const {components, form} = useContext(FormContext);
+  const {authBackends, product} = form;
+
+  const hasYiviAttributeGroups = authBackends.some(
+    backend =>
+      backend.backend === 'yivi_oidc' &&
+      (backend.options?.additionalAttributesGroups || []).length > 0
+  );
+  const hasWMSTileLayers = Object.values(components).some(
+    component => component.type === 'map' && (component?.overlays || []).length > 0
+  );
+  const hasWMTSTileLayers = Object.values(components).some(
+    component => component.type === 'map' && !!component?.tileLayerIdentifier
+  );
+
+  return [
+    Boolean(product) ? 'product' : undefined,
+    hasWMSTileLayers ? 'wmsTileLayers' : undefined,
+    hasWMTSTileLayers ? 'wmtsTileLayers' : undefined,
+    hasYiviAttributeGroups ? 'yiviAttributeGroups' : undefined,
+  ].filter(Boolean);
+};

--- a/src/openforms/js/components/admin/form_export/utils.js
+++ b/src/openforms/js/components/admin/form_export/utils.js
@@ -1,0 +1,8 @@
+/**
+ * Convert camelCase export options to snake_case, for API compatibility.
+ */
+export const serializeExportOptions = exportOptions => ({
+  remove_sensitive_content: exportOptions.removeSensitiveContent,
+  form_configuration: exportOptions.formConfiguration,
+  additional_form_configuration: exportOptions.additionalFormConfiguration,
+});

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -44,6 +44,11 @@
     "description": "action type \"step-applicable\" label",
     "originalDefault": "Mark the form step as applicable"
   },
+  "/GRLBW": {
+    "defaultMessage": "Export file content",
+    "description": "Form export 'export file content' options fieldset title",
+    "originalDefault": "Export file content"
+  },
   "/fAEsY": {
     "defaultMessage": "Submission report CSV informatieobjecttype",
     "description": "Objects API registration options \"Submission report CSV informatieobjecttype\" label",
@@ -68,6 +73,11 @@
     "defaultMessage": "DMN variable",
     "description": "DMN variable label",
     "originalDefault": "DMN variable"
+  },
+  "0PB1XV": {
+    "defaultMessage": "WMS tile layers",
+    "description": "Label for additionalFormConfiguration wmsTileLayers input",
+    "originalDefault": "WMS tile layers"
   },
   "0PhQl9": {
     "defaultMessage": "If enabled, any deceased children will be displayed too.",
@@ -113,6 +123,11 @@
     "defaultMessage": "Configure options",
     "description": "Link label to open registration options modal",
     "originalDefault": "Configure options"
+  },
+  "1cMfAA": {
+    "defaultMessage": "Product",
+    "description": "Label for additionalFormConfiguration product input",
+    "originalDefault": "Product"
   },
   "1fD+K4": {
     "defaultMessage": "Incomplete Submissions Removal Method",
@@ -884,6 +899,11 @@
     "description": "Objects API registration: uploadSubmissionCsv helpText",
     "originalDefault": "Indicates whether or not the submission CSV should be uploaded as a Document in Documenten API and attached to the product request."
   },
+  "E3pztQ": {
+    "defaultMessage": "Whether sensative form configuration should be anonymized during exporting.",
+    "description": "Form export options 'removeSensitiveContent' help text",
+    "originalDefault": "Whether sensative form configuration should be anonymized during exporting."
+  },
   "EDwCbX": {
     "defaultMessage": "<code>{componentKey}</code>: in {numSteps, plural, =1 {{tail}} other {{lead} and {tail}} }",
     "description": "Description of which key is duplicated in which steps.",
@@ -1094,6 +1114,11 @@
     "description": "StUF-ZDS registration variablesMapping label",
     "originalDefault": "Variables mapping (case)"
   },
+  "H51Ms+": {
+    "defaultMessage": "Export form",
+    "description": "Form export options modal submit button text",
+    "originalDefault": "Export form"
+  },
   "H6VxhG": {
     "defaultMessage": "Maintenance mode",
     "description": "Form maintenance mode field label",
@@ -1123,6 +1148,11 @@
     "defaultMessage": "Amount of days errored submissions of this form will remain before being removed. Leave blank to use value in General Configuration.",
     "description": "Errored Submissions Removal Limit help text",
     "originalDefault": "Amount of days errored submissions of this form will remain before being removed. Leave blank to use value in General Configuration."
+  },
+  "HKwvbG": {
+    "defaultMessage": "Which form configuration should be included in the export file content.",
+    "description": "Form import/export options 'formConfiguration' field help text",
+    "originalDefault": "Which form configuration should be included in the export file content."
   },
   "HVG1xy": {
     "defaultMessage": "Cosign content",
@@ -1539,10 +1569,20 @@
     "description": "Form registration options tab title",
     "originalDefault": "Registration"
   },
+  "OH+T6k": {
+    "defaultMessage": "Payment provider",
+    "description": "Label for formConfiguration paymentBackend input",
+    "originalDefault": "Payment provider"
+  },
   "OX8wxE": {
     "defaultMessage": "Your session is about to expire {delta}. Extend your session if you wish to continue.",
     "description": "Session expiry warning (in modal)",
     "originalDefault": "Your session is about to expire {delta}. Extend your session if you wish to continue."
+  },
+  "OaS7Pf": {
+    "defaultMessage": "Export options",
+    "description": "Form export options modal title",
+    "originalDefault": "Export options"
   },
   "Od+jm6": {
     "defaultMessage": "Values:",
@@ -1733,6 +1773,11 @@
     "defaultMessage": "change the value of a variable/component",
     "description": "action type \"variable\" label",
     "originalDefault": "change the value of a variable/component"
+  },
+  "S2Wv2u": {
+    "defaultMessage": "Form configuration",
+    "description": "Form import/export options 'formConfiguration' field label",
+    "originalDefault": "Form configuration"
   },
   "S6eF5o": {
     "defaultMessage": "Data removal",
@@ -2064,6 +2109,11 @@
     "description": "Email registration options 'emailContentTemplateHtml' helpText",
     "originalDefault": "Content of the registration email message (as html)."
   },
+  "Z4/E9e": {
+    "defaultMessage": "Authentication backends",
+    "description": "Label for formConfiguration authBackends input",
+    "originalDefault": "Authentication backends"
+  },
   "Z8f4hI": {
     "defaultMessage": "Document confidentiality level",
     "description": "StUF-ZDS registration options 'zdsZaakdocVertrouwelijkheid' label",
@@ -2284,6 +2334,11 @@
     "description": "JSON editor: complex value representation",
     "originalDefault": "(complex value)"
   },
+  "cIfwUm": {
+    "defaultMessage": "Background tile layers",
+    "description": "Label for additionalFormConfiguration wmtsTileLayers input",
+    "originalDefault": "Background tile layers"
+  },
   "cJnFcK": {
     "defaultMessage": "{plugin} requires one of the \"{requiredAuthAttribute}\" attributes. Please select one or more authentication plugins that provide such an attribute.",
     "description": "Prefill plugin requires unavailable auth attribute warning",
@@ -2399,6 +2454,11 @@
     "description": "ZGW APIs registration options 'partnersDescription' label",
     "originalDefault": "Partners description"
   },
+  "eBHgYL": {
+    "defaultMessage": "Additional form configuration",
+    "description": "Form import/export options 'additionalFormConfiguration' field label",
+    "originalDefault": "Additional form configuration"
+  },
   "eC2etA": {
     "defaultMessage": "Name of the product request type. It is available in the JSON template as the 'productaanvraag_type' variable.",
     "description": "Legacy objects API registration options: 'productaanvraagType' helpText",
@@ -2418,6 +2478,11 @@
     "defaultMessage": "Zds zaaktype status code",
     "description": "StUF-ZDS registration options 'zdsZaaktypeStatusCode' label",
     "originalDefault": "Zds zaaktype status code"
+  },
+  "eVpjb6": {
+    "defaultMessage": "Anonymize form configuration",
+    "description": "Form export options 'removeSensitiveContent' field label",
+    "originalDefault": "Anonymize form configuration"
   },
   "efsF8+": {
     "defaultMessage": "{label} {isPublished, select, false {<draft>(not published)</draft>} other {}}",
@@ -2654,6 +2719,11 @@
     "description": "DMN Input clause label header",
     "originalDefault": "Label"
   },
+  "iAFlLD": {
+    "defaultMessage": "Registration backends",
+    "description": "Label for formConfiguration registrationBackends input",
+    "originalDefault": "Registration backends"
+  },
   "iNmPDd": {
     "defaultMessage": "Attachment informatieobjecttype",
     "description": "Objects API registration options \"Attachment informatieobjecttype\" label",
@@ -2854,6 +2924,11 @@
     "description": "Label for 'value' in MappingArrayInput table column",
     "originalDefault": "Value"
   },
+  "lIwiA/": {
+    "defaultMessage": "Prefill",
+    "description": "Label for formConfiguration prefill input",
+    "originalDefault": "Prefill"
+  },
   "lNBZdl": {
     "defaultMessage": "The path of the folder where folders containing Open-Forms related documents will be created. You can use the expressions <code>'{{' year '}}'</code>, <code>'{{' month '}}'</code> and <code>'{{' day '}}'</code>. The path must start with <code>/</code>.",
     "description": "MS Graph registration options 'folderPath' help text",
@@ -2933,6 +3008,11 @@
     "defaultMessage": "Name",
     "description": "Fixed metadata table name title",
     "originalDefault": "Name"
+  },
+  "n55FhL": {
+    "defaultMessage": "Security",
+    "description": "Form export 'security' options fieldset title",
+    "originalDefault": "Security"
   },
   "nEg4dr": {
     "defaultMessage": "Metadata:",
@@ -3444,6 +3524,11 @@
     "description": "JSON editor: object entry has empty key name",
     "originalDefault": "Set a key name before you can configure this variable"
   },
+  "w2UNV6": {
+    "defaultMessage": "Yivi attribute groups",
+    "description": "Label for additionalFormConfiguration yiviAttributeGroups input",
+    "originalDefault": "Yivi attribute groups"
+  },
   "w4e4jx": {
     "defaultMessage": "After how many seconds should the cached response expire.",
     "description": "Help text cache timeout",
@@ -3473,6 +3558,11 @@
     "defaultMessage": "API group",
     "description": "Customer interactions API group field label",
     "originalDefault": "API group"
+  },
+  "wdvWi/": {
+    "defaultMessage": "Which additional form configuration should be included in the export file content.",
+    "description": "Form import/export options 'additionalFormConfiguration' field help text",
+    "originalDefault": "Which additional form configuration should be included in the export file content."
   },
   "wnTTZr": {
     "defaultMessage": "ID of the drive to use. If left empty, the default drive will be used.",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -44,6 +44,11 @@
     "description": "action type \"step-applicable\" label",
     "originalDefault": "Mark the form step as applicable"
   },
+  "/GRLBW": {
+    "defaultMessage": "Inhoud van het exportbestand",
+    "description": "Form export 'export file content' options fieldset title",
+    "originalDefault": "Export file content"
+  },
   "/fAEsY": {
     "defaultMessage": "Informatieobjecttype CSV-document met inzendingsgegevens",
     "description": "Objects API registration options \"Submission report CSV informatieobjecttype\" label",
@@ -69,6 +74,11 @@
     "defaultMessage": "DMN-variabele",
     "description": "DMN variable label",
     "originalDefault": "DMN variable"
+  },
+  "0PB1XV": {
+    "defaultMessage": "WMS-kaartlagen",
+    "description": "Label for additionalFormConfiguration wmsTileLayers input",
+    "originalDefault": "WMS tile layers"
   },
   "0PhQl9": {
     "defaultMessage": "Indien aangevinkt, dan worden overleden kinderen ook weergegeven.",
@@ -114,6 +124,12 @@
     "defaultMessage": "Opties instellen",
     "description": "Link label to open registration options modal",
     "originalDefault": "Configure options"
+  },
+  "1cMfAA": {
+    "defaultMessage": "Product",
+    "description": "Label for additionalFormConfiguration product input",
+    "isTranslated": true,
+    "originalDefault": "Product"
   },
   "1fD+K4": {
     "defaultMessage": "Opschoonmethode voor niet voltooide inzendingen",
@@ -894,6 +910,11 @@
     "description": "Objects API registration: uploadSubmissionCsv helpText",
     "originalDefault": "Indicates whether or not the submission CSV should be uploaded as a Document in Documenten API and attached to the product request."
   },
+  "E3pztQ": {
+    "defaultMessage": "Anonimiseer gevoelige formulierinstellingen bij het exporteren.",
+    "description": "Form export options 'removeSensitiveContent' help text",
+    "originalDefault": "Whether sensative form configuration should be anonymized during exporting."
+  },
   "EDwCbX": {
     "defaultMessage": "<code>{componentKey}</code>: in {numSteps, plural, =1 {{tail}} other {{lead} en {tail}} }",
     "description": "Description of which key is duplicated in which steps.",
@@ -1105,6 +1126,11 @@
     "description": "StUF-ZDS registration variablesMapping label",
     "originalDefault": "Variables mapping (case)"
   },
+  "H51Ms+": {
+    "defaultMessage": "Formulier exporteren",
+    "description": "Form export options modal submit button text",
+    "originalDefault": "Export form"
+  },
   "H6VxhG": {
     "defaultMessage": "Onderhoudsmodus",
     "description": "Form maintenance mode field label",
@@ -1134,6 +1160,11 @@
     "defaultMessage": "Aantal dagen dat een niet voltooide inzendingen (door fouten in de afhandeling) bewaard blijft. Laat leeg om de waarde van de algemene configuratie te gebruiken.",
     "description": "Errored Submissions Removal Limit help text",
     "originalDefault": "Amount of days errored submissions of this form will remain before being removed. Leave blank to use value in General Configuration."
+  },
+  "HKwvbG": {
+    "defaultMessage": "Welke formulierinstellingen mee geëxporteerd worden.",
+    "description": "Form import/export options 'formConfiguration' field help text",
+    "originalDefault": "Which form configuration should be included in the export file content."
   },
   "HVG1xy": {
     "defaultMessage": "Inhoud (bij mede-ondertekenen)",
@@ -1552,10 +1583,20 @@
     "description": "Form registration options tab title",
     "originalDefault": "Registration"
   },
+  "OH+T6k": {
+    "defaultMessage": "Betaalprovider",
+    "description": "Label for formConfiguration paymentBackend input",
+    "originalDefault": "Payment provider"
+  },
   "OX8wxE": {
     "defaultMessage": "Uw sessie vervalt {delta}. Verleng uw sessie indien u wenst door te gaan.",
     "description": "Session expiry warning (in modal)",
     "originalDefault": "Your session is about to expire {delta}. Extend your session if you wish to continue."
+  },
+  "OaS7Pf": {
+    "defaultMessage": "Formulier exportopties",
+    "description": "Form export options modal title",
+    "originalDefault": "Export options"
   },
   "Od+jm6": {
     "defaultMessage": "Waarden:",
@@ -1749,6 +1790,11 @@
     "defaultMessage": "zet de waarde van een variabele/component",
     "description": "action type \"variable\" label",
     "originalDefault": "change the value of a variable/component"
+  },
+  "S2Wv2u": {
+    "defaultMessage": "Formulierinstellingen",
+    "description": "Form import/export options 'formConfiguration' field label",
+    "originalDefault": "Form configuration"
   },
   "S6eF5o": {
     "defaultMessage": "Gegevens opschonen",
@@ -2084,6 +2130,11 @@
     "description": "Email registration options 'emailContentTemplateHtml' helpText",
     "originalDefault": "Content of the registration email message (as html)."
   },
+  "Z4/E9e": {
+    "defaultMessage": "Authenticatie plugins",
+    "description": "Label for formConfiguration authBackends input",
+    "originalDefault": "Authentication backends"
+  },
   "Z8f4hI": {
     "defaultMessage": "Vertrouwelijkheidaanduiding documenten",
     "description": "StUF-ZDS registration options 'zdsZaakdocVertrouwelijkheid' label",
@@ -2305,6 +2356,11 @@
     "description": "JSON editor: complex value representation",
     "originalDefault": "(complex value)"
   },
+  "cIfwUm": {
+    "defaultMessage": "Kaartachtergrondlagen",
+    "description": "Label for additionalFormConfiguration wmtsTileLayers input",
+    "originalDefault": "Background tile layers"
+  },
   "cJnFcK": {
     "defaultMessage": "{plugin} heeft (één van) de \"{requiredAuthAttribute}\" attribu(u)t(en) nodig. Gebruik één of meerdere inlogopties die dit attribuut aanbieden.",
     "description": "Prefill plugin requires unavailable auth attribute warning",
@@ -2421,6 +2477,11 @@
     "description": "ZGW APIs registration options 'partnersDescription' label",
     "originalDefault": "Partners description"
   },
+  "eBHgYL": {
+    "defaultMessage": "Aanvullende formulierinstellingen",
+    "description": "Form import/export options 'additionalFormConfiguration' field label",
+    "originalDefault": "Additional form configuration"
+  },
   "eC2etA": {
     "defaultMessage": "Naam van het productaanvraagtype. Deze naam is in het JSON-inhoudsjabloon beschikbaar als de 'productaanvraag_type' variabele.",
     "description": "Legacy objects API registration options: 'productaanvraagType' helpText",
@@ -2440,6 +2501,11 @@
     "defaultMessage": "Zaakstatuscode",
     "description": "StUF-ZDS registration options 'zdsZaaktypeStatusCode' label",
     "originalDefault": "Zds zaaktype status code"
+  },
+  "eVpjb6": {
+    "defaultMessage": "Anonimiseer formulierinstellingen",
+    "description": "Form export options 'removeSensitiveContent' field label",
+    "originalDefault": "Anonymize form configuration"
   },
   "efsF8+": {
     "defaultMessage": "{label} {isPublished, select, false {<draft>(concept)</draft>} other {}}",
@@ -2677,6 +2743,11 @@
     "isTranslated": true,
     "originalDefault": "Label"
   },
+  "iAFlLD": {
+    "defaultMessage": "Registratie backends",
+    "description": "Label for formConfiguration registrationBackends input",
+    "originalDefault": "Registration backends"
+  },
   "iNmPDd": {
     "defaultMessage": "Informatieobjecttype bijlagen",
     "description": "Objects API registration options \"Attachment informatieobjecttype\" label",
@@ -2877,6 +2948,12 @@
     "description": "Label for 'value' in MappingArrayInput table column",
     "originalDefault": "Value"
   },
+  "lIwiA/": {
+    "defaultMessage": "Prefill",
+    "description": "Label for formConfiguration prefill input",
+    "isTranslated": true,
+    "originalDefault": "Prefill"
+  },
   "lNBZdl": {
     "defaultMessage": "Het pad naar de map waar mappen voor documenten van Open Formulieren aangemaakt worden. Je kan de expressies <code>'{{' year '}}'</code>, <code>'{{' month '}}'</code> en <code>'{{' day '}}'</code> gebruiken. Het pad moet beginnen met <code>/</code>.",
     "description": "MS Graph registration options 'folderPath' help text",
@@ -2956,6 +3033,11 @@
     "defaultMessage": "Naam",
     "description": "Fixed metadata table name title",
     "originalDefault": "Name"
+  },
+  "n55FhL": {
+    "defaultMessage": "Beveiliging",
+    "description": "Form export 'security' options fieldset title",
+    "originalDefault": "Security"
   },
   "nEg4dr": {
     "defaultMessage": "Metagegevens:",
@@ -3469,6 +3551,11 @@
     "description": "JSON editor: object entry has empty key name",
     "originalDefault": "Set a key name before you can configure this variable"
   },
+  "w2UNV6": {
+    "defaultMessage": "Yivi attribuut groepen",
+    "description": "Label for additionalFormConfiguration yiviAttributeGroups input",
+    "originalDefault": "Yivi attribute groups"
+  },
   "w4e4jx": {
     "defaultMessage": "Na hoeveel seconden moeten gecachete resultaten vervallen.",
     "description": "Help text cache timeout",
@@ -3498,6 +3585,11 @@
     "defaultMessage": "API-groep",
     "description": "Customer interactions API group field label",
     "originalDefault": "API group"
+  },
+  "wdvWi/": {
+    "defaultMessage": "Welke aanvullende formulierinstellingen mee geëxporteerd worden.",
+    "description": "Form import/export options 'additionalFormConfiguration' field help text",
+    "originalDefault": "Which additional form configuration should be included in the export file content."
   },
   "wnTTZr": {
     "defaultMessage": "ID van de schijf/drive waar bestanden terecht moeten komen. Indien leeg, dan wordt de standaard-drive gebruikt.",


### PR DESCRIPTION
Closes #6429

**Changes**

This PR introduces form export options, which are used to provide users control over how a form is exported from Open Forms. These export options can be used to exclude configuration with environment-specific values (like services), include additional configuration (product, tile layers and yivi attributes), and automatically anonymize the form configuration.

### Additional configuration

Product, WMS- and WMTS tile layers and Yivi attribute groups can be exported alongside the main form configuration. These additional pieces of information will be included to the exportdata as separate `.JSON` files.

Theme and category are deliberately not (yet) included in this.
Adding import/export support for theme's would create an easy way to include harmful SVG content to the exportdata.
To add import/export support for categories we need a proper plan on how to deal with the category tree structure when importing a category. Situations where a matching instance is found but the parent category doesn't exist or the instance has a different parent then is expected are things we will have to deal with. Also, in cases were both the instance and parent don't exists, do we then only create the category, or also the parent?

### Anonymize form configuration

The form configuration is anonymized using an export option in combination with a opt-in allowlist. Each exportSerializer must specify which fields don't contain sensitive information. When the 'do anonymize' export option is chosen, only those fields will remain in the exportdata. Otherwise, when the 'don't anonymize' option is chosen, all serializer fields will be included.

The exportSerializers can additionally overrule the `remove_sensitive_content` method, and provide additional anonymize logic. This should only be done for more complex/unconventional anonymization needs.

### Export options UI

User interfaces have been made for singular and bulk export actions. With singular export (exporting from the form detail/edit page) the export options UI only shows the export options that will have effect on that form. For example, the option to include the product data is only visible when the form has a product configured.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [X] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [ ] Added documentation which describes the changes
