### PR TITLE
Implementing form import options

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -1476,7 +1476,10 @@ paths:
       - forms
       requestBody:
         content:
-          '*/*':
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FormImport'
+          application/x-www-form-urlencoded:
             schema:
               $ref: '#/components/schemas/FormImport'
         required: true
@@ -6860,6 +6863,22 @@ components:
         Note that every subsequent API call resets the expiry.
       required: true
   schemas:
+    AdditionalFormConfigurationEnum:
+      enum:
+      - product
+      - wmsTileLayers
+      - wmtsTileLayers
+      - yiviAttributeGroups
+      - theme
+      - category
+      type: string
+      description: |-
+        * `product` - Product
+        * `wmsTileLayers` - WMS-tile layers
+        * `wmtsTileLayers` - WMTS-tile layers
+        * `yiviAttributeGroups` - Yivi attribute groups
+        * `theme` - Theme
+        * `category` - Category
     AddressSearchResult:
       type: object
       properties:
@@ -8073,6 +8092,18 @@ components:
           title: authentication backend options
       required:
       - backend
+    FormConfigurationEnum:
+      enum:
+      - registrationBackends
+      - prefill
+      - paymentBackend
+      - authBackends
+      type: string
+      description: |-
+        * `registrationBackends` - Registration backends
+        * `prefill` - Prefill
+        * `paymentBackend` - Payment backend
+        * `authBackends` - Authentication backends
     FormData:
       type: object
       properties:
@@ -8388,6 +8419,35 @@ components:
           format: uri
           description: The file that contains the form, form definitions and form
             steps.
+        formConfiguration:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormConfigurationEnum'
+          description: Which form configuration should be included in the export file
+            content.
+        reusableFormDefinitions:
+          allOf:
+          - $ref: '#/components/schemas/ReusableFormDefinitionsEnum'
+          description: |-
+            Whether to reuse existing form definitions or create new ones for each form definition in the import file. If no similar form definition exists, a new form definition is created.
+
+            * `reuseExisting` - Reuse existing form definitions
+            * `createNew` - Create all new form definitions
+        linksToUnknownDomains:
+          allOf:
+          - $ref: '#/components/schemas/LinksToUnknownDomainsEnum'
+          description: |-
+            What to do with links in email templates to domains that are not accepted in the global configuration.
+
+            * `ignore` - Keep links to unknown domains as-is
+            * `remove` - Remove the links to unknown domains
+            * `accept` - Accept all unknown domains
+        additionalFormConfiguration:
+          type: array
+          items:
+            $ref: '#/components/schemas/AdditionalFormConfigurationEnum'
+          description: Which additional form configuration should be included in the
+            export file content.
       required:
       - file
     FormImportResponse:
@@ -9287,6 +9347,16 @@ components:
       required:
       - lat
       - lng
+    LinksToUnknownDomainsEnum:
+      enum:
+      - ignore
+      - remove
+      - accept
+      type: string
+      description: |-
+        * `ignore` - Keep links to unknown domains as-is
+        * `remove` - Remove the links to unknown domains
+        * `accept` - Accept all unknown domains
     Location:
       type: object
       properties:
@@ -10423,6 +10493,14 @@ components:
       description: |-
         * `failed` - Failed, should return to the start of the form.
         * `success` - Success, proceed to confirmation page.
+    ReusableFormDefinitionsEnum:
+      enum:
+      - reuseExisting
+      - createNew
+      type: string
+      description: |-
+        * `reuseExisting` - Reuse existing form definitions
+        * `createNew` - Create all new form definitions
     RijksDriehoek:
       type: object
       properties:

--- a/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
+++ b/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
@@ -4,7 +4,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Open Forms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-07-20 22:26+0200\n"
+"POT-Creation-Date: 2026-07-20 23:15+0200\n"
 "PO-Revision-Date: 2026-07-20 22:36+0200\n"
 "Last-Translator:   <admin@admin.com>\n"
 "Language-Team: Dutch <support@maykinmedia.nl>\n"
@@ -28,13 +28,12 @@ msgid ""
 "omit this header without losing functionality. We recommend favouring the "
 "nonce mechanism though."
 msgstr ""
-"De waarde van de CSP-nonce gegenereerd door de pagina die de SDK "
-"insluit/embed. Als deze meegestuurd wordt, dan worden velden met rich tekst "
-"(uit \"WYSIWYG\" editors) verwerkt om inline-styles toe te laten met de "
-"gegeven nonce. Indien de insluitende pagina een `style-src` policy heeft die"
-" `unsafe-inline` bevat, dan kan je deze header weglaten zonder "
-"functionaliteit te verliezen. We raden echter aan om het nonce-mechanisme te"
-" gebruiken."
+"De waarde van de CSP-nonce gegenereerd door de pagina die de SDK insluit/"
+"embed. Als deze meegestuurd wordt, dan worden velden met rich tekst (uit "
+"\"WYSIWYG\" editors) verwerkt om inline-styles toe te laten met de gegeven "
+"nonce. Indien de insluitende pagina een `style-src` policy heeft die `unsafe-"
+"inline` bevat, dan kan je deze header weglaten zonder functionaliteit te "
+"verliezen. We raden echter aan om het nonce-mechanisme te gebruiken."
 
 #: openforms/accounts/admin.py:38
 msgid "Groups"
@@ -87,7 +86,7 @@ msgstr "stafstatus"
 msgid "Designates whether the user can log into this admin site."
 msgstr "Bepaalt of de gebruiker zich op deze beheerwebsite kan aanmelden."
 
-#: openforms/accounts/models.py:55 openforms/forms/models/form.py:311
+#: openforms/accounts/models.py:55 openforms/forms/models/form.py:318
 msgid "active"
 msgstr "actief"
 
@@ -115,8 +114,8 @@ msgstr ""
 "De voorkeurstaal voor de (beheer) gebruikersinterface. Wanneer geen waarde "
 "ingesteld is, worden de browserinstellingen gebruikt."
 
-#: openforms/accounts/models.py:85 openforms/forms/models/form.py:841
-#: openforms/forms/models/form_version.py:64 soap/models.py:53
+#: openforms/accounts/models.py:85 openforms/forms/models/form.py:906
+#: openforms/forms/models/form_version.py:87 soap/models.py:53
 msgid "user"
 msgstr "gebruiker"
 
@@ -226,8 +225,8 @@ msgstr "Google Analytics code"
 msgid ""
 "Typically looks like 'UA-XXXXX-Y'. Supplying this installs Google Analytics."
 msgstr ""
-"Heeft typisch het formaat 'UA-XXXXX-Y'. Schakelt Google Analytics in als een"
-" waarde ingevuld is."
+"Heeft typisch het formaat 'UA-XXXXX-Y'. Schakelt Google Analytics in als een "
+"waarde ingevuld is."
 
 #: openforms/analytics_tools/models.py:122
 msgid "enable google analytics"
@@ -244,8 +243,7 @@ msgstr "Matomo server-URL"
 #: openforms/analytics_tools/models.py:133
 msgid "The base URL of your Matomo server, e.g. 'https://matomo.example.com'."
 msgstr ""
-"De basis-URL van uw Matomo server, bijvoorbeeld "
-"'https://matomo.example.com'."
+"De basis-URL van uw Matomo server, bijvoorbeeld 'https://matomo.example.com'."
 
 #: openforms/analytics_tools/models.py:137
 msgid "Matomo site ID"
@@ -306,8 +304,8 @@ msgstr "Piwik PRO site-ID"
 
 #: openforms/analytics_tools/models.py:183
 msgid ""
-"The 'idsite' of the website you're tracking in Piwik PRO. "
-"https://help.piwik.pro/support/questions/find-website-id/"
+"The 'idsite' of the website you're tracking in Piwik PRO. https://"
+"help.piwik.pro/support/questions/find-website-id/"
 msgstr ""
 "De 'idsite'-waarde van de website die je analyseert met Piwik PRO. Zie ook "
 "https://help.piwik.pro/support/questions/find-website-id/"
@@ -335,12 +333,12 @@ msgstr "SiteImprove ID"
 #: openforms/analytics_tools/models.py:203
 msgid ""
 "Your SiteImprove ID - you can find this from the embed snippet example, "
-"which should contain a URL like "
-"'//siteimproveanalytics.com/js/siteanalyze_XXXXX.js'. The XXXXX is your ID."
+"which should contain a URL like '//siteimproveanalytics.com/js/"
+"siteanalyze_XXXXX.js'. The XXXXX is your ID."
 msgstr ""
 "Uw SiteImprove ID - deze waarde kan je terugvinden in het embed-voorbeeld. "
-"Deze bevat normaal een URL zoals "
-"'//siteimproveanalytics.com/js/siteanalyze_XXXXX.js'. De XXXXX is uw ID."
+"Deze bevat normaal een URL zoals '//siteimproveanalytics.com/js/"
+"siteanalyze_XXXXX.js'. De XXXXX is uw ID."
 
 #: openforms/analytics_tools/models.py:209
 msgid "enable siteImprove analytics"
@@ -398,8 +396,8 @@ msgstr "GovMetric secure GUID (inzending voltooid)"
 
 #: openforms/analytics_tools/models.py:246
 msgid ""
-"Your GovMetric secure GUID for when a form is finished - This is an optional"
-" value. It is created by KLANTINFOCUS when a list  of questions is created. "
+"Your GovMetric secure GUID for when a form is finished - This is an optional "
+"value. It is created by KLANTINFOCUS when a list  of questions is created. "
 "It is a string that is unique per set of questions."
 msgstr ""
 "Het GovMetric secure GUID voor voltooide inzendingen. Deze waarde is niet "
@@ -428,8 +426,8 @@ msgid ""
 "The name of your organization as registered in Expoints. This is used to "
 "construct the URL to communicate with Expoints."
 msgstr ""
-"De naam/het label van de organisatie zoals deze bij Expoints bekend is. Deze"
-" waarde wordt gebruikt om de URL op te bouwen om met Expoints te verbinden."
+"De naam/het label van de organisatie zoals deze bij Expoints bekend is. Deze "
+"waarde wordt gebruikt om de URL op te bouwen om met Expoints te verbinden."
 
 #: openforms/analytics_tools/models.py:270
 msgid "Expoints configuration identifier"
@@ -440,8 +438,8 @@ msgid ""
 "The UUID used to retrieve the configuration from Expoints to initialize the "
 "client satisfaction survey."
 msgstr ""
-"Het UUID van de configuratie in Expoints om het tevredenheidsonderzoek op te"
-" halen."
+"Het UUID van de configuratie in Expoints om het tevredenheidsonderzoek op te "
+"halen."
 
 #: openforms/analytics_tools/models.py:278
 msgid "use Expoints test mode"
@@ -449,8 +447,8 @@ msgstr "gebruik Expoints testmode"
 
 #: openforms/analytics_tools/models.py:281
 msgid ""
-"Indicates whether or not the test mode should be enabled. If enabled, filled"
-" out surveys won't actually be sent, to avoid cluttering Expoints while "
+"Indicates whether or not the test mode should be enabled. If enabled, filled "
+"out surveys won't actually be sent, to avoid cluttering Expoints while "
 "testing."
 msgstr ""
 "Indien aangevinkt, dan wordt de testmode van Expoints ingeschakeld. "
@@ -501,8 +499,8 @@ msgstr ""
 
 #: openforms/analytics_tools/models.py:447
 msgid ""
-"If you enable GovMetric, you need to provide the source ID for all languages"
-" (the same one can be reused)."
+"If you enable GovMetric, you need to provide the source ID for all languages "
+"(the same one can be reused)."
 msgstr ""
 "Wanneer je GovMetric inschakelt, dan moet je een source ID ingegeven voor "
 "elke taaloptie. Je kan hetzelfde ID hergebruiken voor meerdere talen."
@@ -537,8 +535,8 @@ msgid ""
 "has passed, the session is expired and the user is 'logged out'. Note that "
 "every subsequent API call resets the expiry."
 msgstr ""
-"Aantal seconden waarna een sessie verloopt. Na het verlopen van de sessie is"
-" de gebruiker uitgelogd en kan zijn huidige inzending niet meer afmaken. "
+"Aantal seconden waarna een sessie verloopt. Na het verlopen van de sessie is "
+"de gebruiker uitgelogd en kan zijn huidige inzending niet meer afmaken. "
 "Opmerking: Bij elke interactie met de API wordt de sessie verlengd."
 
 #: openforms/api/drf_spectacular/hooks.py:29
@@ -550,8 +548,8 @@ msgid ""
 "If true, the user is allowed to navigate between submission steps even if "
 "previous submission steps have not been completed yet."
 msgstr ""
-"Indien waar, dan mag de gebruiker vrij binnen de formulierstappen navigeren,"
-" ook als de vorige stappen nog niet voltooid zijn."
+"Indien waar, dan mag de gebruiker vrij binnen de formulierstappen navigeren, "
+"ook als de vorige stappen nog niet voltooid zijn."
 
 #: openforms/api/drf_spectacular/hooks.py:45
 msgid "Language code of the currently activated language."
@@ -662,12 +660,12 @@ msgstr "Ping de API"
 
 #: openforms/api/views/views.py:60
 msgid ""
-"Pinging the API extends the user session. Note that you must be a staff user"
-" or have active submission(s) in your session."
+"Pinging the API extends the user session. Note that you must be a staff user "
+"or have active submission(s) in your session."
 msgstr ""
-"Door de API te pingen wordt de sessie van de gebruiker verlengd. Merk op dat"
-" je een actieve inzending in je sessie dient te hebben of ingelogd moet zijn"
-" in de beheerinterface."
+"Door de API te pingen wordt de sessie van de gebruiker verlengd. Merk op dat "
+"je een actieve inzending in je sessie dient te hebben of ingelogd moet zijn "
+"in de beheerinterface."
 
 #: openforms/appointments/admin.py:43
 msgid "Please configure the plugin first"
@@ -735,10 +733,10 @@ msgstr "Unieke sleutel van het product"
 #: openforms/contrib/objects_api/models.py:16
 #: openforms/dmn/api/serializers.py:76 openforms/forms/admin/form.py:271
 #: openforms/forms/admin/form_definition.py:69
-#: openforms/forms/models/category.py:13 openforms/forms/models/form.py:80
+#: openforms/forms/models/category.py:13 openforms/forms/models/form.py:87
 #: openforms/forms/models/form_definition.py:40
 #: openforms/forms/models/form_registration_backend.py:23
-#: openforms/forms/models/form_variable.py:257
+#: openforms/forms/models/form_variable.py:265
 #: openforms/multidomain/models.py:7 openforms/products/models/product.py:24
 #: openforms/registrations/contrib/zgw_apis/models.py:24
 msgid "name"
@@ -767,12 +765,11 @@ msgstr "Limiet aantal afspraakaanvragen"
 
 #: openforms/appointments/api/serializers.py:63
 msgid ""
-"The maximum number of times a user can request this appointment. Defaults to"
-" 0 (unlimited) if the plugin does not specify this."
+"The maximum number of times a user can request this appointment. Defaults to "
+"0 (unlimited) if the plugin does not specify this."
 msgstr ""
 "Het maximale aantal keren dat een gebruiker deze afspraak kan aanvragen. De "
-"standaardwaarde 0 (onbeperkt) wordt gebruikt als de plugin dit niet "
-"aangeeft."
+"standaardwaarde 0 (onbeperkt) wordt gebruikt als de plugin dit niet aangeeft."
 
 #: openforms/appointments/api/serializers.py:75
 msgid ""
@@ -885,13 +882,13 @@ msgid "Products"
 msgstr "Producten"
 
 #: openforms/appointments/api/serializers.py:173
-#: openforms/submissions/api/serializers.py:605
+#: openforms/submissions/api/serializers.py:608
 #: openforms/submissions/api/validation.py:63
 msgid "status check endpoint"
 msgstr "status controle endpoint"
 
 #: openforms/appointments/api/serializers.py:176
-#: openforms/submissions/api/serializers.py:607
+#: openforms/submissions/api/serializers.py:610
 #: openforms/submissions/api/validation.py:65
 msgid ""
 "The API endpoint where the background processing status can be checked. "
@@ -949,8 +946,7 @@ msgstr "Het geselecteerde tijdstip is niet (langer) beschikbaar."
 msgid "ID of the product, repeat for multiple products."
 msgstr "Product-ID, herhaal deze parameter voor meerdere producten."
 
-#: openforms/appointments/api/views.py:77
-#: openforms/products/api/viewsets.py:12
+#: openforms/appointments/api/views.py:77 openforms/products/api/viewsets.py:12
 msgid "List available products"
 msgstr "Producten weergeven"
 
@@ -1028,9 +1024,8 @@ msgid "Submission does not contain all the info needed to make an appointment"
 msgstr ""
 "Er ontbreken gegevens in de inzending om een afspraak te kunnen registreren."
 
-#: openforms/appointments/constants.py:11
-#: openforms/submissions/constants.py:15 openforms/submissions/constants.py:68
-#: openforms/translations/constants.py:9
+#: openforms/appointments/constants.py:11 openforms/submissions/constants.py:15
+#: openforms/submissions/constants.py:68 openforms/translations/constants.py:9
 msgid "Failed"
 msgstr "Mislukt"
 
@@ -1103,7 +1098,7 @@ msgid "First name"
 msgstr "Voornaam"
 
 #: openforms/appointments/contrib/jcc_rest/constants.py:39
-#: openforms/formio/rendering/default.py:440 stuf/stuf_bg/constants.py:29
+#: openforms/formio/rendering/default.py:435 stuf/stuf_bg/constants.py:29
 msgid "Initials"
 msgstr "Voorletters"
 
@@ -1113,8 +1108,8 @@ msgid "Last name prefix"
 msgstr "Voorvoegsel"
 
 #: openforms/appointments/contrib/jcc_rest/constants.py:54
-#: openforms/formio/rendering/default.py:455
-#: openforms/formio/rendering/default.py:576 stuf/stuf_bg/constants.py:50
+#: openforms/formio/rendering/default.py:450
+#: openforms/formio/rendering/default.py:571 stuf/stuf_bg/constants.py:50
 msgid "Date of birth"
 msgstr "Geboortedatum"
 
@@ -1239,7 +1234,7 @@ msgstr "Ongeldige pluginconfiguratie: {exc}"
 #: openforms/prefill/contrib/stufbg/plugin.py:222
 #: openforms/prefill/contrib/suwinet/plugin.py:98
 #: openforms/registrations/contrib/microsoft_graph/plugin.py:130
-#: openforms/registrations/contrib/stuf_zds/plugin.py:684
+#: openforms/registrations/contrib/stuf_zds/plugin.py:681
 #: openforms/submissions/api/serializers.py:313
 msgid "Configuration"
 msgstr "Configuratie"
@@ -1373,7 +1368,7 @@ msgid "The submission that made the appointment"
 msgstr "De inzending bij deze afspraak"
 
 #: openforms/appointments/models.py:68
-#: openforms/forms/models/form_version.py:56
+#: openforms/forms/models/form_version.py:79
 msgid "created"
 msgstr "aangemaakt"
 
@@ -1524,8 +1519,7 @@ msgid "The authentication attribute provided by this plugin."
 msgstr "Het authenticatie attribuut geleverd door deze plugin."
 
 #: openforms/authentication/api/serializers.py:28
-#: openforms/forms/api/viewsets.py:659
-#: openforms/payments/api/serializers.py:18
+#: openforms/forms/api/viewsets.py:659 openforms/payments/api/serializers.py:18
 #: openforms/registrations/api/serializers.py:13
 msgid "JSON schema"
 msgstr "JSON-schema"
@@ -1576,8 +1570,7 @@ msgid "..."
 msgstr "..."
 
 #: openforms/authentication/api/serializers.py:60
-#: openforms/dmn/api/serializers.py:17
-#: openforms/payments/api/serializers.py:25
+#: openforms/dmn/api/serializers.py:17 openforms/payments/api/serializers.py:25
 msgid "Identifier"
 msgstr "Unieke identificatie"
 
@@ -1646,8 +1639,8 @@ msgstr "Authenticatiemodule"
 #: openforms/authentication/constants.py:34
 #: openforms/authentication/constants.py:38
 #: openforms/authentication/contrib/demo/plugin.py:32
-#: openforms/formio/rendering/default.py:435
-#: openforms/formio/rendering/default.py:566 stuf/stuf_bg/constants.py:26
+#: openforms/formio/rendering/default.py:430
+#: openforms/formio/rendering/default.py:561 stuf/stuf_bg/constants.py:26
 msgid "BSN"
 msgstr "BSN"
 
@@ -1757,9 +1750,8 @@ msgstr "Claim pad"
 #: openforms/authentication/contrib/yivi_oidc/oidc_plugins/schemas.py:21
 #: openforms/authentication/contrib/yivi_oidc/oidc_plugins/schemas.py:53
 msgid ""
-"Path to the claim value holding the level of assurance. If left empty, it is"
-" assumed there is no LOA claim and the configured fallback value will be "
-"used."
+"Path to the claim value holding the level of assurance. If left empty, it is "
+"assumed there is no LOA claim and the configured fallback value will be used."
 msgstr ""
 "Naam van de claim die het betrouwbaardheidsniveau bevat. Als er geen waarde "
 "wordt opgegeven, wordt verondersteld dat er geen LOA-claim aanwezig is en "
@@ -1774,8 +1766,7 @@ msgstr "Standaardwaarden"
 #: openforms/authentication/contrib/digid_eherkenning_oidc/oidc_plugins/schemas.py:144
 #: openforms/authentication/contrib/yivi_oidc/oidc_plugins/schemas.py:33
 #: openforms/authentication/contrib/yivi_oidc/oidc_plugins/schemas.py:65
-msgid ""
-"Fallback level of assurance, in case no claim value could be extracted."
+msgid "Fallback level of assurance, in case no claim value could be extracted."
 msgstr ""
 "Standaardwaarde voor het betrouwbaarheidsniveau. Wordt gebruikt wanneer er "
 "geen claimwaarde kan worden verkregen."
@@ -1793,8 +1784,7 @@ msgstr "eIDAS identity instellingen."
 
 #: openforms/authentication/contrib/digid_eherkenning_oidc/oidc_plugins/schemas.py:60
 msgid ""
-"Path to the claim value holding the bsn identifier of the authenticated "
-"user."
+"Path to the claim value holding the bsn identifier of the authenticated user."
 msgstr "Naam van de claim die het BSN bevat van de geauthoriseerde gebruiker."
 
 #: openforms/authentication/contrib/digid_eherkenning_oidc/oidc_plugins/schemas.py:69
@@ -1814,8 +1804,8 @@ msgstr "voornaamclaim van de wettelijke vertegenwoordiger"
 
 #: openforms/authentication/contrib/digid_eherkenning_oidc/oidc_plugins/schemas.py:82
 msgid ""
-"Path to the claim value that holds the legal first name of the authenticated"
-" user."
+"Path to the claim value that holds the legal first name of the authenticated "
+"user."
 msgstr ""
 "Claim die de wettelijke achternaam van de geauthenticeerde gebruiker bevat"
 
@@ -1840,8 +1830,7 @@ msgid ""
 "Path to the claim value that holds the legal birthdate of the authenticated "
 "user."
 msgstr ""
-"Claim die de wettelijke geboortedatum van de geauthenticeerde gebruiker "
-"bevat"
+"Claim die de wettelijke geboortedatum van de geauthenticeerde gebruiker bevat"
 
 #: openforms/authentication/contrib/digid_eherkenning_oidc/oidc_plugins/schemas.py:120
 msgid "OIDC eIDAS company configuration options."
@@ -1904,10 +1893,8 @@ msgstr "geboortedatumclaim van de handelende persoon"
 
 #: openforms/authentication/contrib/digid_eherkenning_oidc/oidc_plugins/schemas.py:241
 msgid ""
-"Path to the claim value that holds the legal birthdate of the acting "
-"subject."
-msgstr ""
-"Claim die de wettelijke geboortedatum van de handelende persoon bevat."
+"Path to the claim value that holds the legal birthdate of the acting subject."
+msgstr "Claim die de wettelijke geboortedatum van de handelende persoon bevat."
 
 #: openforms/authentication/contrib/digid_eherkenning_oidc/oidc_plugins/schemas.py:250
 msgid "Mandate service id claim path"
@@ -1967,8 +1954,8 @@ msgstr "eIDAS"
 
 #: openforms/authentication/contrib/eherkenning/views.py:44
 msgid ""
-"Login failed due to no KvK number/Pseudo ID being returned by "
-"eHerkenning/eIDAS."
+"Login failed due to no KvK number/Pseudo ID being returned by eHerkenning/"
+"eIDAS."
 msgstr ""
 "Inloggen mislukt omdat er geen geldig KvK-nummer/Pseudo-ID terugkwam uit "
 "eHerkenning."
@@ -2075,17 +2062,16 @@ msgstr ""
 #: openforms/authentication/contrib/yivi_oidc/models.py:20
 #: openforms/config/models/map.py:64 openforms/config/models/theme.py:26
 #: openforms/forms/api/serializers/logic/action_serializers.py:214
-#: openforms/forms/models/category.py:10 openforms/forms/models/form.py:79
-#: openforms/forms/models/form.py:828
+#: openforms/forms/models/category.py:10 openforms/forms/models/form.py:86
+#: openforms/forms/models/form.py:893
 #: openforms/forms/models/form_definition.py:39
 #: openforms/forms/models/form_step.py:27
-#: openforms/forms/models/form_version.py:44
-#: openforms/forms/models/logic.py:22 openforms/payments/models.py:99
-#: openforms/products/models/product.py:19
-#: openforms/submissions/models/submission.py:136
-#: openforms/submissions/models/submission_files.py:53
-#: openforms/submissions/models/submission_files.py:144
-#: openforms/submissions/models/submission_step.py:94
+#: openforms/forms/models/form_version.py:67 openforms/forms/models/logic.py:22
+#: openforms/payments/models.py:99 openforms/products/models/product.py:19
+#: openforms/submissions/models/submission.py:134
+#: openforms/submissions/models/submission_files.py:51
+#: openforms/submissions/models/submission_files.py:200
+#: openforms/submissions/models/submission_step.py:102
 msgid "UUID"
 msgstr "UUID"
 
@@ -2095,8 +2081,8 @@ msgstr "groepsbeschrijving"
 
 #: openforms/authentication/contrib/yivi_oidc/models.py:25
 msgid ""
-"A longer human-readable description for the group of attributes, used in the"
-" form configuration."
+"A longer human-readable description for the group of attributes, used in the "
+"form configuration."
 msgstr ""
 "Een beschrijving van de attributengroep die wordt gebruikt in de "
 "formulierconfiguratie."
@@ -2112,8 +2098,8 @@ msgstr "attributen"
 
 #: openforms/authentication/contrib/yivi_oidc/models.py:41
 msgid ""
-"List of attributes that will be requested from the user. The user can choose"
-" whether to grant access to all these attributes, or none. If you want "
+"List of attributes that will be requested from the user. The user can choose "
+"whether to grant access to all these attributes, or none. If you want "
 "individually optional attributes, you should define them as separate "
 "attribute groups."
 msgstr ""
@@ -2158,9 +2144,9 @@ msgid ""
 "claim are proprietary, so you can translate them into their standardized "
 "identifiers."
 msgstr ""
-"Claim-waardekoppeling voor betrouwbaarheidsniveaus. Dit is nuttig wanneer de"
-" waarden in de LOA-claim eigen of niet-standaard zijn, zodat ze kunnen "
-"worden omgezet naar gestandaardiseerde identificaties."
+"Claim-waardekoppeling voor betrouwbaarheidsniveaus. Dit is nuttig wanneer de "
+"waarden in de LOA-claim eigen of niet-standaard zijn, zodat ze kunnen worden "
+"omgezet naar gestandaardiseerde identificaties."
 
 #: openforms/authentication/contrib/yivi_oidc/oidc_plugins/schemas.py:51
 msgid "KvK loa claim path"
@@ -2289,7 +2275,7 @@ msgstr "Authenticatiedetails"
 #: openforms/authentication/models.py:416 openforms/emails/constants.py:17
 #: openforms/formio/api/serializers.py:33
 #: openforms/payments/contrib/worldline/plugin.py:110
-#: openforms/submissions/api/serializers.py:807
+#: openforms/submissions/api/serializers.py:810
 msgid "Submission"
 msgstr "Inzending"
 
@@ -2304,8 +2290,7 @@ msgstr "Betrouwbaarheidsniveau"
 
 #: openforms/authentication/models.py:167
 msgid ""
-"How certain is the identity provider that this identity belongs to this "
-"user."
+"How certain is the identity provider that this identity belongs to this user."
 msgstr ""
 "Indicatie van de mate van zekerheid over de identiteit van de gebruiker, "
 "afgegeven door de identity provider."
@@ -2402,8 +2387,8 @@ msgstr "Inzending registrator: {plugin}::{attr}"
 msgid "You must be logged in to start this form."
 msgstr "Je moet ingelogd zijn om dit formulier te starten."
 
-#: openforms/authentication/signals.py:93
-#: openforms/authentication/views.py:202 openforms/authentication/views.py:369
+#: openforms/authentication/signals.py:93 openforms/authentication/views.py:202
+#: openforms/authentication/views.py:369
 msgid "Demo plugins require an active admin session."
 msgstr "Om demo-plugins te gebruiken moet je als beheerder ingelogd zijn."
 
@@ -2477,8 +2462,7 @@ msgid "Authentication context data: branch number"
 msgstr "Authenticatiecontext: vestigingsnummer"
 
 #: openforms/authentication/static_variables/static_variables.py:375
-msgid ""
-"Authentication context data: authorizee, acting subject identifier type"
+msgid "Authentication context data: authorizee, acting subject identifier type"
 msgstr ""
 "Authenticatiecontext: gemachtigde, identificatiesoort van de handelende "
 "persoon"
@@ -2502,8 +2486,8 @@ msgid ""
 "When filling out a form for a client or company please enter additional "
 "information."
 msgstr ""
-"Wanneer je een formulier invult voor een klant (burger of bedrijf), geef dan"
-" extra informatie op."
+"Wanneer je een formulier invult voor een klant (burger of bedrijf), geef dan "
+"extra informatie op."
 
 #: openforms/authentication/templates/of_authentication/registrator_subject_info.html:35
 #: openforms/authentication/templates/of_authentication/registrator_subject_info.html:49
@@ -2518,7 +2502,8 @@ msgstr "Start het authenticatie proces"
 msgid ""
 "This endpoint is the internal redirect target to start external login flow.\n"
 "\n"
-"Note that this is NOT a JSON 'endpoint', but rather the browser should be redirected to this URL and will in turn receive another redirect.\n"
+"Note that this is NOT a JSON 'endpoint', but rather the browser should be "
+"redirected to this URL and will in turn receive another redirect.\n"
 "\n"
 "Various validations are performed:\n"
 "* the form must be live\n"
@@ -2527,9 +2512,11 @@ msgid ""
 "* the `next` parameter must be present\n"
 "* the `next` parameter must match the CORS policy"
 msgstr ""
-"Dit endpoint is het doel van de interne redirect om het externe login proces te starten.\n"
+"Dit endpoint is het doel van de interne redirect om het externe login proces "
+"te starten.\n"
 "\n"
-"Merk op dat dit GEEN typische JSON-endpoint betreft maar een endpoint waarnaar toe geredirect wordt en zelf ook een redirect teruggeeft.\n"
+"Merk op dat dit GEEN typische JSON-endpoint betreft maar een endpoint "
+"waarnaar toe geredirect wordt en zelf ook een redirect teruggeeft.\n"
 "\n"
 "Diverse validaties worden uitgevoerd:\n"
 "* het formulier is actief\n"
@@ -2544,8 +2531,8 @@ msgstr "URL-deel dat het formulier identificeert."
 
 #: openforms/authentication/views.py:114
 msgid ""
-"Identifier of the authentication plugin. Note that this is validated against"
-" the configured available plugins for this particular form."
+"Identifier of the authentication plugin. Note that this is validated against "
+"the configured available plugins for this particular form."
 msgstr ""
 "Unieke identificatie van de authenticatieplugin. Merk op dat deze waarde "
 "gevalideerd wordt met de beschikbare plugins voor dit formulier."
@@ -2571,8 +2558,8 @@ msgid ""
 "URL of the external authentication service where the end-user will be "
 "redirected to. The value is specific to the selected authentication plugin."
 msgstr ""
-"URL van de externe authenticatie service waar de gebruiker naar toe verwezen"
-" wordt. Deze waarde is specifiek voor de geselecteerde authenticatieplugin"
+"URL van de externe authenticatie service waar de gebruiker naar toe verwezen "
+"wordt. Deze waarde is specifiek voor de geselecteerde authenticatieplugin"
 
 #: openforms/authentication/views.py:155
 msgid "OK. A login page is rendered."
@@ -2593,8 +2580,8 @@ msgid ""
 "Method not allowed. The authentication plugin requires `POST` or `GET`, and "
 "the wrong method was used."
 msgstr ""
-"Methode niet toegestaan. De authenticatieplugin moet worden benaderd middels"
-" een `POST` of `GET`."
+"Methode niet toegestaan. De authenticatieplugin moet worden benaderd middels "
+"een `POST` of `GET`."
 
 #: openforms/authentication/views.py:270
 msgid "Return from external login flow"
@@ -2602,9 +2589,12 @@ msgstr "Aanroeppunt van het externe login proces"
 
 #: openforms/authentication/views.py:272
 msgid ""
-"Authentication plugins call this endpoint in the return step of the authentication flow. Depending on the plugin, either `GET` or `POST` is allowed as HTTP method.\n"
+"Authentication plugins call this endpoint in the return step of the "
+"authentication flow. Depending on the plugin, either `GET` or `POST` is "
+"allowed as HTTP method.\n"
 "\n"
-"Typically authentication plugins will redirect again to the URL where the SDK is embedded.\n"
+"Typically authentication plugins will redirect again to the URL where the "
+"SDK is embedded.\n"
 "\n"
 "Various validations are performed:\n"
 "* the form must be live\n"
@@ -2612,7 +2602,9 @@ msgid ""
 "* logging in is required on the form\n"
 "* the redirect target must match the CORS policy"
 msgstr ""
-"Authenticatieplugins roepen dit endpoint aan zodra het externe login proces is afgerond. Afhankelijk van de plugin, een `POST` of `GET` is toegestaan als HTTP-methode.\n"
+"Authenticatieplugins roepen dit endpoint aan zodra het externe login proces "
+"is afgerond. Afhankelijk van de plugin, een `POST` of `GET` is toegestaan "
+"als HTTP-methode.\n"
 "\n"
 "Authenticatieplugins zullen typisch een redirect uitvoeren naar de SDK.\n"
 "\n"
@@ -2761,8 +2753,7 @@ msgid ""
 "to accept before submitting a form."
 msgstr ""
 "Eén enkel Form.io selectievakjecomponent voor de verklaring die een "
-"gebruiker mogelijks moet accepteren voor het formulier ingestuurd kan "
-"worden."
+"gebruiker mogelijks moet accepteren voor het formulier ingestuurd kan worden."
 
 #: openforms/config/api/constants.py:19
 msgid "Component type (checkbox)"
@@ -2792,8 +2783,8 @@ msgid ""
 "The formatted label to use next to the checkbox when asking the user to "
 "agree to the privacy policy."
 msgstr ""
-"Het opgemaakte label dat naast het selectievakje moet worden getoond wanneer"
-" de gebruiker wordt gevraagd akkoord te gaan met het privacybeleid."
+"Het opgemaakte label dat naast het selectievakje moet worden getoond wanneer "
+"de gebruiker wordt gevraagd akkoord te gaan met het privacybeleid."
 
 #: openforms/config/api/viewsets.py:11
 msgid "List available themes"
@@ -2964,21 +2955,20 @@ msgstr "Paginatitel inzendingsbevestiging"
 
 #: openforms/config/models/config.py:67
 msgid ""
-"The content of the confirmation page title. You can (and should) include the"
-" 'public_reference' variable (using expression '{{ public_reference }}') so "
-"the users have a reference in case they need to contact the customer "
-"service."
+"The content of the confirmation page title. You can (and should) include the "
+"'public_reference' variable (using expression '{{ public_reference }}') so "
+"the users have a reference in case they need to contact the customer service."
 msgstr ""
 "De inhoud van de bevestigingspaginatitel. De 'public_reference' "
-"sjablooninstructie is beschikbaar (gebruik de expressie '{{ public_reference"
-" }}') en we adviseren om deze weer te geven zodat gebruikers een referentie "
-"hebben als ze de klantenservice moeten contacteren."
+"sjablooninstructie is beschikbaar (gebruik de expressie "
+"'{{ public_reference }}') en we adviseren om deze weer te geven zodat "
+"gebruikers een referentie hebben als ze de klantenservice moeten contacteren."
 
 #: openforms/config/models/config.py:72
 msgid "Confirmation: {{ public_reference }}"
 msgstr "Bevestiging: {{ public_reference }}"
 
-#: openforms/config/models/config.py:76 openforms/forms/models/form.py:170
+#: openforms/config/models/config.py:76 openforms/forms/models/form.py:177
 msgid "submission confirmation template"
 msgstr "Bevestigingspagina tekst"
 
@@ -2987,8 +2977,8 @@ msgid ""
 "The content of the submission confirmation page. It can contain variables "
 "that will be templated from the submitted form data."
 msgstr ""
-"De inhoud van bevestigingspagina kan variabelen bevatten die op basis van de"
-" ingediende formuliergegevens worden weergegeven. "
+"De inhoud van bevestigingspagina kan variabelen bevatten die op basis van de "
+"ingediende formuliergegevens worden weergegeven. "
 
 #: openforms/config/models/config.py:81
 msgid "Thank you for submitting this form."
@@ -3000,8 +2990,7 @@ msgstr "titel downloadlink inzendings-PDF"
 
 #: openforms/config/models/config.py:87
 msgid "The title of the link to download the report of a submission."
-msgstr ""
-"Titel/tekst van de downloadlink om de inzending als PDF te downloaden."
+msgstr "Titel/tekst van de downloadlink om de inzending als PDF te downloaden."
 
 #: openforms/config/models/config.py:88
 msgid "Download PDF"
@@ -3031,15 +3020,15 @@ msgstr "Mede-ondertekenenbevestigingspagina tekst"
 msgid ""
 "The content of the submission confirmation page for submissions requiring "
 "cosigning. The variables 'public_reference' and 'cosigner_email' are "
-"available (using expressions '{{ public_reference }}' and '{{ cosigner_email"
-" }}', respectively). We strongly advise you to include the "
+"available (using expressions '{{ public_reference }}' and "
+"'{{ cosigner_email }}', respectively). We strongly advise you to include the "
 "'public_reference' in case users need to contact the customer service."
 msgstr ""
 "De inhoud van de bevestigingspagina wanneer de inzending mede-ondertekend "
 "moet worden. Je kan de variabelen 'public_reference' en 'cosigner_email' "
-"gebruiken (gebruik de expressies '{{ public_reference }}' en '{{ "
-"cosigner_email }}'). We raden sterk aan om de publieke referentie weer te "
-"geven zodat gebruikers hiernaar kunnen verwijzen als ze de klantenservice "
+"gebruiken (gebruik de expressies '{{ public_reference }}' en "
+"'{{ cosigner_email }}'). We raden sterk aan om de publieke referentie weer "
+"te geven zodat gebruikers hiernaar kunnen verwijzen als ze de klantenservice "
 "moeten contacteren."
 
 #: openforms/config/models/config.py:120 openforms/config/models/config.py:146
@@ -3058,8 +3047,8 @@ msgstr ""
 
 #: openforms/config/models/config.py:129 openforms/config/models/config.py:153
 #: openforms/config/models/config.py:211 openforms/emails/models.py:50
-#: openforms/submissions/models/submission_files.py:61
-#: openforms/submissions/models/submission_files.py:187
+#: openforms/submissions/models/submission_files.py:59
+#: openforms/submissions/models/submission_files.py:258
 #: openforms/submissions/models/submission_report.py:21
 msgid "content"
 msgstr "inhoud"
@@ -3135,8 +3124,8 @@ msgid ""
 "without any initiator. Otherwise, a fake initiator is added with BSN "
 "111222333."
 msgstr ""
-"Indien aangevinkt en de inzender is niet geauthenticeerd, dan wordt een zaak"
-" aangemaakt zonder initiator. Indien uitgevinkt, dan zal een nep-initiator "
+"Indien aangevinkt en de inzender is niet geauthenticeerd, dan wordt een zaak "
+"aangemaakt zonder initiator. Indien uitgevinkt, dan zal een nep-initiator "
 "worden toegevoegd met BSN 111222333."
 
 #: openforms/config/models/config.py:231
@@ -3154,7 +3143,7 @@ msgid ""
 msgstr ""
 "Het label van de knop op de overzichtspagina om naar de vorige stap te gaan."
 
-#: openforms/config/models/config.py:240 openforms/forms/models/form.py:271
+#: openforms/config/models/config.py:240 openforms/forms/models/form.py:278
 msgid "change text"
 msgstr "Stap wijzigen-label"
 
@@ -3164,12 +3153,11 @@ msgstr "Wijzigen"
 
 #: openforms/config/models/config.py:244
 msgid ""
-"The text that will be displayed in the overview page to change a certain "
-"step"
+"The text that will be displayed in the overview page to change a certain step"
 msgstr ""
 "Het label de link op de overzichtspagina om een bepaalde stap te wijzigen"
 
-#: openforms/config/models/config.py:249 openforms/forms/models/form.py:281
+#: openforms/config/models/config.py:249 openforms/forms/models/form.py:288
 msgid "confirm text"
 msgstr "Formulier verzenden-label"
 
@@ -3185,7 +3173,7 @@ msgid ""
 msgstr ""
 "Het label van de knop op de overzichtspagina om het formulier in te dienen"
 
-#: openforms/config/models/config.py:258 openforms/forms/models/form.py:251
+#: openforms/config/models/config.py:258 openforms/forms/models/form.py:258
 msgid "begin text"
 msgstr "Formulier starten-label"
 
@@ -3209,8 +3197,7 @@ msgid ""
 msgstr ""
 "Het label van de knop om naar de vorige stap binnen het formulier te gaan"
 
-#: openforms/config/models/config.py:276
-#: openforms/forms/models/form_step.py:51
+#: openforms/config/models/config.py:276 openforms/forms/models/form_step.py:51
 msgid "step save text"
 msgstr "Opslaan-label"
 
@@ -3224,8 +3211,7 @@ msgid ""
 "information"
 msgstr "Het label van de knop om het formulier tussentijds op te slaan"
 
-#: openforms/config/models/config.py:284
-#: openforms/forms/models/form_step.py:60
+#: openforms/config/models/config.py:284 openforms/forms/models/form_step.py:60
 msgid "step next text"
 msgstr "Volgende stap-label"
 
@@ -3234,8 +3220,7 @@ msgid "Next"
 msgstr "Volgende"
 
 #: openforms/config/models/config.py:288
-msgid ""
-"The text that will be displayed in the form step to go to the next step"
+msgid "The text that will be displayed in the form step to go to the next step"
 msgstr ""
 "Het label van de knop om naar de volgende stap binnen het formulier te gaan"
 
@@ -3257,11 +3242,11 @@ msgstr "Markeer verplichte velden met een asterisk"
 #: openforms/config/models/config.py:302
 msgid ""
 "If checked, required fields are marked with an asterisk and optional fields "
-"are unmarked. If unchecked, optional fields will be marked with '(optional)'"
-" and required fields are unmarked."
+"are unmarked. If unchecked, optional fields will be marked with '(optional)' "
+"and required fields are unmarked."
 msgstr ""
-"Indien aangevinkt, dan zijn verplichte velden gemarkeerd met een asterisk en"
-" optionele velden niet gemarkeerd. Indien uitgevinkt, dan zijn optionele "
+"Indien aangevinkt, dan zijn verplichte velden gemarkeerd met een asterisk en "
+"optionele velden niet gemarkeerd. Indien uitgevinkt, dan zijn optionele "
 "velden gemarkeerd met '(niet verplicht)' en verplichte velden ongemarkeerd."
 
 #: openforms/config/models/config.py:309
@@ -3287,8 +3272,8 @@ msgid ""
 "displayed but marked as non-applicable.)"
 msgstr ""
 "Indien aangevinkt, dan worden stappen die (via logicaregels) niet van "
-"toepassing zijn verborgen. Standaard zijn deze zichtbaar maar gemarkeerd als"
-" n.v.t."
+"toepassing zijn verborgen. Standaard zijn deze zichtbaar maar gemarkeerd als "
+"n.v.t."
 
 #: openforms/config/models/config.py:326
 msgid "The default zoom level for the leaflet map."
@@ -3303,8 +3288,8 @@ msgstr ""
 #: openforms/config/models/config.py:339
 msgid "The default longitude for the leaflet map."
 msgstr ""
-"Standaard longitude voor kaartmateriaal (in coördinatenstelsel EPSG:4326/WGS"
-" 84)."
+"Standaard longitude voor kaartmateriaal (in coördinatenstelsel EPSG:4326/WGS "
+"84)."
 
 #: openforms/config/models/config.py:352
 msgid "default theme"
@@ -3337,8 +3322,8 @@ msgstr "hoofdsite link"
 msgid ""
 "URL to the main website. Used for the 'back to municipality website' link."
 msgstr ""
-"URL naar de hoofdsite van de organisatie. Wordt gebruikt voor 'terug naar de"
-" gemeentewebsite' link."
+"URL naar de hoofdsite van de organisatie. Wordt gebruikt voor 'terug naar de "
+"gemeentewebsite' link."
 
 #: openforms/config/models/config.py:375 openforms/config/models/theme.py:32
 msgid "organization name"
@@ -3380,8 +3365,7 @@ msgid ""
 "Due to DigiD requirements this value has to be less than or equal to "
 "%(limit_value)s minutes."
 msgstr ""
-"Om veiligheidsredenen mag de waarde niet groter zijn %(limit_value)s "
-"minuten."
+"Om veiligheidsredenen mag de waarde niet groter zijn %(limit_value)s minuten."
 
 #: openforms/config/models/config.py:415
 msgid ""
@@ -3397,19 +3381,19 @@ msgstr "Betaling: bestellingsnummersjabloon"
 #, python-brace-format
 msgid ""
 "Template to use when generating payment order IDs. It should be alpha-"
-"numerical and can contain the '/._-' characters. You can use the placeholder"
-" tokens: {year}, {public_reference}, {uid}."
+"numerical and can contain the '/._-' characters. You can use the placeholder "
+"tokens: {year}, {public_reference}, {uid}."
 msgstr ""
 "Sjabloon voor de generatie van unieke betalingsreferenties. Het sjabloon "
 "moet alfanumeriek zijn en mag de karakters '/._-' bevatten. De placeholder "
 "tokens {year}, {public_reference} en {uid} zijn beschikbaar. Het sjabloon "
 "moet de placeholder {uid} bevatten."
 
-#: openforms/config/models/config.py:434 openforms/forms/models/form.py:230
+#: openforms/config/models/config.py:434 openforms/forms/models/form.py:237
 msgid "ask privacy consent"
 msgstr "vraag toestemming om gegevens te verwerken"
 
-#: openforms/config/models/config.py:437 openforms/forms/models/form.py:235
+#: openforms/config/models/config.py:437 openforms/forms/models/form.py:242
 msgid ""
 "If enabled, the user will have to agree to the privacy policy before "
 "submitting a form."
@@ -3442,14 +3426,14 @@ msgid ""
 "Yes, I have read the {% privacy_policy %} and explicitly agree to the "
 "processing of my submitted information."
 msgstr ""
-"Ja, ik heb kennis genomen van het {% privacy_policy %} en geef uitdrukkelijk"
-" toestemming voor het verwerken van de door mij opgegeven gegevens."
+"Ja, ik heb kennis genomen van het {% privacy_policy %} en geef uitdrukkelijk "
+"toestemming voor het verwerken van de door mij opgegeven gegevens."
 
-#: openforms/config/models/config.py:467 openforms/forms/models/form.py:239
+#: openforms/config/models/config.py:467 openforms/forms/models/form.py:246
 msgid "ask statement of truth"
 msgstr "vraag waarheidsverklaring"
 
-#: openforms/config/models/config.py:470 openforms/forms/models/form.py:244
+#: openforms/config/models/config.py:470 openforms/forms/models/form.py:251
 msgid ""
 "If enabled, the user will have to agree that they filled out the form "
 "truthfully before submitting it."
@@ -3478,7 +3462,7 @@ msgstr ""
 "Ik verklaar dat ik deze aanvraag naar waarheid heb ingevuld en geen "
 "informatie heb verzwegen."
 
-#: openforms/config/models/config.py:492 openforms/forms/models/form.py:335
+#: openforms/config/models/config.py:492 openforms/forms/models/form.py:342
 msgid "successful submission removal limit"
 msgstr "bewaartermijn voor voltooide inzendingen."
 
@@ -3486,7 +3470,7 @@ msgstr "bewaartermijn voor voltooide inzendingen."
 msgid "Amount of days successful submissions will remain before being removed"
 msgstr "Aantal dagen dat een voltooide inzending bewaard blijft."
 
-#: openforms/config/models/config.py:500 openforms/forms/models/form.py:345
+#: openforms/config/models/config.py:500 openforms/forms/models/form.py:352
 msgid "successful submissions removal method"
 msgstr "opschoonmethode voor voltooide inzendingen"
 
@@ -3495,7 +3479,7 @@ msgid "How successful submissions will be removed after the limit"
 msgstr ""
 "Geeft aan hoe voltooide inzendingen worden opgeschoond na de bewaartermijn."
 
-#: openforms/config/models/config.py:507 openforms/forms/models/form.py:355
+#: openforms/config/models/config.py:507 openforms/forms/models/form.py:362
 msgid "incomplete submission removal limit"
 msgstr "bewaartermijn voor sessies"
 
@@ -3503,7 +3487,7 @@ msgstr "bewaartermijn voor sessies"
 msgid "Amount of days incomplete submissions will remain before being removed"
 msgstr "Aantal dagen dat een sessie bewaard blijft."
 
-#: openforms/config/models/config.py:515 openforms/forms/models/form.py:365
+#: openforms/config/models/config.py:515 openforms/forms/models/form.py:372
 msgid "incomplete submissions removal method"
 msgstr "opschoonmethode voor sessies."
 
@@ -3511,8 +3495,8 @@ msgstr "opschoonmethode voor sessies."
 msgid "How incomplete submissions will be removed after the limit"
 msgstr "Geeft aan hoe sessies worden opgeschoond na de bewaartermijn."
 
-#: openforms/config/models/config.py:522 openforms/forms/models/form.py:375
-#: openforms/forms/models/form.py:385
+#: openforms/config/models/config.py:522 openforms/forms/models/form.py:382
+#: openforms/forms/models/form.py:392
 msgid "errored submission removal limit"
 msgstr "bewaartermijn voor niet voltooide inzendingen"
 
@@ -3532,7 +3516,7 @@ msgstr ""
 "Geeft aan hoe niet voltooide inzendingen (door fouten in de afhandeling) "
 "worden opgeschoond na de bewaartermijn."
 
-#: openforms/config/models/config.py:537 openforms/forms/models/form.py:395
+#: openforms/config/models/config.py:537 openforms/forms/models/form.py:402
 msgid "all submissions removal limit"
 msgstr "bewaartermijn van inzendingen"
 
@@ -3576,9 +3560,9 @@ msgid ""
 "selected services will be shown as options when configuring select or "
 "selectboxes components to be populated from Referentielijsten."
 msgstr ""
-"Selecteer de services die referentielijsten ontsluiten. Je kan vervolgens in"
-" de formuliercomponenten uit deze lijst van services een optie selecteren om"
-" de keuzeopties uit de referentielijsten op te halen."
+"Selecteer de services die referentielijsten ontsluiten. Je kan vervolgens in "
+"de formuliercomponenten uit deze lijst van services een optie selecteren om "
+"de keuzeopties uit de referentielijsten op te halen."
 
 #: openforms/config/models/config.py:573
 msgid "family members data api"
@@ -3679,8 +3663,8 @@ msgstr "Publiek referentiesjabloon"
 #, python-brace-format
 msgid ""
 "Template to use when generating public reference of the submission. It "
-"should be alpha-numerical and can contain the '/._-' characters. You can use"
-" the placeholder tokens: {year}, {uid}."
+"should be alpha-numerical and can contain the '/._-' characters. You can use "
+"the placeholder tokens: {year}, {uid}."
 msgstr ""
 "Sjabloon voor de generatie van de publieke referentie voor een inzending. "
 "Het sjabloon moet alfanumeriek zijn en mag de karakters '/._-' bevatten. De "
@@ -3736,8 +3720,8 @@ msgstr ""
 "worden."
 
 #: openforms/config/models/csp.py:85
-#: openforms/submissions/models/submission_files.py:66
-#: openforms/submissions/models/submission_files.py:197
+#: openforms/submissions/models/submission_files.py:64
+#: openforms/submissions/models/submission_files.py:268
 msgid "content type"
 msgstr "content type"
 
@@ -3756,15 +3740,15 @@ msgstr "achtergrondlaag-URL"
 #: openforms/config/models/map.py:29
 #, python-brace-format
 msgid ""
-"URL to the tile layer image, used to define the map component background. To"
-" ensure correct functionality of the map, EPSG 28992 projection should be "
-"used. Example value: "
-"https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png"
+"URL to the tile layer image, used to define the map component background. To "
+"ensure correct functionality of the map, EPSG 28992 projection should be "
+"used. Example value: https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/"
+"standaard/EPSG:28992/{z}/{x}/{y}.png"
 msgstr ""
-"URL naar de tegels van de achtergrondlaag van de kaart. Om de juiste werking"
-" te garanderen moet de laag de EPSG:28992-projectie gebruiken. Bijvoorbeeld:"
-" "
-"https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png"
+"URL naar de tegels van de achtergrondlaag van de kaart. Om de juiste werking "
+"te garanderen moet de laag de EPSG:28992-projectie gebruiken. Bijvoorbeeld: "
+"https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/"
+"{z}/{x}/{y}.png"
 
 #: openforms/config/models/map.py:39
 msgid "An easily recognizable name for the tile layer, used to identify it."
@@ -3791,12 +3775,13 @@ msgstr ""
 msgid ""
 "URL to collect the WMS tile layer capabilities. To ensure correct "
 "functionality of the map, EPSG 28992 projection should be available on the "
-"WMS tile layer. Example value: "
-"https://service.pdok.nl/lv/bag/wms/v2_0?request=getCapabilities&service=WMS"
+"WMS tile layer. Example value: https://service.pdok.nl/lv/bag/wms/v2_0?"
+"request=getCapabilities&service=WMS"
 msgstr ""
 "URL naar de tegels van de WMS-kaartlaag. Om de juiste werking te garanderen "
-"moet de laag de EPSG:28992-projectie gebruiken. Bijvoorbeeld: "
-"https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png"
+"moet de laag de EPSG:28992-projectie gebruiken. Bijvoorbeeld: https://"
+"service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/"
+"{y}.png"
 
 #: openforms/config/models/map.py:91
 msgid "WMS layer"
@@ -3826,15 +3811,15 @@ msgid ""
 "If left blank, the matching configuration option from the global "
 "configuration is used."
 msgstr ""
-"URL naar de hoofdsite van de organisatie. Wordt gebruikt voor de 'terug naar"
-" de gemeentewebsite' link. Als je dit leeglaat, dan wordt de algemene "
+"URL naar de hoofdsite van de organisatie. Wordt gebruikt voor de 'terug naar "
+"de gemeentewebsite' link. Als je dit leeglaat, dan wordt de algemene "
 "instelling gebruikt."
 
 #: openforms/config/models/theme.py:55
 msgid ""
-"Allow the uploading of a favicon, .png .jpg .svg and .ico are compatible. If"
-" left blank, the matching configuration option from the global configuration"
-" is used."
+"Allow the uploading of a favicon, .png .jpg .svg and .ico are compatible. If "
+"left blank, the matching configuration option from the global configuration "
+"is used."
 msgstr ""
 "Upload het favicon voor de applicatie. Enkel .png, .jpg, .svg en .ico "
 "bestanden zijn toegestaan. Als je dit leeglaat, dan wordt de algemene "
@@ -3861,8 +3846,8 @@ msgid ""
 "Upload the email logo, visible to users who receive an email. We advise "
 "dimensions around 150px by 75px. SVG's are not permitted."
 msgstr ""
-"Upload het logo van de gemeente dat zichtbaar is in e-mails. We adviseren de"
-" dimensies van 150 x 75 pixels. SVG-bestanden zijn niet toegestaan."
+"Upload het logo van de gemeente dat zichtbaar is in e-mails. We adviseren de "
+"dimensies van 150 x 75 pixels. SVG-bestanden zijn niet toegestaan."
 
 #: openforms/config/models/theme.py:93
 msgid "theme CSS class name"
@@ -3871,8 +3856,7 @@ msgstr "Thema CSS class name"
 #: openforms/config/models/theme.py:95
 msgid "If provided, this class name will be set on the <html> element."
 msgstr ""
-"Indien ingevuld, dan wordt deze class name aan het <html> element "
-"toegevoegd."
+"Indien ingevuld, dan wordt deze class name aan het <html> element toegevoegd."
 
 #: openforms/config/models/theme.py:98
 msgid "theme stylesheet URL"
@@ -3887,14 +3871,14 @@ msgid ""
 "The URL stylesheet with theme-specific rules for your organization. This "
 "will be included as final stylesheet, overriding previously defined styles. "
 "Note that you also have to include the host to the `style-src` CSP "
-"directive. Example value: https://unpkg.com/@utrecht/design-"
-"tokens@1.0.0-alpha.20/dist/index.css."
+"directive. Example value: https://unpkg.com/@utrecht/design-tokens@1.0.0-"
+"alpha.20/dist/index.css."
 msgstr ""
-"URL naar de stylesheet met thema-specifieke regels voor uw organisatie. Deze"
-" stylesheet wordt als laatste ingeladen, waarbij eerdere stijlregels dus "
+"URL naar de stylesheet met thema-specifieke regels voor uw organisatie. Deze "
+"stylesheet wordt als laatste ingeladen, waarbij eerdere stijlregels dus "
 "overschreven worden. Vergeet niet dat u ook de host van deze URL aan de "
-"`style-src` CSP configuratie moet toevoegen. Voorbeeldwaarde: "
-"https://unpkg.com/@utrecht/design-tokens@1.0.0-alpha.20/dist/index.css."
+"`style-src` CSP configuratie moet toevoegen. Voorbeeldwaarde: https://"
+"unpkg.com/@utrecht/design-tokens@1.0.0-alpha.20/dist/index.css."
 
 #: openforms/config/models/theme.py:115
 msgid "theme stylesheet"
@@ -3924,14 +3908,14 @@ msgid ""
 "forms.readthedocs.io/en/latest/installation/form_hosting.html#run-time-"
 "configuration for documentation."
 msgstr ""
-"Waarden met diverse stijl parameters, zoals randen, achtergrondkleuren, etc."
-" Dit is voor geavanceerde gebruikers. Attributen die niet zijn opgegeven "
-"vallen terug op standaardwaarden. Zie https://open-"
-"forms.readthedocs.io/en/latest/installation/form_hosting.html#run-time-"
-"configuration voor documentatie."
+"Waarden met diverse stijl parameters, zoals randen, achtergrondkleuren, etc. "
+"Dit is voor geavanceerde gebruikers. Attributen die niet zijn opgegeven "
+"vallen terug op standaardwaarden. Zie https://open-forms.readthedocs.io/en/"
+"latest/installation/form_hosting.html#run-time-configuration voor "
+"documentatie."
 
 #: openforms/config/models/theme.py:156
-#: openforms/forms/api/serializers/form.py:182
+#: openforms/forms/api/serializers/form.py:185
 msgid "theme"
 msgstr "stijl"
 
@@ -3942,7 +3926,7 @@ msgstr "stijlen"
 #: openforms/config/templates/admin/config/overview.html:8
 #: openforms/config/templates/admin/config/theme/preview.html:13
 #: openforms/forms/templates/admin/forms/form/export.html:13
-#: openforms/forms/templates/admin/forms/form/import_form.html:13
+#: openforms/forms/templates/admin/forms/form/import_form.html:14
 #: openforms/forms/templates/admin/forms/form/migrate-payment-backend.html:18
 #: openforms/forms/templates/admin/forms/formsubmissionstatistics/export_form.html:19
 msgid "Home"
@@ -3999,11 +3983,10 @@ msgstr "Medeondertekening nodig"
 
 #: openforms/config/templates/config/default_cosign_submission_confirmation.html:8
 msgid ""
-"You can start the cosigning process immediately by clicking the button "
-"below."
+"You can start the cosigning process immediately by clicking the button below."
 msgstr ""
-"Je kan het mede-ondertekenen meteen starten door de onderstaande knop aan te"
-" klikken."
+"Je kan het mede-ondertekenen meteen starten door de onderstaande knop aan te "
+"klikken."
 
 #: openforms/config/templates/config/default_cosign_submission_confirmation.html:9
 #: openforms/submissions/templatetags/cosign.py:17
@@ -4017,14 +4000,14 @@ msgstr "Alternatieve instructies"
 #: openforms/config/templates/config/default_cosign_submission_confirmation.html:12
 #, python-format
 msgid ""
-"We've sent an email with a cosign request to <a "
-"href=\"mailto:%(tt_openvariable)s cosigner_email "
+"We've sent an email with a cosign request to <a href=\"mailto:"
+"%(tt_openvariable)s cosigner_email "
 "%(tt_closevariable)s\">%(tt_openvariable)s cosigner_email "
 "%(tt_closevariable)s</a>. Once the submission has been cosigned we will "
 "start processing your request."
 msgstr ""
-"Wij hebben een e-mail gestuurd voor medeondertekening naar <a "
-"href=\"mailto:%(tt_openvariable)s cosigner_email "
+"Wij hebben een e-mail gestuurd voor medeondertekening naar <a href=\"mailto:"
+"%(tt_openvariable)s cosigner_email "
 "%(tt_closevariable)s\">%(tt_openvariable)s cosigner_email "
 "%(tt_closevariable)s</a>. Als deze ondertekend is, nemen wij je aanvraag in "
 "behandeling."
@@ -4178,8 +4161,8 @@ msgstr "standaardwaarde BRP Personen doelbinding-header"
 #: openforms/contrib/haal_centraal/models.py:50
 msgid ""
 "The default purpose limitation (\"doelbinding\") for queries to the BRP "
-"Persoon API. If a more specific value is configured on a form, that value is"
-" used instead."
+"Persoon API. If a more specific value is configured on a form, that value is "
+"used instead."
 msgstr ""
 "De standaard \"doelbinding\" voor BRP Personen bevragingen. Mogelijke "
 "waarden hiervoor zijn afhankelijk van je gateway-leverancier en/of eigen "
@@ -4193,13 +4176,12 @@ msgstr "standaardwaarde BRP Personen verwerking-header"
 #: openforms/contrib/haal_centraal/models.py:60
 msgid ""
 "The default processing (\"verwerking\") for queries to the BRP Persoon API. "
-"If a more specific value is configured on a form, that value is used "
-"instead."
+"If a more specific value is configured on a form, that value is used instead."
 msgstr ""
-"De standaard \"verwerking\" voor BRP Personen bevragingen. Mogelijke waarden"
-" hiervoor zijn afhankelijk van je gateway-leverancier. Je kan deze ook op "
-"formulierniveau opgeven en dan overschrijft de formulierspecifieke waarde de"
-" standaardwaarde."
+"De standaard \"verwerking\" voor BRP Personen bevragingen. Mogelijke waarden "
+"hiervoor zijn afhankelijk van je gateway-leverancier. Je kan deze ook op "
+"formulierniveau opgeven en dan overschrijft de formulierspecifieke waarde de "
+"standaardwaarde."
 
 #: openforms/contrib/haal_centraal/models.py:65
 msgid "header name for OIN value"
@@ -4225,8 +4207,8 @@ msgstr "BRP Personen doelbinding-header"
 msgid ""
 "The purpose limitation (\"doelbinding\") for queries to the BRP Persoon API."
 msgstr ""
-"De \"doelbinding\" voor BRP Personen bevragingen. Mogelijke waarden hiervoor"
-" zijn afhankelijk van je gateway-leverancier en/of eigen organisatie-"
+"De \"doelbinding\" voor BRP Personen bevragingen. Mogelijke waarden hiervoor "
+"zijn afhankelijk van je gateway-leverancier en/of eigen organisatie-"
 "instellingen."
 
 #: openforms/contrib/haal_centraal/models.py:102
@@ -4321,13 +4303,11 @@ msgstr "Rijksdriehoekcoördinaten"
 
 #: openforms/contrib/kadaster/api/serializers.py:48
 msgid ""
-"X and Y coordinates in the "
-"[Rijkdsdriehoek](https://nl.wikipedia.org/wiki/Rijksdriehoeksco%C3%B6rdinaten)"
-" coordinate system."
+"X and Y coordinates in the [Rijkdsdriehoek](https://nl.wikipedia.org/wiki/"
+"Rijksdriehoeksco%C3%B6rdinaten) coordinate system."
 msgstr ""
-"X- en Y-coördinaten in de "
-"[Rijkdsdriehoek](https://nl.wikipedia.org/wiki/Rijksdriehoeksco%C3%B6rdinaten)"
-" coordinate system."
+"X- en Y-coördinaten in de [Rijkdsdriehoek](https://nl.wikipedia.org/wiki/"
+"Rijksdriehoeksco%C3%B6rdinaten) coordinate system."
 
 #: openforms/contrib/kadaster/api/serializers.py:59
 msgid "Latitude, in decimal degrees."
@@ -4363,8 +4343,7 @@ msgid "Get an adress based on coordinates"
 msgstr "Zoek adres op basis van coördinaten"
 
 #: openforms/contrib/kadaster/api/views.py:94
-msgid ""
-"Get the closest address name based on the given longitude and latitude."
+msgid "Get the closest address name based on the given longitude and latitude."
 msgstr ""
 "Haal de omschrijving op van het dichtsbijzijndste adres voor de opgegeven "
 "longitude en latitude."
@@ -4383,13 +4362,18 @@ msgstr "Geef lijst van adressuggesties met coördinaten."
 
 #: openforms/contrib/kadaster/api/views.py:147
 msgid ""
-"Get a list of addresses, ordered by relevance/match score of the input query. Note that only results having latitude/longitude data are returned.\n"
+"Get a list of addresses, ordered by relevance/match score of the input "
+"query. Note that only results having latitude/longitude data are returned.\n"
 "\n"
-"The results are retrieved from the configured geo search service, defaulting to the Kadaster location server."
+"The results are retrieved from the configured geo search service, defaulting "
+"to the Kadaster location server."
 msgstr ""
-"Haal een lijst op van adressen, gesorteerd op relevantie/match score van de zoekopdracht. Merk op dat enkel resultaten voorzien van latitude/longitude teruggegeven worden.\n"
+"Haal een lijst op van adressen, gesorteerd op relevantie/match score van de "
+"zoekopdracht. Merk op dat enkel resultaten voorzien van latitude/longitude "
+"teruggegeven worden.\n"
 "\n"
-"Deze resultaten worden opgehaald uit de ingestelde geo-zoekservice. Standaard is dit de Locatieserver van het Kadaster."
+"Deze resultaten worden opgehaald uit de ingestelde geo-zoekservice. "
+"Standaard is dit de Locatieserver van het Kadaster."
 
 #: openforms/contrib/kadaster/api/views.py:158
 msgid ""
@@ -4586,11 +4570,11 @@ msgstr "De gewenste Objecten API-groep."
 
 #: openforms/contrib/objects_api/api/serializers.py:23
 msgid ""
-"URL reference to this object. This is the unique identification and location"
-" of this object."
+"URL reference to this object. This is the unique identification and location "
+"of this object."
 msgstr ""
-"URL-referentie naar dit object. Dit is de unieke identificatie en vindplaats"
-" van het object."
+"URL-referentie naar dit object. Dit is de unieke identificatie en vindplaats "
+"van het object."
 
 #: openforms/contrib/objects_api/api/serializers.py:26
 msgid "Unique identifier (UUID4)."
@@ -4646,11 +4630,10 @@ msgstr ""
 #: openforms/contrib/objects_api/checks.py:36
 #, python-brace-format
 msgid ""
-"Missing Objecttypes API credentials for Objects API group "
-"{objects_api_group}"
+"Missing Objecttypes API credentials for Objects API group {objects_api_group}"
 msgstr ""
-"Ontbrekende Objecttypen API authenticatiegegevens voor de Objecten API-groep"
-" {objects_api_group}"
+"Ontbrekende Objecttypen API authenticatiegegevens voor de Objecten API-groep "
+"{objects_api_group}"
 
 #: openforms/contrib/objects_api/checks.py:70
 #, python-brace-format
@@ -4725,8 +4708,8 @@ msgid ""
 msgstr ""
 "Omschrijving van het documenttype in de Catalogi API (het "
 "INFORMATIEOBJECTTYPE.omschrijving attribuut) voor het PDF-document met "
-"inzendingsgegevens. De juiste versie wordt automatisch geselecteerd op basis"
-" van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
+"inzendingsgegevens. De juiste versie wordt automatisch geselecteerd op basis "
+"van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
 
 #: openforms/contrib/objects_api/models.py:119
 #: openforms/registrations/contrib/objects_api/config.py:194
@@ -4742,8 +4725,8 @@ msgid ""
 msgstr ""
 "Omschrijving van het documenttype in de Catalogi API (het "
 "INFORMATIEOBJECTTYPE.omschrijving attribuut) voor het CSV-document met "
-"inzendingsgegevens. De juiste versie wordt automatisch geselecteerd op basis"
-" van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
+"inzendingsgegevens. De juiste versie wordt automatisch geselecteerd op basis "
+"van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
 
 #: openforms/contrib/objects_api/models.py:134
 #: openforms/registrations/contrib/objects_api/config.py:207
@@ -4759,8 +4742,8 @@ msgid ""
 msgstr ""
 "Omschrijving van het documenttype in de Catalogi API (het "
 "INFORMATIEOBJECTTYPE.omschrijving attribuut) voor inzendingsbijlagen. De "
-"juiste versie wordt automatisch geselecteerd op basis van de inzendingsdatum"
-" en geldigheidsdatums van de documenttypeversies."
+"juiste versie wordt automatisch geselecteerd op basis van de inzendingsdatum "
+"en geldigheidsdatums van de documenttypeversies."
 
 #: openforms/contrib/objects_api/models.py:150
 msgid "submission report informatieobjecttype"
@@ -4804,8 +4787,7 @@ msgstr "Objecten API-groepen"
 
 #: openforms/contrib/objects_api/models.py:185
 #: openforms/registrations/contrib/zgw_apis/models.py:157
-msgid ""
-"You must specify both domain and RSIN to uniquely identify a catalogue."
+msgid "You must specify both domain and RSIN to uniquely identify a catalogue."
 msgstr ""
 "Je moet het domein én RSIN beide opgeven om een catalogus uniek te "
 "identificeren."
@@ -4886,8 +4868,8 @@ msgid ""
 "same case type with the same identification exist. The filter returns a "
 "document type if it occurs within any version of the specified case type."
 msgstr ""
-"Filter documenttypen voor een gegeven zaaktype. De zaaktype-identificatie is"
-" uniek binnen een catalogus. Merk op dat meerdere versies van hetzelfde "
+"Filter documenttypen voor een gegeven zaaktype. De zaaktype-identificatie is "
+"uniek binnen een catalogus. Merk op dat meerdere versies van hetzelfde "
 "zaaktype met dezelfde identificatie kunnen bestaan. De filter geeft een "
 "documenttype terug zodra deze binnen één versie van een zaaktype voorkomt."
 
@@ -5063,8 +5045,7 @@ msgstr "Versie-identificatie"
 
 #: openforms/dmn/api/serializers.py:32
 msgid ""
-"The (unique) identifier pointing to a particular decision definition "
-"version."
+"The (unique) identifier pointing to a particular decision definition version."
 msgstr "De (unieke) identifier voor een beslisdefinitieversie."
 
 #: openforms/dmn/api/serializers.py:37
@@ -5236,8 +5217,7 @@ msgstr ""
 "Testbericht is succesvol verzonden naar %(recipients)s. Controleer uw inbox."
 
 #: openforms/emails/connection_check.py:93
-msgid ""
-"If the message doesn't arrive check the Django-yubin queue and cronjob."
+msgid "If the message doesn't arrive check the Django-yubin queue and cronjob."
 msgstr ""
 "Indien het bericht niet aankomt, controleer de Django-yubin wachtrij en "
 "periodieke acties."
@@ -5309,8 +5289,7 @@ msgstr "ONBEKEND"
 
 #: openforms/emails/digest.py:640
 #, python-brace-format
-msgid ""
-"Service reference '{slug}' could not be resolved (used in form {form})."
+msgid "Service reference '{slug}' could not be resolved (used in form {form})."
 msgstr ""
 "Servicereferentie '{slug}' kon niet worden opgehaald (gebruikt in formulier "
 "{form})."
@@ -5370,13 +5349,13 @@ msgstr ""
 "De inhoud van de e-mail wanneer mede-ondertekenen nodig is. Je moet de "
 "speciale instructies '{% payment_information %}' en '{% cosign_information "
 "%}' opnemen. Daarnaast kan je de '{% confirmation_summary %}'-instructie "
-"gebruiken en zijn nog een aantal variabelen beschikbaar- zie de documentatie"
-" voor meer informatie."
+"gebruiken en zijn nog een aantal variabelen beschikbaar- zie de documentatie "
+"voor meer informatie."
 
 #: openforms/emails/models.py:97 openforms/forms/admin/form_logic.py:28
-#: openforms/forms/models/form.py:437
-#: openforms/forms/models/form_variable.py:241
-#: openforms/forms/models/form_version.py:46
+#: openforms/forms/models/form.py:444
+#: openforms/forms/models/form_variable.py:249
+#: openforms/forms/models/form_version.py:69
 msgid "form"
 msgstr "formulier"
 
@@ -5412,8 +5391,8 @@ msgid ""
 "Use this form to send a test email to the supplied recipient and test the "
 "email backend configuration."
 msgstr ""
-"Gebruik dit formulier om een testbericht te versturen naar een opgegeven "
-"e-mailadres."
+"Gebruik dit formulier om een testbericht te versturen naar een opgegeven e-"
+"mailadres."
 
 #: openforms/emails/templates/admin/emails/connection_check.html:20
 msgid "Send test email"
@@ -5447,8 +5426,8 @@ msgstr "Registraties"
 #: openforms/emails/templates/emails/admin_digest.html:26
 #, python-format
 msgid ""
-"Form '%(form_name)s' failed %(counter)s time(s) between %(first_failure_at)s"
-" and %(last_failure_at)s.<br>"
+"Form '%(form_name)s' failed %(counter)s time(s) between %(first_failure_at)s "
+"and %(last_failure_at)s.<br>"
 msgstr ""
 "Formulier '%(form_name)s' faalde %(counter)s keer tussen "
 "%(first_failure_at)s en %(last_failure_at)s.</br>"
@@ -5559,8 +5538,8 @@ msgid ""
 "We couldn't process logic rule %(index)s for '%(form_name)s' because it "
 "appears to be invalid. <br>"
 msgstr ""
-"Logicaregel %(index)s in formulier '%(form_name)s' lijkt ongeldig te zijn en"
-" kon daarom niet gecontroleerd worden. <br>"
+"Logicaregel %(index)s in formulier '%(form_name)s' lijkt ongeldig te zijn en "
+"kon daarom niet gecontroleerd worden. <br>"
 
 #: openforms/emails/templates/emails/admin_digest.html:145
 #, python-format
@@ -5591,8 +5570,10 @@ msgstr ""
 msgid ""
 "\n"
 "                        <p>\n"
-"                            Something went wrong while trying to retrieve data from service: %(service_label)s.\n"
-"                            This will probably affect the active forms which make use of this service and the user's experience.\n"
+"                            Something went wrong while trying to retrieve "
+"data from service: %(service_label)s.\n"
+"                            This will probably affect the active forms which "
+"make use of this service and the user's experience.\n"
 "                            See the error below:\n"
 "                        </p>\n"
 "                        <i>%(exc_message)s</i>\n"
@@ -5600,8 +5581,10 @@ msgid ""
 msgstr ""
 "\n"
 "<p>\n"
-"Er is iets foutgegaan bij het ophalen van de gegevens uit de servce:   %(service_label)s.\n"
-"Dit heeft waarschijnlijk invloed op de actieve formulieren die van deze service gebruikmaken en op de gebruikerservaring.\n"
+"Er is iets foutgegaan bij het ophalen van de gegevens uit de servce:   "
+"%(service_label)s.\n"
+"Dit heeft waarschijnlijk invloed op de actieve formulieren die van deze "
+"service gebruikmaken en op de gebruikerservaring.\n"
 "Zie de volgende foutmelding:\n"
 "</p>\n"
 "<i>%(exc_message)s</i>"
@@ -5663,8 +5646,8 @@ msgstr "Ongeldige componentinstellingen"
 #: openforms/emails/templates/emails/admin_digest.html:255
 #, python-format
 msgid ""
-"The configuration of %(component_type)s component '%(component_key)s' of the"
-" form '%(form_name)s' is invalid.<br> (%(message)s)<br>"
+"The configuration of %(component_type)s component '%(component_key)s' of the "
+"form '%(form_name)s' is invalid.<br> (%(message)s)<br>"
 msgstr ""
 "De instellingen van de \"%(component_type)s\"-component '%(component_key)s' "
 "in het formulier '%(form_name)s' zijn ongeldig.<br> (%(message)s)<br>"
@@ -5704,20 +5687,25 @@ msgid ""
 "<p>Dear reader,</p>\n"
 "\n"
 "<p>\n"
-"Someone submitted the form \"%(tt_openvariable)s form_name %(tt_closevariable)s\"\n"
-"via the website on %(tt_openvariable)s submission_date %(tt_closevariable)s. This\n"
+"Someone submitted the form \"%(tt_openvariable)s form_name "
+"%(tt_closevariable)s\"\n"
+"via the website on %(tt_openvariable)s submission_date %(tt_closevariable)s. "
+"This\n"
 "submission is not complete yet without your signature.\n"
 "</p>\n"
 "\n"
 "<h2>Cosigning required</h2>\n"
 "\n"
 "<p>\n"
-"With the link below you can log in and sign the form submission. Then, we will\n"
+"With the link below you can log in and sign the form submission. Then, we "
+"will\n"
 "process the request.\n"
 "</p>\n"
 "\n"
 "<p>\n"
-"<a href=\"%(tt_openvariable)s form_url %(tt_closevariable)s\">%(tt_openvariable)s form_url %(tt_closevariable)s</a>\n"
+"<a href=\"%(tt_openvariable)s form_url "
+"%(tt_closevariable)s\">%(tt_openvariable)s form_url %(tt_closevariable)s</"
+"a>\n"
 "</p>\n"
 "\n"
 "<p>Kind regards,</p>\n"
@@ -5728,20 +5716,25 @@ msgstr ""
 "<p>Beste lezer,</p>\n"
 "\n"
 "<p>\n"
-"Via de website heeft iemand het formulier \"%(tt_openvariable)s form_name %(tt_closevariable)s\"\n"
-"op %(tt_openvariable)s submission_date %(tt_closevariable)s ingediend. Deze is nog\n"
+"Via de website heeft iemand het formulier \"%(tt_openvariable)s form_name "
+"%(tt_closevariable)s\"\n"
+"op %(tt_openvariable)s submission_date %(tt_closevariable)s ingediend. Deze "
+"is nog\n"
 "niet compleet zonder je handtekening.\n"
 "</p>\n"
 "\n"
 "<h2>Medeondertekening nodig</h2>\n"
 "\n"
 "<p>\n"
-"Via deze link kun je inloggen om het formulier te ondertekenen. Daarna nemen wij de aanvraag \n"
+"Via deze link kun je inloggen om het formulier te ondertekenen. Daarna nemen "
+"wij de aanvraag \n"
 "in behandeling.\n"
 "</p>\n"
 "\n"
 "<p>\n"
-"<a href=\"%(tt_openvariable)s form_url %(tt_closevariable)s\">%(tt_openvariable)s form_url %(tt_closevariable)s</a>\n"
+"<a href=\"%(tt_openvariable)s form_url "
+"%(tt_closevariable)s\">%(tt_openvariable)s form_url %(tt_closevariable)s</"
+"a>\n"
 "</p>\n"
 "\n"
 "<p>Met vriendelijke groet,</p>\n"
@@ -5754,9 +5747,12 @@ msgid ""
 "\n"
 "Dear Sir, Madam,<br>\n"
 "<br>\n"
-"You have submitted the form \"%(tt_openvariable)s form_name %(tt_closevariable)s\" on %(tt_openvariable)s submission_date %(tt_closevariable)s.<br>\n"
+"You have submitted the form \"%(tt_openvariable)s form_name "
+"%(tt_closevariable)s\" on %(tt_openvariable)s submission_date "
+"%(tt_closevariable)s.<br>\n"
 "<br>\n"
-"Your reference is: %(tt_openvariable)s public_reference %(tt_closevariable)s<br>\n"
+"Your reference is: %(tt_openvariable)s public_reference "
+"%(tt_closevariable)s<br>\n"
 "<br>\n"
 "\n"
 "%(tt_openblock)s confirmation_summary %(tt_closeblock)s<br>\n"
@@ -5771,9 +5767,12 @@ msgstr ""
 "\n"
 "Geachte heer/mevrouw,<br>\n"
 "<br>\n"
-"U heeft via de website het formulier \\\"%(tt_openvariable)s form_name %(tt_closevariable)s\\\" verzonden op %(tt_openvariable)s submission_date %(tt_closevariable)s.<br>\n"
+"U heeft via de website het formulier \\\"%(tt_openvariable)s form_name "
+"%(tt_closevariable)s\\\" verzonden op %(tt_openvariable)s submission_date "
+"%(tt_closevariable)s.<br>\n"
 "<br>\n"
-"Uw referentienummer is: %(tt_openvariable)s public_reference %(tt_closevariable)s<br>\n"
+"Uw referentienummer is: %(tt_openvariable)s public_reference "
+"%(tt_closevariable)s<br>\n"
 "<br>\n"
 "\n"
 "%(tt_openblock)s confirmation_summary %(tt_closeblock)s<br>\n"
@@ -5791,8 +5790,10 @@ msgid ""
 "\n"
 "Dear reader,<br>\n"
 "<br>\n"
-"You submitted the form \"%(tt_openvariable)s form_name %(tt_closevariable)s\"\n"
-"via the website on %(tt_openvariable)s submission_date %(tt_closevariable)s.<br>\n"
+"You submitted the form \"%(tt_openvariable)s form_name "
+"%(tt_closevariable)s\"\n"
+"via the website on %(tt_openvariable)s submission_date %(tt_closevariable)s."
+"<br>\n"
 "<br>\n"
 "\n"
 "%(tt_openblock)s if registration_completed %(tt_closeblock)s<br>\n"
@@ -5807,7 +5808,8 @@ msgid ""
 "    %(tt_openblock)s endif %(tt_closeblock)s<br>\n"
 "%(tt_openblock)s endif %(tt_closeblock)s<br>\n"
 "\n"
-"Your reference is: %(tt_openvariable)s public_reference %(tt_closevariable)s<br>\n"
+"Your reference is: %(tt_openvariable)s public_reference "
+"%(tt_closevariable)s<br>\n"
 "<br>\n"
 "\n"
 "%(tt_openblock)s confirmation_summary %(tt_closeblock)s<br>\n"
@@ -5821,7 +5823,9 @@ msgstr ""
 "\n"
 "Beste lezer,<br>\n"
 "<br>\n"
-"U heeft via de website het formulier \"%(tt_openvariable)s form_name %(tt_closevariable)s\" verzonden op %(tt_openvariable)s submission_date %(tt_closevariable)s.<br>\n"
+"U heeft via de website het formulier \"%(tt_openvariable)s form_name "
+"%(tt_closevariable)s\" verzonden op %(tt_openvariable)s submission_date "
+"%(tt_closevariable)s.<br>\n"
 "<br>\n"
 "\n"
 "%(tt_openblock)s if registration_completed %(tt_closeblock)s<br>\n"
@@ -5836,7 +5840,8 @@ msgstr ""
 "%(tt_openblock)s endif %(tt_closeblock)s<br>\n"
 "%(tt_openblock)s endif %(tt_closeblock)s<br>\n"
 "\n"
-"Uw referentienummer is: %(tt_openvariable)s public_reference %(tt_closevariable)s<br>\n"
+"Uw referentienummer is: %(tt_openvariable)s public_reference "
+"%(tt_closevariable)s<br>\n"
 "<br>\n"
 "\n"
 "%(tt_openblock)s confirmation_summary %(tt_closeblock)s<br>\n"
@@ -5862,22 +5867,26 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"<p>This email address requires verification for the \"%(tt_openvariable)s form_name %(tt_closevariable)s\" form.</p>\n"
+"<p>This email address requires verification for the \"%(tt_openvariable)s "
+"form_name %(tt_closevariable)s\" form.</p>\n"
 "\n"
 "<p>Enter the code below to confirm your email address:</p>\n"
 "\n"
 "<p><strong>%(tt_openvariable)s code %(tt_closevariable)s</strong></p>\n"
 "\n"
-"<p>If you did not request this verification, you can safely ignore this email.</p>\n"
+"<p>If you did not request this verification, you can safely ignore this "
+"email.</p>\n"
 msgstr ""
 "\n"
-"<p>Dit e-mailadres moet gecontroleerd worden voor het \"%(tt_openvariable)s form_name %(tt_closevariable)s\"-formulier.</p>\n"
+"<p>Dit e-mailadres moet gecontroleerd worden voor het \"%(tt_openvariable)s "
+"form_name %(tt_closevariable)s\"-formulier.</p>\n"
 "\n"
 "<p>Voer de code die hieronder staat in om je e-mailadres te bevestigen:</p>\n"
 "\n"
 "<p><strong>%(tt_openvariable)s code %(tt_closevariable)s</strong></p>\n"
 "\n"
-"<p>Als je niet zelf deze controle gestart bent, dan kan je deze e-mail negeren.</p>\n"
+"<p>Als je niet zelf deze controle gestart bent, dan kan je deze e-mail "
+"negeren.</p>\n"
 
 #: openforms/emails/templates/emails/email_verification/subject.txt:1
 #, python-format
@@ -5895,11 +5904,15 @@ msgid ""
 "\n"
 "Dear Sir or Madam,<br>\n"
 "<br>\n"
-"You have stored the form \"%(tt_openvariable)s form_name %(tt_closevariable)s\" via the website on %(tt_openvariable)s save_date %(tt_closevariable)s.\n"
+"You have stored the form \"%(tt_openvariable)s form_name "
+"%(tt_closevariable)s\" via the website on %(tt_openvariable)s save_date "
+"%(tt_closevariable)s.\n"
 "You can resume this form at a later time by clicking the link below.<br>\n"
-"The link is valid up to and including %(tt_openvariable)s expiration_date %(tt_closevariable)s.<br>\n"
+"The link is valid up to and including %(tt_openvariable)s expiration_date "
+"%(tt_closevariable)s.<br>\n"
 "<br>\n"
-"<a href=\"%(tt_openvariable)s continue_url %(tt_closevariable)s\">Resume form \"%(tt_openvariable)s form_name %(tt_closevariable)s\".</a><br>\n"
+"<a href=\"%(tt_openvariable)s continue_url %(tt_closevariable)s\">Resume "
+"form \"%(tt_openvariable)s form_name %(tt_closevariable)s\".</a><br>\n"
 "<br>\n"
 "Kind regards,<br>\n"
 "<br>\n"
@@ -5907,14 +5920,24 @@ msgid ""
 "\n"
 msgstr ""
 "\n"
-"Geachte heer/mevrouw,<br><br>U heeft via de website het formulier \"%(tt_openvariable)s form_name %(tt_closevariable)s\" tussentijds opgeslagen op %(tt_openvariable)s save_date %(tt_closevariable)s. U kunt dit formulier op een later moment hervatten door op onderstaande link te klikken.<br>Onderstaande link is geldig tot en met %(tt_openvariable)s expiration_date %(tt_closevariable)s.<br><br><a href=\"%(tt_openvariable)s continue_url %(tt_closevariable)s\">Verder gaan met formulier \"%(tt_openvariable)s form_name %(tt_closevariable)s\".</a><br><br>Met vriendelijke groet,<br><br>Open Formulieren\n"
+"Geachte heer/mevrouw,<br><br>U heeft via de website het formulier "
+"\"%(tt_openvariable)s form_name %(tt_closevariable)s\" tussentijds "
+"opgeslagen op %(tt_openvariable)s save_date %(tt_closevariable)s. U kunt dit "
+"formulier op een later moment hervatten door op onderstaande link te klikken."
+"<br>Onderstaande link is geldig tot en met %(tt_openvariable)s "
+"expiration_date %(tt_closevariable)s.<br><br><a href=\"%(tt_openvariable)s "
+"continue_url %(tt_closevariable)s\">Verder gaan met formulier "
+"\"%(tt_openvariable)s form_name %(tt_closevariable)s\".</a><br><br>Met "
+"vriendelijke groet,<br><br>Open Formulieren\n"
 
 #: openforms/emails/templates/emails/save_form/save_form.txt:1
 #, python-format
 msgid ""
 "Dear Sir or Madam,\n"
 "\n"
-"You have stored the form \"%(form_name)s\" via the website on %(formatted_save_date)s. You can resume this form at a later time by clicking the link below.\n"
+"You have stored the form \"%(form_name)s\" via the website on "
+"%(formatted_save_date)s. You can resume this form at a later time by "
+"clicking the link below.\n"
 "The link is valid up to and including %(formatted_expiration_date)s.\n"
 "\n"
 "Resume form: %(continue_url)s\n"
@@ -5925,7 +5948,10 @@ msgid ""
 msgstr ""
 "Geachte heer/mevrouw,\n"
 "\n"
-"U heeft via de website het formulier \"%(form_name)s\" tussentijds opgeslagen op %(formatted_save_date)s. U kunt dit formulier op een later moment hervatten door op onderstaande link te klikken.Onderstaande link is geldig tot en met %(formatted_expiration_date)s.\n"
+"U heeft via de website het formulier \"%(form_name)s\" tussentijds "
+"opgeslagen op %(formatted_save_date)s. U kunt dit formulier op een later "
+"moment hervatten door op onderstaande link te klikken.Onderstaande link is "
+"geldig tot en met %(formatted_expiration_date)s.\n"
 "\n"
 "Verder gaan met formulier: %(continue_url)s\n"
 "\n"
@@ -5948,8 +5974,8 @@ msgid ""
 "If you wish to change your appointment, please cancel it using the link "
 "below and create a new one."
 msgstr ""
-"Indien je jouw afspraak wenst te wijzingen, dan kan je deze annuleren en een"
-" nieuwe aanmaken."
+"Indien je jouw afspraak wenst te wijzingen, dan kan je deze annuleren en een "
+"nieuwe aanmaken."
 
 #: openforms/emails/templates/emails/templatetags/appointment_information.html:62
 #: openforms/emails/templates/emails/templatetags/appointment_information.txt:25
@@ -6034,8 +6060,8 @@ msgid ""
 "Payment of &euro; %(payment_price)s is required. You can pay using the link "
 "below."
 msgstr ""
-"Betaling van &euro;%(payment_price)s vereist. U kunt het bedrag betalen door"
-" op onderstaande link te klikken."
+"Betaling van &euro;%(payment_price)s vereist. U kunt het bedrag betalen door "
+"op onderstaande link te klikken."
 
 #: openforms/emails/templates/emails/templatetags/payment_information.html:15
 #: openforms/emails/templates/emails/templatetags/payment_information.txt:8
@@ -6093,12 +6119,12 @@ msgid "URL"
 msgstr "URL"
 
 #: openforms/formio/api/serializers.py:42
-#: openforms/submissions/models/submission_files.py:218
+#: openforms/submissions/models/submission_files.py:291
 msgid "File name"
 msgstr "Bestandsnaam"
 
-#: openforms/formio/api/serializers.py:45 openforms/submissions/admin.py:568
-#: openforms/submissions/admin.py:621
+#: openforms/formio/api/serializers.py:45 openforms/submissions/admin.py:569
+#: openforms/submissions/admin.py:619
 msgid "File size"
 msgstr "Bestandsgrootte"
 
@@ -6121,8 +6147,7 @@ msgid "The provided file is not a {file_type}."
 msgstr "Het bestand is geen {file_type}."
 
 #: openforms/formio/api/validators.py:174
-msgid ""
-"The virus scan could not be performed at this time. Please retry later."
+msgid "The virus scan could not be performed at this time. Please retry later."
 msgstr ""
 "Het is momenteel niet mogelijk om bestanden te scannen op virussen. Probeer "
 "het later opnieuw."
@@ -6150,19 +6175,29 @@ msgstr "Maak tijdelijk bestand aan"
 msgid ""
 "File upload handler for the Form.io file upload \"url\" storage type.\n"
 "\n"
-"The uploads are stored temporarily and have to be claimed by the form submission using the returned JSON data. \n"
+"The uploads are stored temporarily and have to be claimed by the form "
+"submission using the returned JSON data. \n"
 "\n"
-"Access to this view requires an active form submission. Unclaimed temporary files automatically expire after {expire_days} day(s). \n"
+"Access to this view requires an active form submission. Unclaimed temporary "
+"files automatically expire after {expire_days} day(s). \n"
 "\n"
-"The maximum upload size for this instance is `{max_upload_size}`. Note that this includes the multipart metadata and boundaries, so the actual maximum file upload size is slightly smaller."
+"The maximum upload size for this instance is `{max_upload_size}`. Note that "
+"this includes the multipart metadata and boundaries, so the actual maximum "
+"file upload size is slightly smaller."
 msgstr ""
 "Bestandsuploadhandler voor het Form.io bestandsupload opslagtype 'url'.\n"
 "\n"
-"Bestandsuploads worden tijdelijke opgeslagen en moeten gekoppeld worden aan een inzending.\n"
+"Bestandsuploads worden tijdelijke opgeslagen en moeten gekoppeld worden aan "
+"een inzending.\n"
 "\n"
-"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en).\n"
+"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet "
+"gekoppelde bestanden worden automatisch verwijderd na {expire_days} "
+"dag(en).\n"
 "\n"
-"De maximale toegestane upload-bestandsgrootte is `{max_upload_size}` voor deze instantie. Merk op dat dit inclusief multipart-metadata en boundaries is. De daadwerkelijke maximale bestandsgrootte is dus iets lager dan deze waarde."
+"De maximale toegestane upload-bestandsgrootte is `{max_upload_size}` voor "
+"deze instantie. Merk op dat dit inclusief multipart-metadata en boundaries "
+"is. De daadwerkelijke maximale bestandsgrootte is dus iets lager dan deze "
+"waarde."
 
 #: openforms/formio/apps.py:7
 msgid "Formio integration"
@@ -6271,8 +6306,7 @@ msgid "selected"
 msgstr "geselecteerd"
 
 #: openforms/formio/components/custom.py:913
-msgid ""
-"Whether the child is selected by the user or not for further processing"
+msgid "Whether the child is selected by the user or not for further processing"
 msgstr ""
 "Ongeacht of het kind is geselecteerd door de gebruiker voor verdere "
 "behandeling"
@@ -6338,11 +6372,10 @@ msgstr "De waarde ligt niet tussen de minimale en maximale tijd."
 
 #: openforms/formio/components/vanilla.py:439
 #, python-brace-format
-msgid ""
-"The value of {root_key} must match the value of {nested_key} in 'data'."
+msgid "The value of {root_key} must match the value of {nested_key} in 'data'."
 msgstr ""
-"De waarde van {root_key} moet overeenkomen met de waarde van {nested_key} in"
-" 'data'."
+"De waarde van {root_key} moet overeenkomen met de waarde van {nested_key} in "
+"'data'."
 
 #: openforms/formio/components/vanilla.py:448
 #: openforms/formio/components/vanilla.py:461
@@ -6416,8 +6449,8 @@ msgid ""
 "The dynamic options obtained with expression {items_expression} contain non-"
 "primitive types."
 msgstr ""
-"De dynamische keuzelijstopties verkregen met de expressie {items_expression}"
-" bevatten niet-primitieve typen (zoals objecten of arrays)."
+"De dynamische keuzelijstopties verkregen met de expressie {items_expression} "
+"bevatten niet-primitieve typen (zoals objecten of arrays)."
 
 #: openforms/formio/dynamic_config/dynamic_options.py:115
 msgid "Could not retrieve options from Referentielijsten API."
@@ -6427,14 +6460,14 @@ msgstr "Kon geen beschikbare opties ophalen van Referentielijsten API."
 msgid ""
 "Cannot fetch from ReferenceLists API, because no `service` is configured."
 msgstr ""
-"Kan geen gegevens ophalen van referentielijsten-API, omdat er geen `service`"
-" is geconfigureerd."
+"Kan geen gegevens ophalen van referentielijsten-API, omdat er geen `service` "
+"is geconfigureerd."
 
 #: openforms/formio/dynamic_config/reference_lists.py:37
 msgid "Cannot fetch from ReferenceLists API, because no `code` is configured."
 msgstr ""
-"Kan geen gegevens ophalen van referentielijsten-API, omdat er geen `code` is"
-" geconfigureerd."
+"Kan geen gegevens ophalen van referentielijsten-API, omdat er geen `code` is "
+"geconfigureerd."
 
 #: openforms/formio/dynamic_config/reference_lists.py:48
 #, python-brace-format
@@ -6447,8 +6480,7 @@ msgstr ""
 
 #: openforms/formio/dynamic_config/reference_lists.py:68
 #, python-brace-format
-msgid ""
-"Exception occurred while fetching from ReferenceLists API: {exception}."
+msgid "Exception occurred while fetching from ReferenceLists API: {exception}."
 msgstr ""
 "Er deed zich een fout voor tijdens het ophalen van gegevens uit de "
 "referentielijsten-API: {exception}."
@@ -6492,27 +6524,27 @@ msgstr "Weergeven in PDF"
 msgid "Show in confirmation email"
 msgstr "Weergeven in bevestigingsmail"
 
-#: openforms/formio/rendering/default.py:314
+#: openforms/formio/rendering/default.py:304
 msgid "Item"
 msgstr "Item"
 
-#: openforms/formio/rendering/default.py:420
+#: openforms/formio/rendering/default.py:415
 msgid "Partner"
 msgstr "Partner"
 
-#: openforms/formio/rendering/default.py:445
+#: openforms/formio/rendering/default.py:440
 msgid "Affixes"
 msgstr "Voorvoegsels"
 
-#: openforms/formio/rendering/default.py:450
+#: openforms/formio/rendering/default.py:445
 msgid "Lastname"
 msgstr "Achternaam"
 
-#: openforms/formio/rendering/default.py:551
+#: openforms/formio/rendering/default.py:546
 msgid "Child"
 msgstr "Kind"
 
-#: openforms/formio/rendering/default.py:571
+#: openforms/formio/rendering/default.py:566
 msgid "Firstnames"
 msgstr "Voornamen"
 
@@ -6638,8 +6670,8 @@ msgid ""
 "Please configure your email address in your admin profile before requesting "
 "a bulk export"
 msgstr ""
-"Gelieve eerst uw e-mailadres in te stellen in uw gebruikersaccount voordat u"
-" een bulk-export doet."
+"Gelieve eerst uw e-mailadres in te stellen in uw gebruikersaccount voordat u "
+"een bulk-export doet."
 
 #: openforms/forms/admin/form_definition.py:25
 #, python-brace-format
@@ -6669,39 +6701,35 @@ msgstr "Rood"
 msgid "Forms export ready"
 msgstr "Export formulieren gereed"
 
-#: openforms/forms/admin/views.py:43
-#| msgid "Form.io configuration"
+#: openforms/forms/admin/views.py:44
 msgid "Anonymize form configuration"
 msgstr "Formulierconfiguratie anonimiseren"
 
-#: openforms/forms/admin/views.py:47
-#: openforms/forms/api/serializers/form.py:666
-#| msgid ""
-#| "Whether the step progression should be displayed in the UI or not."
+#: openforms/forms/admin/views.py:48
+#: openforms/forms/api/serializers/form.py:669
 msgid ""
 "Whether sensative form configuration should be anonymized during exporting."
 msgstr ""
 "Geeft aan of gevoelige informatie bij het exporteren automatisch "
 "geanonimiseerd worden."
 
-#: openforms/forms/admin/views.py:51
-#| msgid "Form.io configuration"
+#: openforms/forms/admin/views.py:52 openforms/forms/forms/form.py:19
 msgid "Form configuration"
 msgstr "Formulierconfiguratie"
 
-#: openforms/forms/admin/views.py:61
-#: openforms/forms/api/serializers/form.py:673
-msgid ""
-"Which form configuration should be included in the export file content."
+#: openforms/forms/admin/views.py:62
+#: openforms/forms/api/serializers/form.py:676
+#: openforms/forms/api/serializers/form.py:695 openforms/forms/forms/form.py:30
+msgid "Which form configuration should be included in the export file content."
 msgstr "Welke formulierconfiguratie meegenomen worden bij het exporteren."
 
-#: openforms/forms/admin/views.py:65
-#| msgid "Organization configuration"
+#: openforms/forms/admin/views.py:66 openforms/forms/forms/form.py:57
 msgid "Additional form configuration"
 msgstr "Ondersteunende formulierconfiguratie"
 
-#: openforms/forms/admin/views.py:70
-#: openforms/forms/api/serializers/form.py:680
+#: openforms/forms/admin/views.py:71
+#: openforms/forms/api/serializers/form.py:683
+#: openforms/forms/api/serializers/form.py:720 openforms/forms/forms/form.py:62
 msgid ""
 "Which additional form configuration should be included in the export file "
 "content."
@@ -6709,24 +6737,24 @@ msgstr ""
 "Welke ondersteunende formulierconfiguratie meegenomen worden bij het "
 "exporteren."
 
-#: openforms/forms/admin/views.py:76
+#: openforms/forms/admin/views.py:77
 msgid "Invalid form uuids."
 msgstr "Ongeldige formulier-IDs."
 
-#: openforms/forms/admin/views.py:89
+#: openforms/forms/admin/views.py:90
 msgid "Success! You will receive an email when your export is ready."
 msgstr "Gelukt! U ontvangt een e-mail zodra de export gereed is."
 
-#: openforms/forms/admin/views.py:146
+#: openforms/forms/admin/views.py:163
 #, python-brace-format
 msgid "Something went wrong while importing form: {}"
 msgstr "Er is iets foutgegaan bij het importeren van formulier: {}"
 
-#: openforms/forms/admin/views.py:159
+#: openforms/forms/admin/views.py:176
 msgid "Form successfully imported!"
 msgstr "Formulier is succesvol geïmporteerd"
 
-#: openforms/forms/admin/views.py:161
+#: openforms/forms/admin/views.py:178
 msgid ""
 "The bulk import is being processed! The imported forms will soon be "
 "available."
@@ -6752,21 +6780,21 @@ msgstr ""
 "informatie. Formulieren die als \"verwijderd\" gemarkeerd zijn, komen niet "
 "terug."
 
-#: openforms/forms/api/serializers/form.py:74
+#: openforms/forms/api/serializers/form.py:77
 #: openforms/forms/models/form_authentication_backend.py:21
 msgid "authentication backend options"
 msgstr "authenticatie-backend-instellingen"
 
-#: openforms/forms/api/serializers/form.py:99
+#: openforms/forms/api/serializers/form.py:102
 #: openforms/forms/models/form_registration_backend.py:29
 msgid "registration backend options"
 msgstr "registratie backend opties"
 
-#: openforms/forms/api/serializers/form.py:156
+#: openforms/forms/api/serializers/form.py:159
 msgid "cosign request has links in email"
 msgstr "mede-ondertekenenverzoek-e-mail bevat links"
 
-#: openforms/forms/api/serializers/form.py:158
+#: openforms/forms/api/serializers/form.py:161
 msgid ""
 "Indicates whether deep links are included in the cosign request emails or "
 "not."
@@ -6774,7 +6802,7 @@ msgstr ""
 "Geeft aan of er links gebruikt worden in de e-mail voor mede-"
 "ondertekenverzoek."
 
-#: openforms/forms/api/serializers/form.py:166
+#: openforms/forms/api/serializers/form.py:169
 msgid ""
 "The authentication backend to which the user will be automatically "
 "redirected upon starting the form. The chosen backend must be present in "
@@ -6784,95 +6812,108 @@ msgstr ""
 "bij het starten van het formulier. De gekozen plugin moet aanwezig zijn in "
 "`auth_backends`"
 
-#: openforms/forms/api/serializers/form.py:173
+#: openforms/forms/api/serializers/form.py:176
 #: openforms/forms/models/category.py:19
 msgid "category"
 msgstr "categorie"
 
-#: openforms/forms/api/serializers/form.py:179
+#: openforms/forms/api/serializers/form.py:182
 msgid "URL to the category in the Open Forms API"
 msgstr "URL naar de formuliercategorie in de Open Forms API"
 
-#: openforms/forms/api/serializers/form.py:188
+#: openforms/forms/api/serializers/form.py:191
 msgid "URL to the theme in the Open Forms API"
 msgstr "URL naar de stijl in de Open Forms API"
 
-#: openforms/forms/api/serializers/form.py:191
+#: openforms/forms/api/serializers/form.py:194
 msgid "product"
 msgstr "product"
 
-#: openforms/forms/api/serializers/form.py:197
+#: openforms/forms/api/serializers/form.py:200
 msgid "URL to the product in the Open Forms API"
 msgstr "URL van het product in de Open Formulieren API"
 
-#: openforms/forms/api/serializers/form.py:205
-#: openforms/forms/models/form.py:133
+#: openforms/forms/api/serializers/form.py:208
+#: openforms/forms/models/form.py:140
 msgid "payment backend options"
 msgstr "betaalprovider backend opties"
 
-#: openforms/forms/api/serializers/form.py:227
+#: openforms/forms/api/serializers/form.py:230
 msgid "Resume link lifetime"
 msgstr "Geldigheidsduur \"formulier hervatten\"-link"
 
-#: openforms/forms/api/serializers/form.py:229
+#: openforms/forms/api/serializers/form.py:232
 msgid "The number of days that the resume link is valid for."
 msgstr "Het aantal dagen dat de link geldig blijft."
 
-#: openforms/forms/api/serializers/form.py:237
+#: openforms/forms/api/serializers/form.py:240
 msgid "submission statements configuration"
 msgstr "Verklaringenconfiguratie voor inzending"
 
-#: openforms/forms/api/serializers/form.py:239
+#: openforms/forms/api/serializers/form.py:242
 msgid ""
 "A list of statements that need to be accepted by the user before they can "
 "submit a form. Returns a list of formio component definitions, all of type "
 "'checkbox'."
 msgstr ""
-"Een lijst van verklaringen die de gebruiker moet accepteren om het formulier"
-" te kunnen inzenden. Deze worden teruggegeven als lijst van Form.io-"
+"Een lijst van verklaringen die de gebruiker moet accepteren om het formulier "
+"te kunnen inzenden. Deze worden teruggegeven als lijst van Form.io-"
 "componentdefinities, allemaal van het type 'checkbox'."
 
-#: openforms/forms/api/serializers/form.py:574
+#: openforms/forms/api/serializers/form.py:577
 msgid ""
-"The `auto_login_authentication_backend` must be one of the selected backends"
-" from `auth_backends`"
+"The `auto_login_authentication_backend` must be one of the selected backends "
+"from `auth_backends`"
 msgstr ""
 "De `auto_login_authentication_backend` moet één van de backends uit "
 "`auth_backends` zijn."
 
-#: openforms/forms/api/serializers/form.py:687
+#: openforms/forms/api/serializers/form.py:690
 msgid "The file that contains the form, form definitions and form steps."
 msgstr ""
-"Het bestand dat het formulier, de formulierdefinities en de formulierstappen"
-" bevat."
+"Het bestand dat het formulier, de formulierdefinities en de formulierstappen "
+"bevat."
 
-#: openforms/forms/api/serializers/form.py:692
+#: openforms/forms/api/serializers/form.py:703 openforms/forms/forms/form.py:38
+msgid ""
+"Whether to reuse existing form definitions or create new ones for each form "
+"definition in the import file. If no similar form definition exists, a new "
+"form definition is created."
+msgstr ""
+
+#: openforms/forms/api/serializers/form.py:711 openforms/forms/forms/form.py:50
+msgid ""
+"What to do with links in email templates to domains that are not accepted in "
+"the global configuration."
+msgstr ""
+
+#: openforms/forms/api/serializers/form.py:726
 msgid "The uuid of the imported form."
 msgstr "ID van het geïmporteerde formulier."
 
-#: openforms/forms/api/serializers/form.py:697
+#: openforms/forms/api/serializers/form.py:731
 msgid "Registration backend key"
 msgstr "Registratiebackend-sleutel"
 
-#: openforms/forms/api/serializers/form.py:699
+#: openforms/forms/api/serializers/form.py:733
 msgid "The registration backend key for which to generate the schema."
 msgstr ""
 "De registratiebackend-sleutel waarvoor het schema moet worden gegenereerd."
 
-#: openforms/forms/api/serializers/form.py:704
+#: openforms/forms/api/serializers/form.py:738
 msgid "Registration backend identifier"
 msgstr "Registratiebackend-identificatie"
 
-#: openforms/forms/api/serializers/form.py:709
+#: openforms/forms/api/serializers/form.py:743
 msgid "Registration backend options"
 msgstr "Registratiebackend-instellingen"
 
-#: openforms/forms/api/serializers/form.py:721
+#: openforms/forms/api/serializers/form.py:755
 #, python-brace-format
 msgid "Backend with key '{key}' does not exist for form '{form}'"
 msgstr "Backend met sleutel '{key}' bestaat niet voor formulier '{form}'"
 
-#: openforms/forms/api/serializers/form.py:738
+#: openforms/forms/api/serializers/form.py:772
 #, python-brace-format
 msgid "Backend with id '{backend}' does not allow JSON schema generation"
 msgstr ""
@@ -6956,7 +6997,7 @@ msgstr ""
 "{static_data}."
 
 #: openforms/forms/api/serializers/form_variable.py:117
-#: openforms/forms/api/v3/serializers/form.py:452
+#: openforms/forms/api/v3/serializers/form.py:443
 msgid ""
 "This profile form variable is already used in another communication "
 "preferences prefill plugin."
@@ -6979,7 +7020,7 @@ msgstr ""
 "sleutel in de formulierdefinitie."
 
 #: openforms/forms/api/serializers/form_variable.py:252
-#: openforms/forms/api/v3/serializers/form.py:471
+#: openforms/forms/api/v3/serializers/form.py:462
 msgid ""
 "Prefill plugin, attribute and options can not be specified at the same time."
 msgstr ""
@@ -6993,7 +7034,7 @@ msgstr ""
 "afgeleid zijn."
 
 #: openforms/forms/api/serializers/form_variable.py:272
-#: openforms/forms/api/v3/serializers/form.py:482
+#: openforms/forms/api/v3/serializers/form.py:473
 msgid ""
 "Prefill plugin must be specified with either prefill attribute or prefill "
 "options."
@@ -7021,8 +7062,8 @@ msgstr "waarde van het attribuut"
 
 #: openforms/forms/api/serializers/logic/action_serializers.py:49
 msgid ""
-"Valid JSON determining the new value of the specified property. For example:"
-" `true` or `false`."
+"Valid JSON determining the new value of the specified property. For example: "
+"`true` or `false`."
 msgstr ""
 "De JSON die de nieuwe waarde van het gespecificeerde attribuut bepaald. "
 "Bijvoorbeeld: `true` of `false`."
@@ -7034,8 +7075,8 @@ msgstr "Waarde"
 
 #: openforms/forms/api/serializers/logic/action_serializers.py:66
 msgid ""
-"A valid JsonLogic expression describing the value. This may refer to (other)"
-" Form.io components."
+"A valid JsonLogic expression describing the value. This may refer to (other) "
+"Form.io components."
 msgstr ""
 "Een JSON-logic expressie die de waarde beschrijft. Deze mag naar (andere) "
 "Form.io componenten verwijzen."
@@ -7125,8 +7166,8 @@ msgid ""
 "Key of the Form.io component that the action applies to. This field is "
 "required for the action types {action_types} - otherwise it's optional."
 msgstr ""
-"Sleutel van de Form.io-component waarop de actie van toepassing is. Dit veld"
-" is verplicht voor de actietypes {action_types} - anders is het optioneel. "
+"Sleutel van de Form.io-component waarop de actie van toepassing is. Dit veld "
+"is verplicht voor de actietypes {action_types} - anders is het optioneel. "
 
 #: openforms/forms/api/serializers/logic/action_serializers.py:230
 msgid "Key of the target variable"
@@ -7149,8 +7190,8 @@ msgstr "formulierstap"
 #: openforms/forms/api/serializers/logic/action_serializers.py:243
 #, python-brace-format
 msgid ""
-"The UUID of the form step that will be affected by the action. This field is"
-" required for action types {action_types} - otherwise it's optional."
+"The UUID of the form step that will be affected by the action. This field is "
+"required for action types {action_types} - otherwise it's optional."
 msgstr ""
 "De UUID van de formulierstap waarop de actie van invloed is. Dit veld is "
 "verplicht voor actietypen {action_types} - anders is het optioneel."
@@ -7191,8 +7232,8 @@ msgstr ""
 #: openforms/submissions/api/serializers.py:246
 msgid "Actions triggered when the trigger expression evaluates to 'truthy'."
 msgstr ""
-"Acties die worden geactiveerd wanneer de trigger-expressie wordt geëvalueerd"
-" als 'truthy'."
+"Acties die worden geactiveerd wanneer de trigger-expressie wordt geëvalueerd "
+"als 'truthy'."
 
 #: openforms/forms/api/serializers/logic/form_logic.py:143
 #: openforms/forms/models/form_step.py:85 openforms/forms/models/logic.py:36
@@ -7239,33 +7280,33 @@ msgstr ""
 "Er is een dubbele componentsleutel gedetecteerd in de formulierdefinitie "
 "{form_definition}."
 
-#: openforms/forms/api/v3/serializers/form.py:394
-#: openforms/forms/validators.py:142
+#: openforms/forms/api/v3/serializers/form.py:385
+#: openforms/forms/validators.py:91 openforms/forms/validators.py:160
 #, python-brace-format
 msgid "\"{duplicate_key}\" (in {paths})"
 msgstr "\"{duplicate_key}\" (in {paths})"
 
-#: openforms/forms/api/v3/serializers/form.py:401
-#: openforms/forms/validators.py:149
+#: openforms/forms/api/v3/serializers/form.py:392
+#: openforms/forms/validators.py:99 openforms/forms/validators.py:167
 #, python-brace-format
 msgid "Detected duplicate keys in configuration: {errors}"
 msgstr "Er zijn dubbele sleutels gedetecteerd in de configuratie: {errors}."
 
-#: openforms/forms/api/v3/serializers/form.py:437
+#: openforms/forms/api/v3/serializers/form.py:428
 #: openforms/prefill/contrib/customer_interactions/config.py:57
 msgid ""
 "Only variables of 'profile' components are allowed as profile form variable."
 msgstr "Je kan enkel variabelen gebruiken die bij profielcomponenten horen."
 
-#: openforms/forms/api/v3/serializers/form.py:555
+#: openforms/forms/api/v3/serializers/form.py:546
 msgid "At least one form step is required in a regular form."
 msgstr "Ten minste één formulierstap is verplicht in een standaardformulier."
 
-#: openforms/forms/api/v3/serializers/form.py:560
+#: openforms/forms/api/v3/serializers/form.py:551
 msgid "Form steps are not allowed in an appointment form."
 msgstr "Formulierstappen zijn niet toegestaan in afspraakformulieren."
 
-#: openforms/forms/api/v3/serializers/form.py:565
+#: openforms/forms/api/v3/serializers/form.py:556
 msgid "Exactly one form step is required in a single step form."
 msgstr "Precies één formulierstap is verplicht in een formulier met één stap."
 
@@ -7292,7 +7333,8 @@ msgstr "Alle gegevens van een formulier aanmaken of bijwerken"
 
 #: openforms/forms/api/validators.py:31
 msgid "The first operand must be a `{\"var\": \"<componentKey>\"}` expression."
-msgstr "De eerste operand moet een `{\"var\": \"<componentKey>\"}` expressie zijn."
+msgstr ""
+"De eerste operand moet een `{\"var\": \"<componentKey>\"}` expressie zijn."
 
 #: openforms/forms/api/validators.py:124
 msgid "The variable cannot be empty."
@@ -7311,9 +7353,17 @@ msgstr "De eerste formulierstap moet altijd van toepassing zijn."
 msgid "Appointment forms require an appointment plugin to be configured."
 msgstr "Afspraakformulieren vereisen de configuratie van een afspraakplugin."
 
-#: openforms/forms/api/validators.py:212
-msgid "There are template syntax errors in the expression."
-msgstr "Er zijn sjabloonsyntaxfouten in de expressie."
+#: openforms/forms/api/validators.py:210 openforms/forms/validators.py:62
+#, python-brace-format
+msgid ", at location \"{location}\""
+msgstr ""
+
+#: openforms/forms/api/validators.py:212 openforms/forms/validators.py:64
+#, python-brace-format
+msgid ""
+"The component \"{label}\" (with key \"{key}\"{location}) has a problem in "
+"the field \"{property}\": there are template syntax errors in the expression."
+msgstr ""
 
 #: openforms/forms/api/viewsets.py:80 openforms/forms/api/viewsets.py:222
 msgid "Either a UUID4 or a slug identifiying the form."
@@ -7350,27 +7400,40 @@ msgstr "Formulierstap definities weergeven"
 #: openforms/forms/api/viewsets.py:135
 #, python-brace-format
 msgid ""
-"Get a list of existing form definitions, where a single item may be a re-usable or single-use definition. This includes form definitions not currently used in any form(s) at all.\n"
+"Get a list of existing form definitions, where a single item may be a re-"
+"usable or single-use definition. This includes form definitions not "
+"currently used in any form(s) at all.\n"
 "\n"
-"You can filter this list down to only re-usable definitions or definitions used in a particular form.\n"
+"You can filter this list down to only re-usable definitions or definitions "
+"used in a particular form.\n"
 "\n"
-"**Note**: filtering on both `is_reusable` and `used_in` at the same time is implemented as an OR-filter.\n"
+"**Note**: filtering on both `is_reusable` and `used_in` at the same time is "
+"implemented as an OR-filter.\n"
 "\n"
 "**Warning: the response data depends on user permissions**\n"
 "\n"
-"Non-staff users receive a subset of all the documented fields. The fields reserved for staff users are used for internal form configuration. These are: \n"
+"Non-staff users receive a subset of all the documented fields. The fields "
+"reserved for staff users are used for internal form configuration. These "
+"are: \n"
 "\n"
 "{admin_fields}"
 msgstr ""
-"Geef een lijst van bestaande formulierdefinities waarin één enkele definitie herbruikbaar of voor éénmalig gebruik kan zijn. Dit is inclusief definities die in geen enkel formulier gebruikt zijn.\n"
+"Geef een lijst van bestaande formulierdefinities waarin één enkele definitie "
+"herbruikbaar of voor éénmalig gebruik kan zijn. Dit is inclusief definities "
+"die in geen enkel formulier gebruikt zijn.\n"
 "\n"
-"Je kan deze lijst filteren op enkel herbruikbare definities of definities die in een specifiek formulier gebruikt worden.\n"
+"Je kan deze lijst filteren op enkel herbruikbare definities of definities "
+"die in een specifiek formulier gebruikt worden.\n"
 "\n"
-"**Merk op**: tegelijk filteren op `is_reusable` en `used_in` is geïmplementeerd als een OF-filter - je krijgt dus beide resultaten terug.\n"
+"**Merk op**: tegelijk filteren op `is_reusable` en `used_in` is "
+"geïmplementeerd als een OF-filter - je krijgt dus beide resultaten terug.\n"
 "\n"
-"**Waarschuwing: de gegevens in het antwoord zijn afhankelijk van je gebruikersrechten**\n"
+"**Waarschuwing: de gegevens in het antwoord zijn afhankelijk van je "
+"gebruikersrechten**\n"
 "\n"
-"Gebruikers die geen beheerder zijn, ontvangen maar een deel van de gedocumenteerde velden. De velden die enkel voor beheerders beschikbaar zijn, zijn voor interne formulierconfiguratie. Het gaat om de velden:\n"
+"Gebruikers die geen beheerder zijn, ontvangen maar een deel van de "
+"gedocumenteerde velden. De velden die enkel voor beheerders beschikbaar "
+"zijn, zijn voor interne formulierconfiguratie. Het gaat om de velden:\n"
 "\n"
 "{admin_fields}"
 
@@ -7401,19 +7464,27 @@ msgstr "Formulierdefinitie JSON schema weergeven"
 #: openforms/forms/api/viewsets.py:232
 #, python-brace-format
 msgid ""
-"List the active forms, including the pointers to the form steps. Form steps are included in order as they should appear.\n"
+"List the active forms, including the pointers to the form steps. Form steps "
+"are included in order as they should appear.\n"
 "\n"
 "**Warning: the response data depends on user permissions**\n"
 "\n"
-"Non-staff users receive a subset of all the documented fields. The fields reserved for staff users are used for internal form configuration. These are: \n"
+"Non-staff users receive a subset of all the documented fields. The fields "
+"reserved for staff users are used for internal form configuration. These "
+"are: \n"
 "\n"
 "{admin_fields}"
 msgstr ""
-"Geef een lijst van actieve formulieren, inclusief verwijzingen naar de formulierstappen. De formulierstappen komen voor in de volgorde waarin ze zichtbaar moeten zijn.\n"
+"Geef een lijst van actieve formulieren, inclusief verwijzingen naar de "
+"formulierstappen. De formulierstappen komen voor in de volgorde waarin ze "
+"zichtbaar moeten zijn.\n"
 "\n"
-"**Waarschuwing: de gegevens in het antwoord zijn afhankelijk van je gebruikersrechten**\n"
+"**Waarschuwing: de gegevens in het antwoord zijn afhankelijk van je "
+"gebruikersrechten**\n"
 "\n"
-"Gebruikers die geen beheerder zijn, ontvangen maar een deel van de gedocumenteerde velden. De velden die enkel voor beheerders beschikbaar zijn, zijn voor interne formulierconfiguratie. Het gaat om de velden:\n"
+"Gebruikers die geen beheerder zijn, ontvangen maar een deel van de "
+"gedocumenteerde velden. De velden die enkel voor beheerders beschikbaar "
+"zijn, zijn voor interne formulierconfiguratie. Het gaat om de velden:\n"
 "\n"
 "{admin_fields}"
 
@@ -7425,35 +7496,53 @@ msgstr "Formulier details weergeven"
 msgid ""
 "If used, then all authorization methods are visible when the form starts"
 msgstr ""
-"Indien gebruikt, zijn alle autorisatieopties zichtbaar wanneer het formulier"
-" wordt gestart."
+"Indien gebruikt, zijn alle autorisatieopties zichtbaar wanneer het formulier "
+"wordt gestart."
 
 #: openforms/forms/api/viewsets.py:255
 #, python-brace-format
 msgid ""
 "Retrieve the details/configuration of a particular form. \n"
 "\n"
-"A form is a collection of form steps, where each form step points to a formio.js form definition. Multiple definitions are combined in logical steps to build a multi-step/page form for end-users to fill out. Form definitions can be (and are) re-used among different forms.\n"
+"A form is a collection of form steps, where each form step points to a "
+"formio.js form definition. Multiple definitions are combined in logical "
+"steps to build a multi-step/page form for end-users to fill out. Form "
+"definitions can be (and are) re-used among different forms.\n"
 "\n"
 "**Warning: the response data depends on user permissions**\n"
 "\n"
-"Non-staff users receive a subset of all the documented fields. The fields reserved for staff users are used for internal form configuration. These are: \n"
+"Non-staff users receive a subset of all the documented fields. The fields "
+"reserved for staff users are used for internal form configuration. These "
+"are: \n"
 "\n"
 "{admin_fields}\n"
 "\n"
-"If the form doesn't have translations enabled, its default language is forced by setting a language cookie and reflected in the Content-Language response header. Normal HTTP Content Negotiation rules apply."
+"If the form doesn't have translations enabled, its default language is "
+"forced by setting a language cookie and reflected in the Content-Language "
+"response header. Normal HTTP Content Negotiation rules apply."
 msgstr ""
 "Haal de details/configuratie op van een specifiek formulier.\n"
 "\n"
-"Een formulier is een verzameling van één of meerdere formulierstappen waarbij elke stap een verwijzing heeft naar een formio.js formulierdefinitie. Meerdere definities samen vormen een logisch geheel van formulierstappen die de klant doorloopt tijdens het invullen van het formulier. Formulierdefinities kunnen herbruikbaar zijn tussen verschillende formulieren.\n"
+"Een formulier is een verzameling van één of meerdere formulierstappen "
+"waarbij elke stap een verwijzing heeft naar een formio.js "
+"formulierdefinitie. Meerdere definities samen vormen een logisch geheel van "
+"formulierstappen die de klant doorloopt tijdens het invullen van het "
+"formulier. Formulierdefinities kunnen herbruikbaar zijn tussen verschillende "
+"formulieren.\n"
 "\n"
 "**Waarschuwing: de response-data is afhankelijk van de gebruikersrechten**\n"
 "\n"
-"Gebruikers die geen beheerder zijn, ontvangen maar een deel van de gedocumenteerde velden. De velden die enkel voor beheerders beschikbaar zijn, zijn voor interne formulierconfiguratie. Het gaat om de velden:\n"
+"Gebruikers die geen beheerder zijn, ontvangen maar een deel van de "
+"gedocumenteerde velden. De velden die enkel voor beheerders beschikbaar "
+"zijn, zijn voor interne formulierconfiguratie. Het gaat om de velden:\n"
 "\n"
 "{admin_fields}\n"
 "\n"
-"Wanneer meertaligheid niet ingeschakeld is voor het formulier, dan wordt de standaardtaal (`settings.LANGUAGE_CODE`) geforceerd gezet in een language cookie. De actieve taal wordt gecommuniceerd in de Content-Language response header. De gebruikelijke HTTP Content Negotiation principes zijn van toepassing."
+"Wanneer meertaligheid niet ingeschakeld is voor het formulier, dan wordt de "
+"standaardtaal (`settings.LANGUAGE_CODE`) geforceerd gezet in een language "
+"cookie. De actieve taal wordt gecommuniceerd in de Content-Language response "
+"header. De gebruikelijke HTTP Content Negotiation principes zijn van "
+"toepassing."
 
 #: openforms/forms/api/viewsets.py:269
 msgid "Create form"
@@ -7498,8 +7587,8 @@ msgstr "Configureer logicaregels in bulk"
 
 #: openforms/forms/api/viewsets.py:306
 msgid ""
-"By sending a list of LogicRules to this endpoint, all the LogicRules related"
-" to the form will be replaced with the data sent to the endpoint."
+"By sending a list of LogicRules to this endpoint, all the LogicRules related "
+"to the form will be replaced with the data sent to the endpoint."
 msgstr ""
 "Alle logicaregels van het formulier worden vervangen met de toegestuurde "
 "regels."
@@ -7557,9 +7646,9 @@ msgstr "Het UUID van de formulierversie"
 msgid "List form versions"
 msgstr "Formulierversies weergeven"
 
-#: openforms/forms/api/viewsets.py:784
-#: openforms/forms/templates/admin/forms/form/import_form.html:15
-#: openforms/forms/templates/admin/forms/form/import_form.html:20
+#: openforms/forms/api/viewsets.py:787
+#: openforms/forms/templates/admin/forms/form/import_form.html:16
+#: openforms/forms/templates/admin/forms/form/import_form.html:21
 msgid "Import form"
 msgstr "Formulier importeren"
 
@@ -7651,13 +7740,25 @@ msgstr "Afspraak"
 msgid "Single step"
 msgstr "Enkele stap"
 
-#: openforms/forms/forms/form.py:7
+#: openforms/forms/forms/form.py:14
 msgid "file"
 msgstr "bestand"
 
-#: openforms/forms/forms/form.py:9
+#: openforms/forms/forms/form.py:16
 msgid "Upload your exported ZIP-file."
 msgstr "Upload het geëxporteerde ZIP-bestand."
+
+#: openforms/forms/forms/form.py:34
+#, fuzzy
+#| msgid "Create a form definition"
+msgid "Reusable form definition"
+msgstr "Formulierdefinitie toevoegen"
+
+#: openforms/forms/forms/form.py:46
+#, fuzzy
+#| msgid "Confirmation email templates"
+msgid "Links to unknown domains in email templates"
+msgstr "Bevestigingsmailsjablonen"
 
 #: openforms/forms/forms/form_statistics.py:38
 msgid "Successfully registered"
@@ -7700,7 +7801,7 @@ msgstr "Exporteer inzendingen die op of voor deze datum ingestuurd zijn."
 
 #: openforms/forms/forms/form_statistics.py:72
 #: openforms/forms/templates/admin/forms/form/export.html:14
-#: openforms/forms/templates/admin/forms/form/import_form.html:14
+#: openforms/forms/templates/admin/forms/form/import_form.html:15
 #: openforms/forms/templates/admin/forms/form/migrate-payment-backend.html:19
 msgid "Forms"
 msgstr "Formulieren"
@@ -7748,8 +7849,8 @@ msgid ""
 "The {name} \"{obj}\" was changed successfully. You may add another {name} "
 "below."
 msgstr ""
-"De {name} \"{obj}\" is met succes gewijzigd. U kunt hieronder nog een {name}"
-" bewerken."
+"De {name} \"{obj}\" is met succes gewijzigd. U kunt hieronder nog een {name} "
+"bewerken."
 
 #: openforms/forms/messages.py:70
 msgid "You may edit it again below."
@@ -7763,21 +7864,21 @@ msgstr "Eenvoudige naam"
 msgid "categories"
 msgstr "categorieën"
 
-#: openforms/forms/models/form.py:82
+#: openforms/forms/models/form.py:89
 #: openforms/forms/models/form_definition.py:42
 msgid "internal name"
 msgstr "interne naam"
 
-#: openforms/forms/models/form.py:85
+#: openforms/forms/models/form.py:92
 #: openforms/forms/models/form_definition.py:45
 msgid "internal name for management purposes"
 msgstr "interne naam voor beheerdoeleinden "
 
-#: openforms/forms/models/form.py:88
+#: openforms/forms/models/form.py:95
 msgid "internal remarks"
 msgstr "interne opmerkingen"
 
-#: openforms/forms/models/form.py:90
+#: openforms/forms/models/form.py:97
 msgid ""
 "Remarks or intentions about the form. Can also be used to save notes for "
 "later use or for another admin user."
@@ -7785,17 +7886,17 @@ msgstr ""
 "Opmerkingen of intenties over het formulier. Kan ook gebruikt worden voor "
 "het maken van notities voor later gebruik of voor een andere beheerder."
 
-#: openforms/forms/models/form.py:97
+#: openforms/forms/models/form.py:104
 #: openforms/forms/models/form_definition.py:47
 #: openforms/forms/models/form_step.py:33
 msgid "slug"
 msgstr "URL-deel"
 
-#: openforms/forms/models/form.py:100
+#: openforms/forms/models/form.py:107
 msgid "form type"
 msgstr "formuliertype"
 
-#: openforms/forms/models/form.py:104
+#: openforms/forms/models/form.py:111
 msgid ""
 "The type of the form. The choices are regular, appointment or a single step "
 "form. Depending on the choice a different form design is required/rendered."
@@ -7804,57 +7905,56 @@ msgstr ""
 "standaard, afspraak of een formulier met één stap. Afhankelijk van de keuze "
 "zijn andere formulierinstellingen beschikbaar/verplicht."
 
-#: openforms/forms/models/form.py:122
+#: openforms/forms/models/form.py:129
 msgid "form theme"
 msgstr "formulierstijl"
 
-#: openforms/forms/models/form.py:124
+#: openforms/forms/models/form.py:131
 msgid ""
 "Apply a specific appearance configuration to the form. If left blank, then "
 "the globally configured default is applied."
 msgstr ""
-"Pas een specifieke stijl toe op het formulier. Indien geen optie gekozen is,"
-" dan wordt de globale instelling toegepast."
+"Pas een specifieke stijl toe op het formulier. Indien geen optie gekozen is, "
+"dan wordt de globale instelling toegepast."
 
-#: openforms/forms/models/form.py:128
+#: openforms/forms/models/form.py:135
 msgid "translation enabled"
 msgstr "meertaligheid ingeschakeld"
 
-#: openforms/forms/models/form.py:131 openforms/forms/models/form.py:521
+#: openforms/forms/models/form.py:138 openforms/forms/models/form.py:528
 msgid "payment backend"
 msgstr "betaalprovider backend"
 
-#: openforms/forms/models/form.py:138
+#: openforms/forms/models/form.py:145
 msgid "price variable key"
 msgstr "sleutel prijsvariabele"
 
-#: openforms/forms/models/form.py:141
+#: openforms/forms/models/form.py:148
 msgid "Key of the variable that contains the calculated submission price."
 msgstr ""
-"Sleutel van de variabele die de (berekende) kostprijs van de inzending "
-"bevat."
+"Sleutel van de variabele die de (berekende) kostprijs van de inzending bevat."
 
-#: openforms/forms/models/form.py:148
+#: openforms/forms/models/form.py:155
 msgid "automatic login"
 msgstr "automatisch inloggen"
 
-#: openforms/forms/models/form.py:153
+#: openforms/forms/models/form.py:160
 msgid "maximum allowed submissions"
 msgstr "maximum aantal inzendingen"
 
-#: openforms/forms/models/form.py:157
+#: openforms/forms/models/form.py:164
 msgid ""
-"Maximum number of allowed submissions per form. Leave this empty if no limit"
-" is needed."
+"Maximum number of allowed submissions per form. Leave this empty if no limit "
+"is needed."
 msgstr ""
 "Het maximum aantal inzendingen die toegestaan zijn voor het formulier. Laat "
 "dit veld leeg als er geen beperking is."
 
-#: openforms/forms/models/form.py:161
+#: openforms/forms/models/form.py:168
 msgid "submissions counter"
 msgstr "aantal inzendingen"
 
-#: openforms/forms/models/form.py:164
+#: openforms/forms/models/form.py:171
 msgid ""
 "Counter to track how many submissions have been completed for the specific "
 "form. This works in combination with the maximum allowed submissions per "
@@ -7864,7 +7964,7 @@ msgstr ""
 "Deze werkt samen met de inzendingslimiet en kan gereset worden via de "
 "frontend."
 
-#: openforms/forms/models/form.py:172
+#: openforms/forms/models/form.py:179
 msgid ""
 "The content of the submission confirmation page. It can contain variables "
 "that will be templated from the submitted form data. If not specified, the "
@@ -7874,12 +7974,12 @@ msgstr ""
 "de ingediende formuliergegevens worden weergegeven. Indien niet opgegeven "
 "dan wordt de globale bevestingspagina gebruikt."
 
-#: openforms/forms/models/form.py:181
+#: openforms/forms/models/form.py:188
 #: openforms/submissions/api/serializers.py:157
 msgid "submission allowed"
 msgstr "inzenden toegestaan"
 
-#: openforms/forms/models/form.py:185
+#: openforms/forms/models/form.py:192
 msgid ""
 "Whether the user is allowed to submit this form or not, and whether the "
 "overview page should be shown if they are not."
@@ -7887,63 +7987,63 @@ msgstr ""
 "Geeft aan of de gebruiker het formulier kan verzenden en of de "
 "overzichtspagina getoond wordt als het formulier niet verzonden kan worden."
 
-#: openforms/forms/models/form.py:191
+#: openforms/forms/models/form.py:198
 msgid "suspension allowed"
 msgstr "tussentijds opslaan"
 
-#: openforms/forms/models/form.py:193
+#: openforms/forms/models/form.py:200
 msgid "Whether the user is allowed to suspend this form or not."
 msgstr ""
 "Geeft aan of de gebruiker het formulier tussentijds kan opslaan/pauzeren of "
 "niet."
 
-#: openforms/forms/models/form.py:196
+#: openforms/forms/models/form.py:203
 msgid "show progress indicator"
 msgstr "toon formulierstappen"
 
-#: openforms/forms/models/form.py:199
+#: openforms/forms/models/form.py:206
 msgid "Whether the step progression should be displayed in the UI or not."
 msgstr ""
 "Indien aangevinkt dan worden de stappen van het formulier aan de gebruiker "
 "getoond."
 
-#: openforms/forms/models/form.py:203
+#: openforms/forms/models/form.py:210
 msgid "show summary of the progress"
 msgstr "toon voortgangsoverzicht"
 
-#: openforms/forms/models/form.py:206
+#: openforms/forms/models/form.py:213
 msgid ""
 "Whether to display the short progress summary, indicating the current step "
 "number and total amount of steps."
 msgstr ""
-"Vink aan om het korte voortgangsoverzicht weer te geven. Dit overzicht toont"
-" de huidige stap en het totaal aantal stappen, typisch onder de "
+"Vink aan om het korte voortgangsoverzicht weer te geven. Dit overzicht toont "
+"de huidige stap en het totaal aantal stappen, typisch onder de "
 "formuliertitel."
 
-#: openforms/forms/models/form.py:211
+#: openforms/forms/models/form.py:218
 msgid "display main website link"
 msgstr "toon hoofdsite link"
 
-#: openforms/forms/models/form.py:214
+#: openforms/forms/models/form.py:221
 msgid ""
 "Display the link to the main website on the submission confirmation page."
 msgstr "Toon de link naar de hoofdsite op de bevestigingspagina na inzenden."
 
-#: openforms/forms/models/form.py:218
+#: openforms/forms/models/form.py:225
 msgid "include confirmation page content in PDF"
 msgstr "voeg de \"bevestigingspaginatekst\" toe in de bevestigings-PDF"
 
-#: openforms/forms/models/form.py:220
+#: openforms/forms/models/form.py:227
 msgid "Display the instruction from the confirmation page in the PDF."
 msgstr ""
-"Vink aan om de inhoud van het \"bevestigingspaginatekst\"-veld toe te voegen"
-" aan de PDF met gegevens ter bevestiging."
+"Vink aan om de inhoud van het \"bevestigingspaginatekst\"-veld toe te voegen "
+"aan de PDF met gegevens ter bevestiging."
 
-#: openforms/forms/models/form.py:223
+#: openforms/forms/models/form.py:230
 msgid "send confirmation email"
 msgstr "verstuur bevestigingsmail"
 
-#: openforms/forms/models/form.py:225
+#: openforms/forms/models/form.py:232
 msgid ""
 "Whether a confirmation email should be sent to the end user filling in the "
 "form."
@@ -7951,7 +8051,7 @@ msgstr ""
 "Geef aan of er een bevestigingsmail naar de formulierinzender verstuurd "
 "dient te worden."
 
-#: openforms/forms/models/form.py:255
+#: openforms/forms/models/form.py:262
 msgid ""
 "The text that will be displayed at the start of the form to indicate the "
 "user can begin to fill in the form. Leave blank to get value from global "
@@ -7960,19 +8060,19 @@ msgstr ""
 "Het label van de knop om het formulier te starten. Laat leeg om de waarde "
 "van de algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:261
+#: openforms/forms/models/form.py:268
 msgid "previous text"
 msgstr "Vorige stap-label"
 
-#: openforms/forms/models/form.py:265
+#: openforms/forms/models/form.py:272
 msgid ""
 "The text that will be displayed in the overview page to go to the previous "
 "step. Leave blank to get value from global configuration."
 msgstr ""
-"Het label van de knop op de overzichtspagina om naar de vorige stap te gaan."
-" Laat leeg om de waarde van de algemene configuratie te gebruiken."
+"Het label van de knop op de overzichtspagina om naar de vorige stap te gaan. "
+"Laat leeg om de waarde van de algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:275
+#: openforms/forms/models/form.py:282
 msgid ""
 "The text that will be displayed in the overview page to change a certain "
 "step. Leave blank to get value from global configuration."
@@ -7980,7 +8080,7 @@ msgstr ""
 "Het label de link op de overzichtspagina om een bepaalde stap te wijzigen. "
 "Laat leeg om de waarde van de algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:285
+#: openforms/forms/models/form.py:292
 msgid ""
 "The text that will be displayed in the overview page to confirm the form is "
 "filled in correctly. Leave blank to get value from global configuration."
@@ -7988,11 +8088,11 @@ msgstr ""
 "Het label van de knop op de overzichtspagina om het formulier in te dienen. "
 "Laat leeg om de waarde van de algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:293
+#: openforms/forms/models/form.py:300
 msgid "introduction page"
 msgstr "introductiepagina"
 
-#: openforms/forms/models/form.py:295
+#: openforms/forms/models/form.py:302
 msgid ""
 "Content for the introduction page that leads to the start page of the form. "
 "Leave blank to disable the introduction page."
@@ -8000,43 +8100,43 @@ msgstr ""
 "Inhoud voor de introductiepagina die naar de formulierstartpagina leidt. "
 "Laat deze leeg om de introductiepagina uit te schakelen."
 
-#: openforms/forms/models/form.py:303
+#: openforms/forms/models/form.py:310
 msgid "explanation template"
 msgstr "Toelichtingssjabloon"
 
-#: openforms/forms/models/form.py:305
+#: openforms/forms/models/form.py:312
 msgid ""
 "Content that will be shown on the start page of the form, below the title "
 "and above the log in text."
 msgstr ""
-"Inhoud die op de formulierstartpagina wordt getoond, onder de titel en boven"
-" de startknop(pen)."
+"Inhoud die op de formulierstartpagina wordt getoond, onder de titel en boven "
+"de startknop(pen)."
 
-#: openforms/forms/models/form.py:313
+#: openforms/forms/models/form.py:320
 msgid "maintenance mode"
 msgstr "onderhoudsmodus"
 
-#: openforms/forms/models/form.py:316
+#: openforms/forms/models/form.py:323
 msgid "Users will not be able to start the form if it is in maintenance mode."
 msgstr "Gebruikers kunnen een formulier in onderhoudsmodus niet starten."
 
-#: openforms/forms/models/form.py:321
+#: openforms/forms/models/form.py:328
 msgid "activate on"
 msgstr "Activeren op"
 
-#: openforms/forms/models/form.py:324
+#: openforms/forms/models/form.py:331
 msgid "Date and time on which the form should be activated."
 msgstr "Datum en tijdstip waarop het formulier geactiveerd moet worden."
 
-#: openforms/forms/models/form.py:327
+#: openforms/forms/models/form.py:334
 msgid "deactivate on"
 msgstr "Deactiveren op"
 
-#: openforms/forms/models/form.py:330
+#: openforms/forms/models/form.py:337
 msgid "Date and time on which the form should be deactivated."
 msgstr "Datum en tijdstip waarop het formulier gedeactiveerd moet worden."
 
-#: openforms/forms/models/form.py:340
+#: openforms/forms/models/form.py:347
 msgid ""
 "Amount of days successful submissions of this form will remain before being "
 "removed. Leave blank to use value in General Configuration."
@@ -8044,7 +8144,7 @@ msgstr ""
 "Aantal dagen dat een voltooide inzending bewaard blijft. Laat leeg om de "
 "waarde van de algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:350
+#: openforms/forms/models/form.py:357
 msgid ""
 "How successful submissions of this form will be removed after the limit. "
 "Leave blank to use value in General Configuration."
@@ -8052,7 +8152,7 @@ msgstr ""
 "Geeft aan hoe voltooide inzendingen worden opgeschoond na de bewaartermijn. "
 "Laat leeg om de waarde van de algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:360
+#: openforms/forms/models/form.py:367
 msgid ""
 "Amount of days incomplete submissions of this form will remain before being "
 "removed. Leave blank to use value in General Configuration."
@@ -8060,7 +8160,7 @@ msgstr ""
 "Aantal dagen dat een sessie bewaard blijft. Laat leeg om de waarde van de "
 "algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:370
+#: openforms/forms/models/form.py:377
 msgid ""
 "How incomplete submissions of this form will be removed after the limit. "
 "Leave blank to use value in General Configuration."
@@ -8068,7 +8168,7 @@ msgstr ""
 "Geeft aan hoe sessies worden opgeschoond na de bewaartermijn. Laat leeg om "
 "de waarde van de algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:380
+#: openforms/forms/models/form.py:387
 msgid ""
 "Amount of days errored submissions of this form will remain before being "
 "removed. Leave blank to use value in General Configuration."
@@ -8077,7 +8177,7 @@ msgstr ""
 "afhandeling) bewaard blijft. Laat leeg om de waarde van de algemene "
 "configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:390
+#: openforms/forms/models/form.py:397
 msgid ""
 "How errored submissions of this form will be removed after the limit. Leave "
 "blank to use value in General Configuration."
@@ -8086,7 +8186,7 @@ msgstr ""
 "worden opgeschoond na de bewaartermijn. Laat leeg om de waarde van de "
 "algemene configuratie te gebruiken."
 
-#: openforms/forms/models/form.py:400
+#: openforms/forms/models/form.py:407
 msgid ""
 "Amount of days when all submissions of this form will be permanently "
 "deleted. Leave blank to use value in General Configuration."
@@ -8095,11 +8195,11 @@ msgstr ""
 "verwijderd wordt. Laat leeg om de waarde van de algemene configuratie te "
 "gebruiken."
 
-#: openforms/forms/models/form.py:408
+#: openforms/forms/models/form.py:415
 msgid "enable new logic rule evaluation"
 msgstr "gebruik nieuwe logica-evaluatie"
 
-#: openforms/forms/models/form.py:411
+#: openforms/forms/models/form.py:418
 msgid ""
 "Enabling this will analyze logic rules and re-order them according to their "
 "dependency on other logic rules (happens when the form is saved). Each rule "
@@ -8113,76 +8213,76 @@ msgstr ""
 "Daarnaast zullen ook andere snelheidsverbeteringen toegepast worden waar "
 "mogelijk."
 
-#: openforms/forms/models/form.py:438
+#: openforms/forms/models/form.py:445
 msgid "forms"
 msgstr "formulieren"
 
-#: openforms/forms/models/form.py:442
+#: openforms/forms/models/form.py:449
 #, python-brace-format
 msgid "{name} (deleted)"
 msgstr "{name} (verwijderd)"
 
-#: openforms/forms/models/form.py:502 openforms/forms/models/form.py:518
-#: openforms/forms/models/form.py:531
+#: openforms/forms/models/form.py:509 openforms/forms/models/form.py:525
+#: openforms/forms/models/form.py:538
 #, python-brace-format
 msgid "{backend} (invalid)"
 msgstr "{backend} (ongeldig)"
 
-#: openforms/forms/models/form.py:509
+#: openforms/forms/models/form.py:516
 msgid "registrations"
 msgstr "Registraties"
 
-#: openforms/forms/models/form.py:536
+#: openforms/forms/models/form.py:543
 msgid "logins"
 msgstr "inloggen"
 
-#: openforms/forms/models/form.py:581 openforms/forms/models/form.py:596
+#: openforms/forms/models/form.py:588 openforms/forms/models/form.py:603
 #: openforms/forms/models/form_definition.py:106
 #: openforms/forms/models/form_definition.py:124
 #, python-brace-format
 msgid "{name} (copy)"
 msgstr "{name} (kopie)"
 
-#: openforms/forms/models/form.py:585
+#: openforms/forms/models/form.py:592
 #: openforms/forms/models/form_definition.py:110
 #, python-brace-format
 msgid "{slug}-copy"
 msgstr "{slug}-kopie"
 
-#: openforms/forms/models/form.py:708
+#: openforms/forms/models/form.py:773
 #, python-brace-format
 msgid "Restored form version {version} (from {created})."
 msgstr "Formulierversie {version} hersteld (van {created})."
 
-#: openforms/forms/models/form.py:830
+#: openforms/forms/models/form.py:895
 msgid "export content"
 msgstr "Exportinhoud"
 
-#: openforms/forms/models/form.py:832
+#: openforms/forms/models/form.py:897
 msgid "Zip file containing all the exported forms."
 msgstr "Het ZIP-bestand met daarin alle geëxporteerde formulieren."
 
-#: openforms/forms/models/form.py:835
+#: openforms/forms/models/form.py:900
 msgid "date time requested"
 msgstr "Moment van aanvraag"
 
-#: openforms/forms/models/form.py:836
+#: openforms/forms/models/form.py:901
 msgid "The date and time on which the bulk export was requested."
 msgstr "De datum en tijdstip waarop de bulk export aangevraagd is."
 
-#: openforms/forms/models/form.py:842
+#: openforms/forms/models/form.py:907
 msgid "The user that requested the download."
 msgstr "De gebruiker die de download heeft aangevraagd."
 
-#: openforms/forms/models/form.py:849
+#: openforms/forms/models/form.py:914
 msgid "forms export"
 msgstr "formulierenexport"
 
-#: openforms/forms/models/form.py:850
+#: openforms/forms/models/form.py:915
 msgid "forms exports"
 msgstr "Formulierexports"
 
-#: openforms/forms/models/form.py:853
+#: openforms/forms/models/form.py:918
 #, python-format
 msgid "Bulk export requested by %(username)s on %(datetime)s"
 msgstr "Bulk-export aangevraagd door %(username)s op %(datetime)s"
@@ -8239,7 +8339,7 @@ msgstr ""
 "meerdere formulieren gebruikt wordt."
 
 #: openforms/forms/models/form_registration_backend.py:18
-#: openforms/forms/models/form_variable.py:261
+#: openforms/forms/models/form_variable.py:269
 #: openforms/submissions/models/submission_value_variable.py:454
 msgid "key"
 msgstr "sleutel"
@@ -8268,8 +8368,8 @@ msgstr "Vorige stap-label"
 
 #: openforms/forms/models/form_step.py:46
 msgid ""
-"The text that will be displayed in the form step to go to the previous step."
-" Leave blank to get value from global configuration."
+"The text that will be displayed in the form step to go to the previous step. "
+"Leave blank to get value from global configuration."
 msgstr ""
 "Het label van de knop om naar de vorige stap binnen het formulier te gaan. "
 "Laat leeg om de waarde van de algemene configuratie te gebruiken."
@@ -8279,16 +8379,16 @@ msgid ""
 "The text that will be displayed in the form step to save the current "
 "information. Leave blank to get value from global configuration."
 msgstr ""
-"Het label van de knop om het formulier tussentijds op te slaan. Laat leeg om"
-" de waarde van de algemene configuratie te gebruiken."
+"Het label van de knop om het formulier tussentijds op te slaan. Laat leeg om "
+"de waarde van de algemene configuratie te gebruiken."
 
 #: openforms/forms/models/form_step.py:64
 msgid ""
 "The text that will be displayed in the form step to go to the next step. "
 "Leave blank to get value from global configuration."
 msgstr ""
-"Het label van de knop om naar de volgende stap binnen het formulier te gaan."
-" Laat leeg om de waarde van de algemene configuratie te gebruiken."
+"Het label van de knop om naar de volgende stap binnen het formulier te gaan. "
+"Laat leeg om de waarde van de algemene configuratie te gebruiken."
 
 #: openforms/forms/models/form_step.py:69
 msgid "is applicable"
@@ -8308,95 +8408,95 @@ msgstr "{form_name} stap {order}: {definition_name}"
 msgid "form submission statistics"
 msgstr "inzendingstatistieken"
 
-#: openforms/forms/models/form_variable.py:242
+#: openforms/forms/models/form_variable.py:250
 msgid "Form to which this variable is related"
 msgstr "Formulier waarbij deze variabele hoort"
 
-#: openforms/forms/models/form_variable.py:248
+#: openforms/forms/models/form_variable.py:256
 msgid "form definition"
 msgstr "Formulierdefinitie"
 
-#: openforms/forms/models/form_variable.py:250
+#: openforms/forms/models/form_variable.py:258
 msgid ""
 "Form definition to which this variable is related. This is kept as metadata"
 msgstr "Formulierdefinitie waarbij deze variabele hoort."
 
-#: openforms/forms/models/form_variable.py:258
+#: openforms/forms/models/form_variable.py:266
 msgid "Name of the variable"
 msgstr "Variabelenaam"
 
-#: openforms/forms/models/form_variable.py:262
+#: openforms/forms/models/form_variable.py:270
 msgid "Key of the variable, should be unique with the form."
 msgstr "Sleutel van de variabele, uniek binnen het formulier."
 
-#: openforms/forms/models/form_variable.py:266
+#: openforms/forms/models/form_variable.py:274
 #: openforms/submissions/models/submission_value_variable.py:465
 msgid "source"
 msgstr "bron"
 
-#: openforms/forms/models/form_variable.py:268
+#: openforms/forms/models/form_variable.py:276
 msgid ""
 "Where will the data that will be associated with this variable come from"
 msgstr "Oorsprong van de gegevens die in deze variabele opgeslagen worden"
 
-#: openforms/forms/models/form_variable.py:274
+#: openforms/forms/models/form_variable.py:282
 #: openforms/variables/models.py:106
 msgid "service fetch configuration"
 msgstr "Servicebevragingconfiguratie"
 
-#: openforms/forms/models/form_variable.py:281
+#: openforms/forms/models/form_variable.py:289
 msgid "prefill plugin"
 msgstr "prefillplugin"
 
-#: openforms/forms/models/form_variable.py:282
+#: openforms/forms/models/form_variable.py:290
 msgid "Which, if any, prefill plugin should be used"
 msgstr "Prefill-plugin om gegevens op te halen"
 
-#: openforms/forms/models/form_variable.py:287
+#: openforms/forms/models/form_variable.py:295
 msgid "prefill attribute"
 msgstr "prefillattribuut"
 
-#: openforms/forms/models/form_variable.py:289
+#: openforms/forms/models/form_variable.py:297
 msgid ""
 "Which attribute from the prefill response should be used to fill this "
 "variable"
 msgstr "Attribuut uit de prefill-response om de waarde mee te vullen"
 
-#: openforms/forms/models/form_variable.py:295
+#: openforms/forms/models/form_variable.py:303
 msgid "prefill identifier role"
 msgstr "Prefill-bron"
 
-#: openforms/forms/models/form_variable.py:297
+#: openforms/forms/models/form_variable.py:305
 msgid ""
 "In case that multiple identifiers are returned (in the case of eHerkenning "
 "bewindvoering and DigiD Machtigen), should the prefill data related to the "
 "main identifier be used, or that related to the authorised person?"
 msgstr ""
 "Indien meerdere unieke identificaties beschikbaar zijn (bijvoorbeeld bij "
-"eHerkenning Bewindvoering en DigiD Machtigen), welke prefill-gegevens moeten"
-" dan opgehaald worden? Deze voor de machtiger of de gemachtigde?"
+"eHerkenning Bewindvoering en DigiD Machtigen), welke prefill-gegevens moeten "
+"dan opgehaald worden? Deze voor de machtiger of de gemachtigde?"
 
-#: openforms/forms/models/form_variable.py:305
+#: openforms/forms/models/form_variable.py:313
 msgid "prefill options"
 msgstr "prefillopties"
 
-#: openforms/forms/models/form_variable.py:310
-#: openforms/submissions/models/submission_value_variable.py:496
+#: openforms/forms/models/form_variable.py:318
+#: openforms/submissions/models/submission_value_variable.py:498
 msgid "data type"
 msgstr "datatype"
 
-#: openforms/forms/models/form_variable.py:311
-#: openforms/submissions/models/submission_value_variable.py:497
+#: openforms/forms/models/form_variable.py:319
+#: openforms/submissions/models/submission_value_variable.py:499
 msgid "The type of the value that will be associated with this variable"
 msgstr "Datatype van de waarden voor deze variabele"
 
-#: openforms/forms/models/form_variable.py:316
-#: openforms/submissions/models/submission_value_variable.py:502
+#: openforms/forms/models/form_variable.py:324
+#: openforms/submissions/models/submission_value_variable.py:504
 msgid "data subtype"
 msgstr "data subtype"
 
-#: openforms/forms/models/form_variable.py:318
-#: openforms/submissions/models/submission_value_variable.py:504
+#: openforms/forms/models/form_variable.py:326
+#: openforms/submissions/models/submission_value_variable.py:506
 msgid ""
 "This field represents the data type of the values inside the container for "
 "components that are configured as 'multiple'."
@@ -8404,50 +8504,50 @@ msgstr ""
 "Dit veld representeert het data type van de waarde binnen de container voor "
 "componenten die geconfigureerd zijn als 'meerdere'."
 
-#: openforms/forms/models/form_variable.py:326
+#: openforms/forms/models/form_variable.py:334
 msgid "data format"
 msgstr "dataformaat"
 
-#: openforms/forms/models/form_variable.py:328
+#: openforms/forms/models/form_variable.py:336
 msgid "The format of the value that will be associated with this variable"
 msgstr "Formaat van de waarden voor deze variabele"
 
-#: openforms/forms/models/form_variable.py:334
+#: openforms/forms/models/form_variable.py:342
 msgid "is sensitive data"
 msgstr "is privacy-gevoelig"
 
-#: openforms/forms/models/form_variable.py:335
+#: openforms/forms/models/form_variable.py:343
 msgid "Will this variable be associated with sensitive data?"
 msgstr ""
 "Geef aan of de variabele (mogelijks) privacy-gevoelige waarden zal hebben."
 
-#: openforms/forms/models/form_variable.py:339
+#: openforms/forms/models/form_variable.py:347
 msgid "initial value"
 msgstr "beginwaarde"
 
-#: openforms/forms/models/form_variable.py:340
+#: openforms/forms/models/form_variable.py:348
 msgid "The initial value for this field"
 msgstr "De beginwaarde voor dit veld"
 
-#: openforms/forms/models/form_variable.py:352
+#: openforms/forms/models/form_variable.py:360
 msgid "Form variable"
 msgstr "Formuliervariabele"
 
-#: openforms/forms/models/form_variable.py:353
+#: openforms/forms/models/form_variable.py:361
 msgid "Form variables"
 msgstr "Formuliervariabelen"
 
-#: openforms/forms/models/form_variable.py:426
+#: openforms/forms/models/form_variable.py:434
 #, python-brace-format
 msgid "Form variable '{key}'"
 msgstr "Formuliervariabele '{key}'"
 
-#: openforms/forms/models/form_version.py:29
+#: openforms/forms/models/form_version.py:52
 #, python-brace-format
 msgid "Version {number}"
 msgstr "Versie {number}"
 
-#: openforms/forms/models/form_version.py:52
+#: openforms/forms/models/form_version.py:75
 msgid ""
 "The form, form definitions and form steps that make up this version, saved "
 "as JSON data."
@@ -8455,44 +8555,44 @@ msgstr ""
 "Het formulier, formulierdefinities en formulierstappen waaruit deze versie "
 "bestaat, bewaard als JSON."
 
-#: openforms/forms/models/form_version.py:57
+#: openforms/forms/models/form_version.py:80
 msgid "Date and time of creation of the form version."
 msgstr "Datum en tijd waarop de formulierversie is aangemaakt."
 
-#: openforms/forms/models/form_version.py:65
+#: openforms/forms/models/form_version.py:88
 msgid "User who authored this version."
 msgstr "Gebruiker die deze versie aangemaakt heeft."
 
-#: openforms/forms/models/form_version.py:68
+#: openforms/forms/models/form_version.py:91
 msgid "version description"
 msgstr "Versie-omschrijving"
 
-#: openforms/forms/models/form_version.py:70
+#: openforms/forms/models/form_version.py:93
 msgid "Description/context about this particular version."
 msgstr "Omschrijving/context bij deze specifieke versie."
 
-#: openforms/forms/models/form_version.py:73
+#: openforms/forms/models/form_version.py:96
 #: openforms/translations/models.py:78
 msgid "application version"
 msgstr "applicatieversie"
 
-#: openforms/forms/models/form_version.py:76
+#: openforms/forms/models/form_version.py:99
 msgid "App release/version at the time this version was created."
 msgstr "Applicatieversie op het moment dat deze versie onstond."
 
-#: openforms/forms/models/form_version.py:81
+#: openforms/forms/models/form_version.py:104
 msgid "application commit hash"
 msgstr "Commit hash van de applicatie"
 
-#: openforms/forms/models/form_version.py:84
+#: openforms/forms/models/form_version.py:107
 msgid "Application commit hash at the time this version was created."
 msgstr "Commit hash van de applicatie op het moment dat deze versie onstond."
 
-#: openforms/forms/models/form_version.py:92
+#: openforms/forms/models/form_version.py:115
 msgid "form version"
 msgstr "formulierversie"
 
-#: openforms/forms/models/form_version.py:93
+#: openforms/forms/models/form_version.py:116
 msgid "form versions"
 msgstr "formulierversies"
 
@@ -8549,8 +8649,7 @@ msgstr "Is geavanceerd"
 
 #: openforms/forms/models/logic.py:67
 msgid ""
-"Is this an advanced rule (the admin user manually wrote the trigger as "
-"JSON)?"
+"Is this an advanced rule (the admin user manually wrote the trigger as JSON)?"
 msgstr ""
 "Is dit een geavanceerde regel (de beheerder heeft de trigger handmatig als "
 "JSON geschreven)?"
@@ -8576,7 +8675,7 @@ msgstr "Afgeronde inzendingen van {start} tot en met {end}"
 #: openforms/forms/statistics.py:52
 #: openforms/registrations/contrib/generic_json/registration_variables.py:27
 #: openforms/registrations/contrib/objects_api/registration_variables.py:31
-#: openforms/submissions/api/serializers.py:649
+#: openforms/submissions/api/serializers.py:652
 msgid "Public reference"
 msgstr "Publieke referentie"
 
@@ -8619,10 +8718,10 @@ msgstr "Formulieren zonder categorie"
 
 #: openforms/forms/templates/admin/forms/form/export.html:34
 msgid ""
-"<p> Here you can control how the previously selected forms will be exported."
-" Using these options, sensitive information can be anonymized, certain form "
-"configuration can be left out, and additional information can be included. "
-"</p> <p> These export options will be used for each form that will be "
+"<p> Here you can control how the previously selected forms will be exported. "
+"Using these options, sensitive information can be anonymized, certain form "
+"configuration can be left out, and additional information can be included. </"
+"p> <p> These export options will be used for each form that will be "
 "exported. </p> <p> After you've clicked the \"Export\" button, the forms "
 "will be exported in the background. <br/> Once your request has been "
 "processed, you will be sent an email (at the address configured in your "
@@ -8634,20 +8733,20 @@ msgstr ""
 "kunnen formulierinstellingen uitgesloten worden en ondersteunende gegevens "
 "toegevoegd worden. </p><p>Deze exporteeropties worden gebruikt voor ieder "
 "formulier dat geëxporteerd zal worden. </p><p> Nadat je op de \"Export\" "
-"knop hebt gedrukt, worden de formulieren in de achtergrond geëxporteerd. "
-"<br/> Zodra uw verzoek verwerkt is, ontvangt u een e-mail met een link naar "
-"het ZIP-bestand dat alle geëxporteerde formulieren bevat.</p>"
+"knop hebt gedrukt, worden de formulieren in de achtergrond geëxporteerd. <br/"
+"> Zodra uw verzoek verwerkt is, ontvangt u een e-mail met een link naar het "
+"ZIP-bestand dat alle geëxporteerde formulieren bevat.</p>"
 
-#: openforms/forms/templates/admin/forms/form/export.html:72
+#: openforms/forms/templates/admin/forms/form/export.html:81
 #: openforms/forms/templates/admin/forms/formsubmissionstatistics/export_form.html:62
 msgid "Export"
 msgstr "Exporteren"
 
-#: openforms/forms/templates/admin/forms/form/import_form.html:9
+#: openforms/forms/templates/admin/forms/form/import_form.html:10
 msgid "Import forms"
 msgstr "Importeer formulieren"
 
-#: openforms/forms/templates/admin/forms/form/import_form.html:33
+#: openforms/forms/templates/admin/forms/form/import_form.html:55
 msgid "Import"
 msgstr "Importeren"
 
@@ -8665,12 +8764,14 @@ msgstr "Terug"
 #: openforms/forms/templates/admin/forms/form/migrate-payment-backend.html:45
 msgid ""
 "\n"
-"                Please confirm that the forms below should be migrated to the Worldline payment\n"
+"                Please confirm that the forms below should be migrated to "
+"the Worldline payment\n"
 "                provider backend:\n"
 "                "
 msgstr ""
 "\n"
-"                Bevestig dat de onderstaande formulieren gemigreerd moeten worden\n"
+"                Bevestig dat de onderstaande formulieren gemigreerd moeten "
+"worden\n"
 "                naar de Worldline betalingsprovider backend:\n"
 "                 "
 
@@ -8682,11 +8783,13 @@ msgstr "Hallo,"
 #, python-format
 msgid ""
 "\n"
-"    Your zip file containing the exported forms is ready and can be downloaded at the following URL:\n"
+"    Your zip file containing the exported forms is ready and can be "
+"downloaded at the following URL:\n"
 "    %(download_url)s\n"
 msgstr ""
 "\n"
-"Uw ZIP-bestand met formulier-exports is klaar. U kunt deze downloaden op de volgende URL: %(download_url)s.\n"
+"Uw ZIP-bestand met formulier-exports is klaar. U kunt deze downloaden op de "
+"volgende URL: %(download_url)s.\n"
 
 #: openforms/forms/templates/admin/forms/formsexport/email_content.html:13
 msgid "Best wishes,"
@@ -8716,8 +8819,8 @@ msgid ""
 "<p>Here you can create an export of successfully registered form "
 "submissions. The export file contains the following columns: public "
 "reference, form name, form internal name, the submission datetime and the "
-"timestamp of registration.</p> <p>You can use the filters below to limit the"
-" result set in the export.</p>"
+"timestamp of registration.</p> <p>You can use the filters below to limit the "
+"result set in the export.</p>"
 msgstr ""
 "<p>Je kan hier een export maken van inzendingen die met success "
 "geregistreerd zijn. Het exportbestand bevat de volgende kolommen: publieke "
@@ -8742,11 +8845,11 @@ msgstr "U ziet deze pagina omdat u een ingelogde beheerder bent."
 msgid "FormIO '{type}' component validator"
 msgstr "FormIO '{type}' component validatie"
 
-#: openforms/forms/validators.py:23
+#: openforms/forms/validators.py:25
 msgid "Form is deleted."
 msgstr "Formulier is verwijderd"
 
-#: openforms/forms/validators.py:43
+#: openforms/forms/validators.py:45
 msgid ""
 "This form definition cannot be marked as 'not-reusable' as it is used in "
 "multiple existing forms."
@@ -8754,17 +8857,7 @@ msgstr ""
 "De formulierdefinitie kan niet als 'niet-herbruikbaar' gemarkeerd worden "
 "omdat deze in meerdere formulieren gebruikt wordt."
 
-#: openforms/forms/validators.py:66
-#, python-brace-format
-msgid ""
-"The component '{key}' (at JSON path '{path}') has template syntax errors in "
-"the field '{field}'."
-msgstr ""
-"De component  '{key}' (op JSON-pad '{path}') heeft sjabloonsyntaxfouten in "
-"het veld '{field}'."
-
 #: openforms/import_export/typing.py:11
-#| msgid "Registration backend"
 msgid "Registration backends"
 msgstr "Registratiebackends"
 
@@ -8778,39 +8871,56 @@ msgid "Payment backend"
 msgstr "Betaalprovider backend"
 
 #: openforms/import_export/typing.py:14
-#| msgid "authentication backends"
 msgid "Authentication backends"
 msgstr "Inlogmethoden"
 
-#: openforms/import_export/typing.py:30
-#: openforms/products/models/product.py:43
+#: openforms/import_export/typing.py:30 openforms/products/models/product.py:43
 msgid "Product"
 msgstr "Product"
 
 #: openforms/import_export/typing.py:31
-#| msgid "WMS layers"
 msgid "WMS-tile layers"
 msgstr "WMS-kaartlagen"
 
 #: openforms/import_export/typing.py:32
-#| msgid "WMS layers"
 msgid "WMTS-tile layers"
 msgstr "WMTS-kaartlagen"
 
 #: openforms/import_export/typing.py:33
-#| msgid "yivi attribute groups"
 msgid "Yivi attribute groups"
 msgstr "Yivi-attribuutgroepen"
 
 #: openforms/import_export/typing.py:34
-#| msgid "Themes"
 msgid "Theme"
 msgstr "Stijl"
 
 #: openforms/import_export/typing.py:35
-#| msgid "category"
 msgid "Category"
 msgstr "Categorie"
+
+#: openforms/import_export/typing.py:39
+#, fuzzy
+#| msgid "List form step definitions"
+msgid "Reuse existing form definitions"
+msgstr "Formulierstap definities weergeven"
+
+#: openforms/import_export/typing.py:40
+#, fuzzy
+#| msgid "Create a form definition"
+msgid "Create all new form definitions"
+msgstr "Formulierdefinitie toevoegen"
+
+#: openforms/import_export/typing.py:44
+msgid "Keep links to unknown domains as-is"
+msgstr ""
+
+#: openforms/import_export/typing.py:45
+msgid "Remove the links to unknown domains"
+msgstr ""
+
+#: openforms/import_export/typing.py:46
+msgid "Accept all unknown domains"
+msgstr ""
 
 #: openforms/logging/apps.py:7
 msgid "Logging"
@@ -9073,8 +9183,8 @@ msgstr "%(lead)s: bulk-export bestand gedownload."
 #: openforms/logging/templates/logging/events/email_status_change.txt:2
 #, python-format
 msgid ""
-"%(lead)s: The status of the email being sent for the event \"%(event)s\" has"
-" changed. It is now: \"%(status)s\""
+"%(lead)s: The status of the email being sent for the event \"%(event)s\" has "
+"changed. It is now: \"%(status)s\""
 msgstr ""
 "%(lead)s: De e-mailverzendstatus voor het event \"%(event)s\" is gewijzigd "
 "naar \"%(status)s\"."
@@ -9129,17 +9239,17 @@ msgstr ""
 #: openforms/logging/templates/logging/events/object_ownership_check_failure.txt:2
 #, python-format
 msgid ""
-"%(lead)s: Registration plugin %(plugin)s reported: authenticated user is not"
-" the owner of referenced object."
+"%(lead)s: Registration plugin %(plugin)s reported: authenticated user is not "
+"the owner of referenced object."
 msgstr ""
-"%(lead)s: Registratieplugin %(plugin)s meldt: de ingelogde gebruiker is niet"
-" de eigenaar van het aangewezen object."
+"%(lead)s: Registratieplugin %(plugin)s meldt: de ingelogde gebruiker is niet "
+"de eigenaar van het aangewezen object."
 
 #: openforms/logging/templates/logging/events/object_ownership_check_success.txt:2
 #, python-format
 msgid ""
-"%(lead)s: Registration plugin %(plugin)s reported: authenticated user is the"
-" owner of referenced object."
+"%(lead)s: Registration plugin %(plugin)s reported: authenticated user is the "
+"owner of referenced object."
 msgstr ""
 "%(lead)s: Registratieplugin %(plugin)s meldt: de ingelogde gebruiker is de "
 "eigenaar van het aangewezen object."
@@ -9150,8 +9260,8 @@ msgid ""
 "%(lead)s: User %(user)s viewed outgoing request log %(method)s %(url)s in "
 "the admin"
 msgstr ""
-"%(lead)s: Gebruiker %(user)s bekeek de log voor uitgaande verzoek %(method)s"
-" %(url)s in de admin."
+"%(lead)s: Gebruiker %(user)s bekeek de log voor uitgaande verzoek %(method)s "
+"%(url)s in de admin."
 
 #: openforms/logging/templates/logging/events/payment_flow_failure.txt:2
 #, python-format
@@ -9239,8 +9349,7 @@ msgstr "%(lead)s: Prefillplugin %(plugin)s gaf lege waarden terug."
 #: openforms/logging/templates/logging/events/prefill_retrieve_failure.txt:2
 #, python-format
 msgid ""
-"%(lead)s: Prefill plugin %(plugin)s reported: Failed to retrieve "
-"information."
+"%(lead)s: Prefill plugin %(plugin)s reported: Failed to retrieve information."
 msgstr ""
 "%(lead)s: Prefillplugin %(plugin)s meldt: Informatie kon niet worden "
 "opgehaald."
@@ -9251,8 +9360,8 @@ msgid ""
 "%(lead)s: Prefill plugin %(plugin)s reported: Successfully retrieved "
 "information to prefill fields: %(fields)s"
 msgstr ""
-"%(lead)s: Prefillplugin %(plugin)s meldt: Informatie met succes opgehaald om"
-" velden te prefillen: %(fields)s."
+"%(lead)s: Prefillplugin %(plugin)s meldt: Informatie met succes opgehaald om "
+"velden te prefillen: %(fields)s."
 
 #: openforms/logging/templates/logging/events/price_calculation_variable_error.txt:2
 #, python-format
@@ -9292,8 +9401,7 @@ msgstr "%(lead)s: Registratie-debuggegevens: %(message)s %(resolved_backend)s"
 
 #: openforms/logging/templates/logging/events/registration_failure.txt:2
 #, python-format
-msgid ""
-"%(lead)s: Registration plugin %(plugin)s reported: Registration failed."
+msgid "%(lead)s: Registration plugin %(plugin)s reported: Registration failed."
 msgstr "%(lead)s: Registratieplugin %(plugin)s meldt: Registratie mislukt."
 
 #: openforms/logging/templates/logging/events/registration_payment_update_failure.txt:2
@@ -9362,8 +9470,8 @@ msgstr ""
 #: openforms/logging/templates/logging/events/registration_update_with_confirmation_email_skip.txt:2
 #, python-format
 msgid ""
-"%(lead)s: Update submission registration with confirmation email skipped: no"
-" backend configured."
+"%(lead)s: Update submission registration with confirmation email skipped: no "
+"backend configured."
 msgstr ""
 "%(lead)s: Wijzigen registratietaak met bevestigingsmail overgeslagen: Geen "
 "\"backend geconfigureerd."
@@ -9479,8 +9587,8 @@ msgid ""
 "[%(lead)s] (Form %(form)s): User authenticated with plugin %(plugin)s "
 "(identifier: %(identifier)s)"
 msgstr ""
-"[%(lead)s] (Formulier %(form)s): Gebruiker is ingelogd met plugin %(plugin)s"
-" (identificatie: %(identifier)s)"
+"[%(lead)s] (Formulier %(form)s): Gebruiker is ingelogd met plugin %(plugin)s "
+"(identificatie: %(identifier)s)"
 
 #: openforms/multidomain/models.py:9
 msgid "The name to show in the domain switcher."
@@ -9489,14 +9597,12 @@ msgstr "De naam om weer te geven in de domeinwisselaar"
 #: openforms/multidomain/models.py:14
 msgid ""
 "The absolute URL to redirect to. Typically this starts the login process on "
-"the other domain. For example: https://open-"
-"forms.example.com/oidc/authenticate/ or https://open-"
-"forms.example.com/admin/login/"
+"the other domain. For example: https://open-forms.example.com/oidc/"
+"authenticate/ or https://open-forms.example.com/admin/login/"
 msgstr ""
 "De volledige URL om naar om te leiden. Deze URL start typisch het login "
-"proces op het doeldomein. Bijvoorbeeld: https://open-"
-"forms.example.com/oidc/authenticate/ of https://open-"
-"forms.example.com/admin/login/"
+"proces op het doeldomein. Bijvoorbeeld: https://open-forms.example.com/oidc/"
+"authenticate/ of https://open-forms.example.com/admin/login/"
 
 #: openforms/multidomain/models.py:20
 msgid "current"
@@ -9504,11 +9610,11 @@ msgstr "huidige"
 
 #: openforms/multidomain/models.py:22
 msgid ""
-"Select this to show this domain as the current domain. The current domain is"
-" selected by default and will not trigger a redirect."
+"Select this to show this domain as the current domain. The current domain is "
+"selected by default and will not trigger a redirect."
 msgstr ""
-"Selecteer deze optie om dit domein weer te geven als het huidige domein. Het"
-" huidige domein is standaard geselecteerd in de domeinwisselaar."
+"Selecteer deze optie om dit domein weer te geven als het huidige domein. Het "
+"huidige domein is standaard geselecteerd in de domeinwisselaar."
 
 #: openforms/multidomain/models.py:29
 msgid "domains"
@@ -9654,13 +9760,13 @@ msgid ""
 "Optional custom template for the description, included in the payment "
 "overviews for the backoffice. Use this to link the payment back to a "
 "particular process or form. You can include all form variables (using their "
-"keys) and the 'public_reference' variable (using expression '{{ "
-"public_reference }}'). If unspecified, a default description is used. Note "
-"that the length of the result is capped to 32 characters."
+"keys) and the 'public_reference' variable (using expression "
+"'{{ public_reference }}'). If unspecified, a default description is used. "
+"Note that the length of the result is capped to 32 characters."
 msgstr ""
 "Sjabloon voor de omschrijving van de betaling in de afschriften die je bij "
-"Worldline kan ophalen. Gebruik dit om betalingen aan processen/afdelingen te"
-" koppelen. Je kan alle formuliervariabelen gebruiken (gebruik de "
+"Worldline kan ophalen. Gebruik dit om betalingen aan processen/afdelingen te "
+"koppelen. Je kan alle formuliervariabelen gebruiken (gebruik de "
 "variabelesleutel als naam) en de 'public_reference' sjabloonvariabele "
 "(gebruik de expressie '{{ public_reference }}'). Indien geen sjabloon "
 "opgegeven is, dan wordt een standaardomschrijving gebruikt. Merk op dat het "
@@ -9707,8 +9813,7 @@ msgstr "Webhooks instellen"
 #, python-brace-format
 msgid ""
 "[Open Forms] {form_name} - submission payment received {public_reference}"
-msgstr ""
-"[Open Formulieren] {form_name} - betaling ontvangen {public_reference}"
+msgstr "[Open Formulieren] {form_name} - betaling ontvangen {public_reference}"
 
 #: openforms/payments/models.py:107
 msgid "Payment options"
@@ -9726,8 +9831,8 @@ msgstr "Bestelling ID"
 #: openforms/payments/models.py:118
 msgid ""
 "The order ID to be sent to the payment provider. This ID is built by "
-"concatenating an optional global prefix, the submission public reference and"
-" a unique incrementing ID."
+"concatenating an optional global prefix, the submission public reference and "
+"a unique incrementing ID."
 msgstr ""
 "Het ordernummer wat naar de betaalprovider gestuurd wordt. Dit nummer wordt "
 "opgebouwd met een (optionele) globale prefix, publieke "
@@ -9785,9 +9890,11 @@ msgstr "Start het betaalproces"
 
 #: openforms/payments/views.py:52
 msgid ""
-"This endpoint provides information to start the payment flow for a submission.\n"
+"This endpoint provides information to start the payment flow for a "
+"submission.\n"
 "\n"
-"Due to support for legacy platforms this view doesn't redirect but provides information for the frontend to be used client side.\n"
+"Due to support for legacy platforms this view doesn't redirect but provides "
+"information for the frontend to be used client side.\n"
 "\n"
 "Various validations are performed:\n"
 "* the form and submission must require payment\n"
@@ -9796,11 +9903,16 @@ msgid ""
 "* the `next` parameter must be present\n"
 "* the `next` parameter must match the CORS policy\n"
 "\n"
-"The HTTP 200 response contains the information to start the flow with the payment provider. Depending on the 'type', send a `GET` or `POST` request with the `data` as 'Form Data' to the given 'url'."
+"The HTTP 200 response contains the information to start the flow with the "
+"payment provider. Depending on the 'type', send a `GET` or `POST` request "
+"with the `data` as 'Form Data' to the given 'url'."
 msgstr ""
-"Dit endpoint geeft informatie om het betaalproces te starten voor een inzending.\n"
+"Dit endpoint geeft informatie om het betaalproces te starten voor een "
+"inzending.\n"
 "\n"
-"Om legacy platformen te ondersteunen kan dit endpoint niet doorverwijzen maar geeft doorverwijs informatie terug aan de frontend die het verder moet afhandelen.\n"
+"Om legacy platformen te ondersteunen kan dit endpoint niet doorverwijzen "
+"maar geeft doorverwijs informatie terug aan de frontend die het verder moet "
+"afhandelen.\n"
 "\n"
 "Diverse validaties worden uitgevoerd:\n"
 "* het formulier vereist betaling\n"
@@ -9808,7 +9920,9 @@ msgstr ""
 "* de `next` parameter moet aanwezig zijn\n"
 "* de `next` parameter moet overeenkomen met het CORS-beleid\n"
 "\n"
-"Het HTTP 200 antwoord bevat informatie om het betaalproces te starten bij de betaalprovider. Afhankelijk van het `type`, een `POST` of `GET` is wordt verstuurd met de `data` als 'Form Data' naar de opgegeven 'url'."
+"Het HTTP 200 antwoord bevat informatie om het betaalproces te starten bij de "
+"betaalprovider. Afhankelijk van het `type`, een `POST` of `GET` is wordt "
+"verstuurd met de `data` als 'Form Data' naar de opgegeven 'url'."
 
 #: openforms/payments/views.py:70
 msgid "UUID identifying the submission."
@@ -9836,9 +9950,11 @@ msgstr "Aanroeppunt van het externe betaalprovider proces"
 
 #: openforms/payments/views.py:154
 msgid ""
-"Payment plugins call this endpoint in the return step of the payment flow. Depending on the plugin, either `GET` or `POST` is allowed as HTTP method.\n"
+"Payment plugins call this endpoint in the return step of the payment flow. "
+"Depending on the plugin, either `GET` or `POST` is allowed as HTTP method.\n"
 "\n"
-"Typically payment plugins will redirect again to the URL where the SDK is embedded.\n"
+"Typically payment plugins will redirect again to the URL where the SDK is "
+"embedded.\n"
 "\n"
 "Various validations are performed:\n"
 "* the form and submission must require payment\n"
@@ -9846,7 +9962,9 @@ msgid ""
 "* payment is required and configured on the form\n"
 "* the redirect target must match the CORS policy"
 msgstr ""
-"Betaalproviderplugins roepen dit endpoint aan zodra het externe betaalproces is afgerond. Afhankelijk van de plugin, een `POST` of `GET` is toegestaan als HTTP-methode.\n"
+"Betaalproviderplugins roepen dit endpoint aan zodra het externe betaalproces "
+"is afgerond. Afhankelijk van de plugin, een `POST` of `GET` is toegestaan "
+"als HTTP-methode.\n"
 "\n"
 "Betaalproviderplugins zullen typisch een redirect uitvoeren naar de SDK.\n"
 "\n"
@@ -9881,21 +9999,30 @@ msgstr "Webhook-handler voor externe betalingsproces"
 
 #: openforms/payments/views.py:299
 msgid ""
-"This endpoint is used for server-to-server calls. Depending on the plugin, multiple request HTTP methods are supported.\n"
+"This endpoint is used for server-to-server calls. Depending on the plugin, "
+"multiple request HTTP methods are supported.\n"
 "\n"
 "Various validations are performed:\n"
 "* the `plugin_id` is configured on the form\n"
 "* payment is required and configured on the form\n"
 "\n"
-"Whenever the webhook_verification_header and webhook_verification_method settings are set for a plugin and a request has an empty request body, the request headers will be searched for the webhook_verification_header and will be returned as the response body."
+"Whenever the webhook_verification_header and webhook_verification_method "
+"settings are set for a plugin and a request has an empty request body, the "
+"request headers will be searched for the webhook_verification_header and "
+"will be returned as the response body."
 msgstr ""
-"Deze endpoint wordt gebruikt voor server-to-server verzoeken. Afhankelijk van de plugin, worden meerdere HTTP methoden ondersteund.\n"
+"Deze endpoint wordt gebruikt voor server-to-server verzoeken. Afhankelijk "
+"van de plugin, worden meerdere HTTP methoden ondersteund.\n"
 "\n"
 "Verschillende acties omtrent validatie vinden plaats:\n"
 "* de `plugin_id` is geconfigureerd in het formulier\n"
 "* betalingen zijn verplicht en geconfigureerd in het formulier\n"
 "\n"
-"Wanneer de webhook_verification_header en de webook_verification_method instellingen een waarde toegekend hebben en de body van de HTTP-request leeg is zullen de HTTP headers doorzocht worden voor de webhook_verification_header header en zal deze teruggeven worden als inhoud van de response."
+"Wanneer de webhook_verification_header en de webook_verification_method "
+"instellingen een waarde toegekend hebben en de body van de HTTP-request leeg "
+"is zullen de HTTP headers doorzocht worden voor de "
+"webhook_verification_header header en zal deze teruggeven worden als inhoud "
+"van de response."
 
 #: openforms/payments/views.py:339
 msgid "The response returned when a webhook event is processed."
@@ -9950,8 +10077,8 @@ msgstr "Verplichte authenticatieplugin"
 
 #: openforms/prefill/api/serializers.py:27
 msgid ""
-"The specific authentication plugin required for this plugin to be activated."
-" If empty, then no requirements apply."
+"The specific authentication plugin required for this plugin to be activated. "
+"If empty, then no requirements apply."
 msgstr ""
 "De specifieke authenticatieplugin die noodzakelijk is voor het inschakelen "
 "van deze plugin. Als dit veld leeg is, dan zijn er geen verplichtingen van "
@@ -9974,8 +10101,7 @@ msgstr "Form.io componenttype"
 
 #: openforms/prefill/api/serializers.py:45
 msgid "Only return plugins applicable for the specified component type."
-msgstr ""
-"Geef enkel plugins die relevant zijn voor het opgegeven componenttype."
+msgstr "Geef enkel plugins die relevant zijn voor het opgegeven componenttype."
 
 #: openforms/prefill/api/serializers.py:79
 #: openforms/registrations/api/serializers.py:31
@@ -10050,8 +10176,7 @@ msgid ""
 "The format should comply to how Formio handles nested component keys."
 msgstr ""
 "De sleutel van de formuliervariabele die naar de klantprofielcomponent "
-"wijst. Het formaat moet overeenkomen met hoe Formio omgaat met geneste "
-"paden."
+"wijst. Het formaat moet overeenkomen met hoe Formio omgaat met geneste paden."
 
 #: openforms/prefill/contrib/customer_interactions/config.py:45
 #, python-brace-format
@@ -10066,7 +10191,7 @@ msgstr "Communicatievoorkeuren (klantinteracties API)"
 #: openforms/prefill/contrib/customer_interactions/plugin.py:107
 #: openforms/prefill/contrib/objects_api/plugin.py:88
 #: openforms/registrations/contrib/objects_api/plugin.py:155
-#: openforms/registrations/contrib/zgw_apis/plugin.py:862
+#: openforms/registrations/contrib/zgw_apis/plugin.py:913
 msgid "Manage API groups"
 msgstr "API-groepen beheren"
 
@@ -10142,8 +10267,7 @@ msgstr "Geen (ingeschakelde) OIDC-client gevonden voor eIDAS (burger)."
 #: openforms/prefill/contrib/eidas/plugin.py:96
 msgid "Missing OIDC client identity settings for eIDAS."
 msgstr ""
-"Ontbrekende identificatie-instellingen in de OIDC-client voor eIDAS "
-"(burger)."
+"Ontbrekende identificatie-instellingen in de OIDC-client voor eIDAS (burger)."
 
 #: openforms/prefill/contrib/eidas/plugin.py:109
 #: openforms/prefill/contrib/eidas/plugin.py:187
@@ -10201,8 +10325,8 @@ msgstr "formuliervariabelesleutel van de gegevens"
 
 #: openforms/prefill/contrib/family_members/config.py:42
 msgid ""
-"The 'dotted' path to a form variable key which is a copy of the initial data"
-" which has been retrieved and may change. The format should comply to how "
+"The 'dotted' path to a form variable key which is a copy of the initial data "
+"which has been retrieved and may change. The format should comply to how "
 "Formio handles nested component keys."
 msgstr ""
 "Het 'gestippelde' pad naar een formuliervariabelesleutel die een kopie is "
@@ -10214,6 +10338,7 @@ msgid "The type of the person we want to prefill/retrieve data for."
 msgstr "Het persoonstype waarvoor de gegevens opgehaald worden."
 
 #: openforms/prefill/contrib/family_members/constants.py:6
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:889
 #: openforms/variables/constants.py:26
 msgid "Partners"
 msgstr "Partners"
@@ -10244,161 +10369,1216 @@ msgstr ""
 msgid "Haal Centraal: BRP Personen Bevragen prefill plugin"
 msgstr "Haal Centraal: BRP Personen Bevragen voorinvullen-plugin"
 
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:6
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:9
+msgid "A-nummer"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:15
 msgid "Burgerservicenummer"
 msgstr "Burgerservicenummer"
 
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:7
-msgid "Naam > Geslachtsnaam"
-msgstr "Naam > Geslachtsnaam"
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:21
+msgid "Datum Eerste Inschrijving GBA > Type"
+msgstr ""
 
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:8
-msgid "Naam > Volledigenaam"
-msgstr "Naam > Volledigenaam"
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:25
+msgid "Datum Eerste Inschrijving GBA > Lang Formaat"
+msgstr ""
 
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:9
-msgid "Naam > Voorletters"
-msgstr "Naam > Voorletters"
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:29
+msgid "Datum Eerste Inschrijving GBA > Datum"
+msgstr ""
 
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:10
-msgid "Naam > Voornamen"
-msgstr "Naam > Voornamen"
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:33
+msgid "Datum Eerste Inschrijving GBA > Onbekend"
+msgstr ""
 
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:11
-msgid "Naam > Voorvoegsel"
-msgstr "Naam > Voorvoegsel"
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:37
+msgid "Datum Eerste Inschrijving GBA > Jaar"
+msgstr ""
 
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:14
-msgid "Verblijfplaats > Verblijf Adres > Huisletter"
-msgstr "Verblijfplaats > Verblijf Adres > Huisletter"
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:41
+msgid "Datum Eerste Inschrijving GBA > Maand"
+msgstr ""
 
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:18
-msgid "Verblijfplaats > Verblijf Adres > Huisnummer"
-msgstr "Verblijfplaats > Verblijf Adres > Huisnummer"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:22
-msgid "Verblijfplaats > Verblijf Adres > Huisnummertoevoeging"
-msgstr "Verblijfplaats > Verblijf Adres > Huisnummertoevoeging"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:26
-msgid "Verblijfplaats > Verblijf Adres > Kortestraatnaam"
-msgstr "Verblijfplaats > Verblijf Adres > Kortestraatnaam"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:30
-msgid "Verblijfplaats > Verblijf Adres > Officiele Straatnaam"
-msgstr "Verblijfplaats > Verblijf Adres > Officiele Straatnaam"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:34
-msgid "Verblijfplaats > Verblijf Adres > Postcode"
-msgstr "Verblijfplaats > Verblijf Adres > Postcode"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:38
-msgid "Verblijfplaats > Verblijf Adres > Woonplaats"
-msgstr "Verblijfplaats > Verblijf Adres > Woonplaats"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:42
-msgid "Gemeentevaninschrijving > Code"
-msgstr "Gemeentevaninschrijving > Code"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:46
-msgid "Gemeentevaninschrijving > Omschrijving"
-msgstr "Gemeentevaninschrijving > Omschrijving"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:50
-msgid "Adressering > Adres Regel 1"
-msgstr "Adressering > Adres Regel 1"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:54
-msgid "Adressering > Adres Regel 2"
-msgstr "Adressering > Adres Regel 2"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:58
-msgid "Adressering > Adres Regel 3"
-msgstr "Adressering > Adres Regel 3"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:60
-msgid "Adressering > Land"
-msgstr "Adressering > Land"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:61
-msgid "Geboorte > Land"
-msgstr "Geboorte > Land"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:62
-msgid "Geboorte > Land > Code"
-msgstr "Geboorte > Land > Code"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:65
-msgid "Geboorte > Land > Omschrijving"
-msgstr "Geboorte > Land > Omschrijving"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:67
-msgid "Geboorte > Plaats"
-msgstr "Geboorte > Plaats"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:68
-msgid "Geboorte > Plaats > Code"
-msgstr "Geboorte > Plaats > Code"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:71
-msgid "Geboorte > Plaats > Omschrijving"
-msgstr "Geboorte > Plaats > Omschrijving"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:75
-msgid "Geboorte > Datum > Lang Formaat"
-msgstr "Geboorte > Datum > Lang Formaat"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:77
-msgid "Geboorte > Datum > Type"
-msgstr "Geboorte > Datum > Type"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:78
-msgid "Geboorte > Datum > Datum"
-msgstr "Geboorte > Datum > Datum"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:81
-msgid "Geboorte > Datum > Onbekend"
-msgstr "Geboorte > Datum > Onbekend"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:83
-msgid "Geboorte > Datum > Jaar"
-msgstr "Geboorte > Datum > Jaar"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:84
-msgid "Geboorte > Datum > Maand"
-msgstr "Geboorte > Datum > Maand"
-
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:85
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:47
 msgid "Geslacht > Code"
 msgstr "Geslacht > Code"
 
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:86
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:51
 msgid "Geslacht > Omschrijving"
 msgstr "Geslacht > Omschrijving"
 
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:89
-msgid "Overlijden > Datum > Lang Formaat"
-msgstr "Overlijden > Datum > Lang Formaat"
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:57
+msgid "Uitsluiting Kiesrecht > Uitgesloten Van Kiesrecht"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:61
+msgid "Uitsluiting Kiesrecht > Einddatum > Type"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:65
+#, fuzzy
+#| msgid "Geboorte > Datum > Lang Formaat"
+msgid "Uitsluiting Kiesrecht > Einddatum > Lang Formaat"
+msgstr "Geboorte > Datum > Lang Formaat"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:69
+msgid "Uitsluiting Kiesrecht > Einddatum > Datum"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:73
+msgid "Uitsluiting Kiesrecht > Einddatum > Onbekend"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:77
+msgid "Uitsluiting Kiesrecht > Einddatum > Jaar"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:81
+msgid "Uitsluiting Kiesrecht > Einddatum > Maand"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:87
+msgid "Europees Kiesrecht > Aanduiding > Code"
+msgstr ""
 
 #: openforms/prefill/contrib/haalcentraal_brp/constants.py:91
+#, fuzzy
+#| msgid "Geboorte > Land > Omschrijving"
+msgid "Europees Kiesrecht > Aanduiding > Omschrijving"
+msgstr "Geboorte > Land > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:95
+msgid "Europees Kiesrecht > Einddatum Uitsluiting > Type"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:99
+msgid "Europees Kiesrecht > Einddatum Uitsluiting > Lang Formaat"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:103
+msgid "Europees Kiesrecht > Einddatum Uitsluiting > Datum"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:107
+msgid "Europees Kiesrecht > Einddatum Uitsluiting > Onbekend"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:111
+msgid "Europees Kiesrecht > Einddatum Uitsluiting > Jaar"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:115
+msgid "Europees Kiesrecht > Einddatum Uitsluiting > Maand"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:121
+msgid "Leeftijd"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:127
+msgid "Naam > Voornamen"
+msgstr "Naam > Voornamen"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:131
+msgid "Naam > Adellijke Titel/Predicaat > Code"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:135
+msgid "Naam > Adellijke Titel/Predicaat > Omschrijving"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:139
+msgid "Naam > Adellijke Titel/Predicaat > Soort"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:143
+msgid "Naam > Voorvoegsel"
+msgstr "Naam > Voorvoegsel"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:147
+msgid "Naam > Geslachtsnaam"
+msgstr "Naam > Geslachtsnaam"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:151
+msgid "Naam > Voorletters"
+msgstr "Naam > Voorletters"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:155
+#, fuzzy
+#| msgid "Naam > Volledigenaam"
+msgid "Naam > Volledige Naam"
+msgstr "Naam > Volledigenaam"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:159
+msgid "Naam > Aanduiding Naamgebruik > Code"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:163
+msgid "Naam > Aanduiding Naamgebruik > Omschrijving"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:169
+#, fuzzy
+#| msgid "Nationality"
+msgid "Nationaliteiten"
+msgstr "Nationaliteit"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:178
+#, fuzzy
+#| msgid "Nationality"
+msgid "Nationaliteiten > Type"
+msgstr "Nationaliteit"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:182
+msgid "Nationaliteiten > Reden Opname > Code"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:186
+msgid "Nationaliteiten > Reden Opname > Omschrijving"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:190
+msgid "Nationaliteiten > Datum Ingang Geldigheid > Type"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:194
+#, fuzzy
+#| msgid "Overlijden > Datum > Lang Formaat"
+msgid "Nationaliteiten > Datum Ingang Geldigheid > Lang Formaat"
+msgstr "Overlijden > Datum > Lang Formaat"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:198
+msgid "Nationaliteiten > Datum Ingang Geldigheid > Datum"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:202
+msgid "Nationaliteiten > Datum Ingang Geldigheid > Onbekend"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:206
+msgid "Nationaliteiten > Datum Ingang Geldigheid > Jaar"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:210
+msgid "Nationaliteiten > Datum Ingang Geldigheid > Maand"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:214
+msgid "Nationaliteiten > Nationaliteit > Code"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:218
+#, fuzzy
+#| msgid "Geboorte > Plaats > Omschrijving"
+msgid "Nationaliteiten > Nationaliteit > Omschrijving"
+msgstr "Geboorte > Plaats > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:224
+msgid "Geboorte > Datum > Type"
+msgstr "Geboorte > Datum > Type"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:228
+msgid "Geboorte > Datum > Lang Formaat"
+msgstr "Geboorte > Datum > Lang Formaat"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:232
+msgid "Geboorte > Datum > Datum"
+msgstr "Geboorte > Datum > Datum"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:236
+msgid "Geboorte > Datum > Onbekend"
+msgstr "Geboorte > Datum > Onbekend"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:240
+msgid "Geboorte > Datum > Jaar"
+msgstr "Geboorte > Datum > Jaar"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:244
+msgid "Geboorte > Datum > Maand"
+msgstr "Geboorte > Datum > Maand"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:248
+msgid "Geboorte > Land > Code"
+msgstr "Geboorte > Land > Code"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:252
+msgid "Geboorte > Land > Omschrijving"
+msgstr "Geboorte > Land > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:256
+msgid "Geboorte > Plaats > Code"
+msgstr "Geboorte > Plaats > Code"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:260
+msgid "Geboorte > Plaats > Omschrijving"
+msgstr "Geboorte > Plaats > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:266
+#, fuzzy
+#| msgid "Geboorte > Land > Code"
+msgid "Overlijden > Land > Code"
+msgstr "Geboorte > Land > Code"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:270
+#, fuzzy
+#| msgid "Geboorte > Land > Omschrijving"
+msgid "Overlijden > Land > Omschrijving"
+msgstr "Geboorte > Land > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:274
+#, fuzzy
+#| msgid "Geboorte > Plaats > Code"
+msgid "Overlijden > Plaats > Code"
+msgstr "Geboorte > Plaats > Code"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:278
+#, fuzzy
+#| msgid "Geboorte > Plaats > Omschrijving"
+msgid "Overlijden > Plaats > Omschrijving"
+msgstr "Geboorte > Plaats > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:282
 msgid "Overlijden > Datum > Type"
 msgstr "Overlijden > Datum > Type"
 
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:92
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:286
+msgid "Overlijden > Datum > Lang Formaat"
+msgstr "Overlijden > Datum > Lang Formaat"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:290
 msgid "Overlijden > Datum > Datum"
 msgstr "Overlijden > Datum > Datum"
 
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:95
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:294
 msgid "Overlijden > Datum > Onbekend"
 msgstr "Overlijden > Datum > Onbekend"
 
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:97
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:298
 msgid "Overlijden > Datum > Jaar"
 msgstr "Overlijden > Datum > Jaar"
 
-#: openforms/prefill/contrib/haalcentraal_brp/constants.py:98
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:302
 msgid "Overlijden > Datum > Maand"
 msgstr "Overlijden > Datum > Maand"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:308
+#, fuzzy
+#| msgid "Overlijden > Datum > Type"
+msgid "Verblijfplaats > Type"
+msgstr "Overlijden > Datum > Type"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:312
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Kortestraatnaam"
+msgid "Verblijfplaats > Verblijfadres > Locatiebeschrijving"
+msgstr "Verblijfplaats > Verblijf Adres > Kortestraatnaam"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:316
+#, fuzzy
+#| msgid "Overlijden > Datum > Type"
+msgid "Verblijfplaats > Datum Van > Type"
+msgstr "Overlijden > Datum > Type"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:320
+#, fuzzy
+#| msgid "Overlijden > Datum > Lang Formaat"
+msgid "Verblijfplaats > Datum Van > Lang Formaat"
+msgstr "Overlijden > Datum > Lang Formaat"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:324
+#, fuzzy
+#| msgid "Overlijden > Datum > Datum"
+msgid "Verblijfplaats > Datum Van > Datum"
+msgstr "Overlijden > Datum > Datum"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:328
+#, fuzzy
+#| msgid "Overlijden > Datum > Onbekend"
+msgid "Verblijfplaats > Datum Van > Onbekend"
+msgstr "Overlijden > Datum > Onbekend"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:332
+#, fuzzy
+#| msgid "Overlijden > Datum > Jaar"
+msgid "Verblijfplaats > Datum Van > Jaar"
+msgstr "Overlijden > Datum > Jaar"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:336
+#, fuzzy
+#| msgid "Overlijden > Datum > Maand"
+msgid "Verblijfplaats > Datum Van > Maand"
+msgstr "Overlijden > Datum > Maand"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:340
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Postcode"
+msgid "Verblijfplaats > Functie Adres > Code"
+msgstr "Verblijfplaats > Verblijf Adres > Postcode"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:344
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Huisnummertoevoeging"
+msgid "Verblijfplaats > Functie Adres > Omschrijving"
+msgstr "Verblijfplaats > Verblijf Adres > Huisnummertoevoeging"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:348
+msgid "Verblijfplaats > Adresseerbaar Object Identificatie"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:352
+msgid "Verblijfplaats > Nummeraanduiding Identificatie"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:356
+msgid "Verblijfplaats > Indicatie Vastgesteld Verblijft Niet Op Adres"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:360
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Huisletter"
+msgid "Verblijfplaats > Verblijfadres > Regel 1"
+msgstr "Verblijfplaats > Verblijf Adres > Huisletter"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:364
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Huisletter"
+msgid "Verblijfplaats > Verblijfadres > Regel 2"
+msgstr "Verblijfplaats > Verblijf Adres > Huisletter"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:368
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Huisletter"
+msgid "Verblijfplaats > Verblijfadres > Regel 3"
+msgstr "Verblijfplaats > Verblijf Adres > Huisletter"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:372
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Postcode"
+msgid "Verblijfplaats > Verblijfadres > Land > Code"
+msgstr "Verblijfplaats > Verblijf Adres > Postcode"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:376
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Huisnummertoevoeging"
+msgid "Verblijfplaats > Verblijfadres > Land > Omschrijving"
+msgstr "Verblijfplaats > Verblijf Adres > Huisnummertoevoeging"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:380
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Officiele Straatnaam"
+msgid "Verblijfplaats > Verblijfadres > Officiële Straatnaam"
+msgstr "Verblijfplaats > Verblijf Adres > Officiele Straatnaam"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:384
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Kortestraatnaam"
+msgid "Verblijfplaats > Verblijfadres > Korte Straatnaam"
+msgstr "Verblijfplaats > Verblijf Adres > Kortestraatnaam"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:388
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Huisnummer"
+msgid "Verblijfplaats > Verblijfadres > Huisnummer"
+msgstr "Verblijfplaats > Verblijf Adres > Huisnummer"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:392
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Huisletter"
+msgid "Verblijfplaats > Verblijfadres > Huisletter"
+msgstr "Verblijfplaats > Verblijf Adres > Huisletter"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:396
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Huisnummertoevoeging"
+msgid "Verblijfplaats > Verblijfadres > Huisnummertoevoeging"
+msgstr "Verblijfplaats > Verblijf Adres > Huisnummertoevoeging"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:400
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Huisnummer"
+msgid "Verblijfplaats > Verblijfadres > Aanduiding Bij Huisnummer > Code"
+msgstr "Verblijfplaats > Verblijf Adres > Huisnummer"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:404
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Huisnummertoevoeging"
+msgid ""
+"Verblijfplaats > Verblijfadres > Aanduiding Bij Huisnummer > Omschrijving"
+msgstr "Verblijfplaats > Verblijf Adres > Huisnummertoevoeging"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:408
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Postcode"
+msgid "Verblijfplaats > Verblijfadres > Postcode"
+msgstr "Verblijfplaats > Verblijf Adres > Postcode"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:412
+#, fuzzy
+#| msgid "Verblijfplaats > Verblijf Adres > Woonplaats"
+msgid "Verblijfplaats > Verblijfadres > Woonplaats"
+msgstr "Verblijfplaats > Verblijf Adres > Woonplaats"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:418
+msgid "Immigratie > Land Vanwaar Ingeschreven > Code"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:422
+#, fuzzy
+#| msgid "Geboorte > Land > Omschrijving"
+msgid "Immigratie > Land Vanwaar Ingeschreven > Omschrijving"
+msgstr "Geboorte > Land > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:426
+msgid "Immigratie > Datum Vestiging In Nederland > Type"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:430
+msgid "Immigratie > Datum Vestiging In Nederland > Lang Formaat"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:434
+msgid "Immigratie > Datum Vestiging In Nederland > Datum"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:438
+msgid "Immigratie > Datum Vestiging In Nederland > Onbekend"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:442
+msgid "Immigratie > Datum Vestiging In Nederland > Jaar"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:446
+msgid "Immigratie > Datum Vestiging In Nederland > Maand"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:450
+msgid "Immigratie > Vanuit Verblijfplaats Onbekend"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:454
+msgid "Immigratie > Indicatie Vestiging Vanuit Buitenland"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:460
+#, fuzzy
+#| msgid "Gemeentevaninschrijving > Code"
+msgid "Gemeente Van Inschrijving > Code"
+msgstr "Gemeentevaninschrijving > Code"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:464
+#, fuzzy
+#| msgid "Gemeentevaninschrijving > Omschrijving"
+msgid "Gemeente Van Inschrijving > Omschrijving"
+msgstr "Gemeentevaninschrijving > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:470
+msgid "Datum Inschrijving In Gemeente > Type"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:474
+msgid "Datum Inschrijving In Gemeente > Lang Formaat"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:478
+msgid "Datum Inschrijving In Gemeente > Datum"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:482
+msgid "Datum Inschrijving In Gemeente > Onbekend"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:486
+msgid "Datum Inschrijving In Gemeente > Jaar"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:490
+msgid "Datum Inschrijving In Gemeente > Maand"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:496
+#, fuzzy
+#| msgid "Adressering > Adres Regel 1"
+msgid "Adressering > Adresregel 1"
+msgstr "Adressering > Adres Regel 1"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:500
+#, fuzzy
+#| msgid "Adressering > Adres Regel 2"
+msgid "Adressering > Adresregel 2"
+msgstr "Adressering > Adres Regel 2"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:504
+#, fuzzy
+#| msgid "Adressering > Adres Regel 3"
+msgid "Adressering > Adresregel 3"
+msgstr "Adressering > Adres Regel 3"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:508
+#, fuzzy
+#| msgid "Adressering > Land"
+msgid "Adressering > Land > Code"
+msgstr "Adressering > Land"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:512
+#, fuzzy
+#| msgid "Geboorte > Land > Omschrijving"
+msgid "Adressering > Land > Omschrijving"
+msgstr "Geboorte > Land > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:516
+msgid "Adressering > Indicatie Vastgesteld Verblijft Niet Op Adres"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:520
+#, fuzzy
+#| msgid "Adressering > Land"
+msgid "Adressering > Aanhef"
+msgstr "Adressering > Land"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:524
+#, fuzzy
+#| msgid "Adressering > Adres Regel 1"
+msgid "Adressering > Aanschrijfwijze > Naam"
+msgstr "Adressering > Adres Regel 1"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:528
+msgid "Adressering > Aanschrijfwijze > Aanspreekvorm"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:532
+#, fuzzy
+#| msgid "Adressering > Land"
+msgid "Adressering > Gebruik In Lopende Tekst"
+msgstr "Adressering > Land"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:538
+msgid "Indicatie Curatele Register"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:544
+msgid "Gezag"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:553
+msgid "Gezag > Type"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:557
+#, fuzzy
+#| msgid "Burgerservicenummer"
+msgid "Gezag > Minderjarige > Burgerservicenummer"
+msgstr "Burgerservicenummer"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:561
+msgid "Gezag > Minderjarige > Naam > Volledige Naam"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:565
+msgid "Gezag > Minderjarige > Leeftijd"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:571
+msgid "Gezag > Ouders"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:576
+#, fuzzy
+#| msgid "Burgerservicenummer"
+msgid "Gezag > Ouders > Burgerservicenummer"
+msgstr "Burgerservicenummer"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:580
+#, fuzzy
+#| msgid "Naam > Volledigenaam"
+msgid "Gezag > Ouders > Naam > Volledige Naam"
+msgstr "Naam > Volledigenaam"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:584
+#, fuzzy
+#| msgid "Burgerservicenummer"
+msgid "Gezag > Ouder > Burgerservicenummer"
+msgstr "Burgerservicenummer"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:588
+#, fuzzy
+#| msgid "Naam > Volledigenaam"
+msgid "Gezag > Ouder > Naam > Volledige Naam"
+msgstr "Naam > Volledigenaam"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:594
+msgid "Gezag > Derden"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:599
+#, fuzzy
+#| msgid "Geboorte > Datum > Type"
+msgid "Gezag > Derde > Type"
+msgstr "Geboorte > Datum > Type"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:603
+#, fuzzy
+#| msgid "Burgerservicenummer"
+msgid "Gezag > Derde > Burgerservicenummer"
+msgstr "Burgerservicenummer"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:607
+#, fuzzy
+#| msgid "Naam > Volledigenaam"
+msgid "Gezag > Derde > Naam > Volledige Naam"
+msgstr "Naam > Volledigenaam"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:611
+msgid "Gezag > Derden > Type"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:615
+#, fuzzy
+#| msgid "Burgerservicenummer"
+msgid "Gezag > Derden > Burgerservicenummer"
+msgstr "Burgerservicenummer"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:619
+#, fuzzy
+#| msgid "Naam > Volledigenaam"
+msgid "Gezag > Derden > Naam > Volledige Naam"
+msgstr "Naam > Volledigenaam"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:623
+#, fuzzy
+#| msgid "Toelichting"
+msgid "Gezag > Toelichting"
+msgstr "Toelichting"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:629
+#, fuzzy
+#| msgid "Geboorte > Land > Code"
+msgid "Verblijfstitel > Aanduiding > Code"
+msgstr "Geboorte > Land > Code"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:633
+#, fuzzy
+#| msgid "Geboorte > Land > Omschrijving"
+msgid "Verblijfstitel > Aanduiding > Omschrijving"
+msgstr "Geboorte > Land > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:637
+#, fuzzy
+#| msgid "Overlijden > Datum > Type"
+msgid "Verblijfstitel > Datum Einde > Type"
+msgstr "Overlijden > Datum > Type"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:641
+#, fuzzy
+#| msgid "Overlijden > Datum > Lang Formaat"
+msgid "Verblijfstitel > Datum Einde > Lang Formaat"
+msgstr "Overlijden > Datum > Lang Formaat"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:645
+#, fuzzy
+#| msgid "Overlijden > Datum > Datum"
+msgid "Verblijfstitel > Datum Einde > Datum"
+msgstr "Overlijden > Datum > Datum"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:649
+#, fuzzy
+#| msgid "Overlijden > Datum > Onbekend"
+msgid "Verblijfstitel > Datum Einde > Onbekend"
+msgstr "Overlijden > Datum > Onbekend"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:653
+#, fuzzy
+#| msgid "Overlijden > Datum > Jaar"
+msgid "Verblijfstitel > Datum Einde > Jaar"
+msgstr "Overlijden > Datum > Jaar"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:657
+#, fuzzy
+#| msgid "Overlijden > Datum > Maand"
+msgid "Verblijfstitel > Datum Einde > Maand"
+msgstr "Overlijden > Datum > Maand"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:661
+#, fuzzy
+#| msgid "Overlijden > Datum > Type"
+msgid "Verblijfstitel > Datum Ingang > Type"
+msgstr "Overlijden > Datum > Type"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:665
+#, fuzzy
+#| msgid "Overlijden > Datum > Lang Formaat"
+msgid "Verblijfstitel > Datum Ingang > Lang Formaat"
+msgstr "Overlijden > Datum > Lang Formaat"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:669
+#, fuzzy
+#| msgid "Overlijden > Datum > Datum"
+msgid "Verblijfstitel > Datum Ingang > Datum"
+msgstr "Overlijden > Datum > Datum"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:673
+#, fuzzy
+#| msgid "Overlijden > Datum > Onbekend"
+msgid "Verblijfstitel > Datum Ingang > Onbekend"
+msgstr "Overlijden > Datum > Onbekend"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:677
+#, fuzzy
+#| msgid "Overlijden > Datum > Jaar"
+msgid "Verblijfstitel > Datum Ingang > Jaar"
+msgstr "Overlijden > Datum > Jaar"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:681
+#, fuzzy
+#| msgid "Overlijden > Datum > Maand"
+msgid "Verblijfstitel > Datum Ingang > Maand"
+msgstr "Overlijden > Datum > Maand"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:687
+#, fuzzy
+#| msgid "Kind"
+msgid "Kinderen"
+msgstr "Soort"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:696
+#, fuzzy
+#| msgid "Burgerservicenummer"
+msgid "Kinderen > Burgerservicenummer"
+msgstr "Burgerservicenummer"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:700
+#, fuzzy
+#| msgid "Naam > Voornamen"
+msgid "Kinderen > Naam > Voornamen"
+msgstr "Naam > Voornamen"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:704
+msgid "Kinderen > Naam > Adellijke Titel/Predicaat > Code"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:708
+msgid "Kinderen > Naam > Adellijke Titel/Predicaat > Omschrijving"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:712
+msgid "Kinderen > Naam > Adellijke Titel/Predicaat > Soort"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:716
+#, fuzzy
+#| msgid "Naam > Voorvoegsel"
+msgid "Kinderen > Naam > Voorvoegsel"
+msgstr "Naam > Voorvoegsel"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:720
+#, fuzzy
+#| msgid "Naam > Geslachtsnaam"
+msgid "Kinderen > Naam > Geslachtsnaam"
+msgstr "Naam > Geslachtsnaam"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:724
+#, fuzzy
+#| msgid "Naam > Voorletters"
+msgid "Kinderen > Naam > Voorletters"
+msgstr "Naam > Voorletters"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:728
+#, fuzzy
+#| msgid "Geboorte > Datum > Type"
+msgid "Kinderen > Geboorte > Datum > Type"
+msgstr "Geboorte > Datum > Type"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:732
+#, fuzzy
+#| msgid "Geboorte > Datum > Lang Formaat"
+msgid "Kinderen > Geboorte > Datum > Lang Formaat"
+msgstr "Geboorte > Datum > Lang Formaat"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:736
+#, fuzzy
+#| msgid "Geboorte > Datum > Datum"
+msgid "Kinderen > Geboorte > Datum > Datum"
+msgstr "Geboorte > Datum > Datum"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:740
+#, fuzzy
+#| msgid "Geboorte > Datum > Onbekend"
+msgid "Kinderen > Geboorte > Datum > Onbekend"
+msgstr "Geboorte > Datum > Onbekend"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:744
+#, fuzzy
+#| msgid "Geboorte > Datum > Jaar"
+msgid "Kinderen > Geboorte > Datum > Jaar"
+msgstr "Geboorte > Datum > Jaar"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:748
+#, fuzzy
+#| msgid "Geboorte > Datum > Maand"
+msgid "Kinderen > Geboorte > Datum > Maand"
+msgstr "Geboorte > Datum > Maand"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:752
+#, fuzzy
+#| msgid "Geboorte > Land > Code"
+msgid "Kinderen > Geboorte > Land > Code"
+msgstr "Geboorte > Land > Code"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:756
+#, fuzzy
+#| msgid "Geboorte > Land > Omschrijving"
+msgid "Kinderen > Geboorte > Land > Omschrijving"
+msgstr "Geboorte > Land > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:760
+#, fuzzy
+#| msgid "Geboorte > Plaats > Code"
+msgid "Kinderen > Geboorte > Plaats > Code"
+msgstr "Geboorte > Plaats > Code"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:764
+#, fuzzy
+#| msgid "Geboorte > Plaats > Omschrijving"
+msgid "Kinderen > Geboorte > Plaats > Omschrijving"
+msgstr "Geboorte > Plaats > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:770
+msgid "Ouders"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:779
+#, fuzzy
+#| msgid "Burgerservicenummer"
+msgid "Ouders > Burgerservicenummer"
+msgstr "Burgerservicenummer"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:783
+#, fuzzy
+#| msgid "Geslacht > Code"
+msgid "Ouders > Geslacht > Code"
+msgstr "Geslacht > Code"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:787
+#, fuzzy
+#| msgid "Geslacht > Omschrijving"
+msgid "Ouders > Geslacht > Omschrijving"
+msgstr "Geslacht > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:791
+msgid "Ouders > Ouderaanduiding"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:795
+msgid "Ouders > Datum Ingang Familierechtelijke Betrekking > Type"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:799
+msgid "Ouders > Datum Ingang Familierechtelijke Betrekking > Lang Formaat"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:803
+msgid "Ouders > Datum Ingang Familierechtelijke Betrekking > Datum"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:807
+msgid "Ouders > Datum Ingang Familierechtelijke Betrekking > Onbekend"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:811
+msgid "Ouders > Datum Ingang Familierechtelijke Betrekking > Jaar"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:815
+msgid "Ouders > Datum Ingang Familierechtelijke Betrekking > Maand"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:819
+#, fuzzy
+#| msgid "Naam > Voornamen"
+msgid "Ouders > Naam > Voornamen"
+msgstr "Naam > Voornamen"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:823
+msgid "Ouders > Naam > Adellijke Titel/Predicaat > Code"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:827
+msgid "Ouders > Naam > Adellijke Titel/Predicaat > Omschrijving"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:831
+msgid "Ouders > Naam > Adellijke Titel/Predicaat > Soort"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:835
+#, fuzzy
+#| msgid "Naam > Voorvoegsel"
+msgid "Ouders > Naam > Voorvoegsel"
+msgstr "Naam > Voorvoegsel"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:839
+#, fuzzy
+#| msgid "Naam > Geslachtsnaam"
+msgid "Ouders > Naam > Geslachtsnaam"
+msgstr "Naam > Geslachtsnaam"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:843
+#, fuzzy
+#| msgid "Naam > Voorletters"
+msgid "Ouders > Naam > Voorletters"
+msgstr "Naam > Voorletters"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:847
+#, fuzzy
+#| msgid "Geboorte > Datum > Type"
+msgid "Ouders > Geboorte > Datum > Type"
+msgstr "Geboorte > Datum > Type"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:851
+#, fuzzy
+#| msgid "Geboorte > Datum > Lang Formaat"
+msgid "Ouders > Geboorte > Datum > Lang Formaat"
+msgstr "Geboorte > Datum > Lang Formaat"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:855
+#, fuzzy
+#| msgid "Geboorte > Datum > Datum"
+msgid "Ouders > Geboorte > Datum > Datum"
+msgstr "Geboorte > Datum > Datum"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:859
+#, fuzzy
+#| msgid "Geboorte > Datum > Onbekend"
+msgid "Ouders > Geboorte > Datum > Onbekend"
+msgstr "Geboorte > Datum > Onbekend"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:863
+#, fuzzy
+#| msgid "Geboorte > Datum > Jaar"
+msgid "Ouders > Geboorte > Datum > Jaar"
+msgstr "Geboorte > Datum > Jaar"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:867
+#, fuzzy
+#| msgid "Geboorte > Datum > Maand"
+msgid "Ouders > Geboorte > Datum > Maand"
+msgstr "Geboorte > Datum > Maand"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:871
+#, fuzzy
+#| msgid "Geboorte > Land > Code"
+msgid "Ouders > Geboorte > Land > Code"
+msgstr "Geboorte > Land > Code"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:875
+#, fuzzy
+#| msgid "Geboorte > Land > Omschrijving"
+msgid "Ouders > Geboorte > Land > Omschrijving"
+msgstr "Geboorte > Land > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:879
+#, fuzzy
+#| msgid "Geboorte > Plaats > Code"
+msgid "Ouders > Geboorte > Plaats > Code"
+msgstr "Geboorte > Plaats > Code"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:883
+#, fuzzy
+#| msgid "Geboorte > Plaats > Omschrijving"
+msgid "Ouders > Geboorte > Plaats > Omschrijving"
+msgstr "Geboorte > Plaats > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:898
+#, fuzzy
+#| msgid "Burgerservicenummer"
+msgid "Partners > Burgerservicenummer"
+msgstr "Burgerservicenummer"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:902
+#, fuzzy
+#| msgid "Geslacht > Code"
+msgid "Partners > Geslacht > Code"
+msgstr "Geslacht > Code"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:906
+#, fuzzy
+#| msgid "Geslacht > Omschrijving"
+msgid "Partners > Geslacht > Omschrijving"
+msgstr "Geslacht > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:910
+msgid "Partners > Soort Verbintenis > Code"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:914
+#, fuzzy
+#| msgid "Geboorte > Plaats > Omschrijving"
+msgid "Partners > Soort Verbintenis > Omschrijving"
+msgstr "Geboorte > Plaats > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:918
+#, fuzzy
+#| msgid "Naam > Voornamen"
+msgid "Partners > Naam > Voornamen"
+msgstr "Naam > Voornamen"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:922
+msgid "Partners > Naam > Adellijke Titel/Predicaat > Code"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:926
+msgid "Partners > Naam > Adellijke Titel/Predicaat > Omschrijving"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:930
+msgid "Partners > Naam > Adellijke Titel/Predicaat > Soort"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:934
+#, fuzzy
+#| msgid "Naam > Voorvoegsel"
+msgid "Partners > Naam > Voorvoegsel"
+msgstr "Naam > Voorvoegsel"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:938
+#, fuzzy
+#| msgid "Naam > Geslachtsnaam"
+msgid "Partners > Naam > Geslachtsnaam"
+msgstr "Naam > Geslachtsnaam"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:942
+#, fuzzy
+#| msgid "Naam > Voorletters"
+msgid "Partners > Naam > Voorletters"
+msgstr "Naam > Voorletters"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:946
+#, fuzzy
+#| msgid "Geboorte > Datum > Type"
+msgid "Partners > Geboorte > Datum > Type"
+msgstr "Geboorte > Datum > Type"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:950
+#, fuzzy
+#| msgid "Geboorte > Datum > Lang Formaat"
+msgid "Partners > Geboorte > Datum > Lang Formaat"
+msgstr "Geboorte > Datum > Lang Formaat"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:954
+#, fuzzy
+#| msgid "Geboorte > Datum > Datum"
+msgid "Partners > Geboorte > Datum > Datum"
+msgstr "Geboorte > Datum > Datum"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:958
+#, fuzzy
+#| msgid "Geboorte > Datum > Onbekend"
+msgid "Partners > Geboorte > Datum > Onbekend"
+msgstr "Geboorte > Datum > Onbekend"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:962
+#, fuzzy
+#| msgid "Geboorte > Datum > Jaar"
+msgid "Partners > Geboorte > Datum > Jaar"
+msgstr "Geboorte > Datum > Jaar"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:966
+#, fuzzy
+#| msgid "Geboorte > Datum > Maand"
+msgid "Partners > Geboorte > Datum > Maand"
+msgstr "Geboorte > Datum > Maand"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:970
+#, fuzzy
+#| msgid "Geboorte > Land > Code"
+msgid "Partners > Geboorte > Land > Code"
+msgstr "Geboorte > Land > Code"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:974
+#, fuzzy
+#| msgid "Geboorte > Land > Omschrijving"
+msgid "Partners > Geboorte > Land > Omschrijving"
+msgstr "Geboorte > Land > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:978
+#, fuzzy
+#| msgid "Geboorte > Plaats > Code"
+msgid "Partners > Geboorte > Plaats > Code"
+msgstr "Geboorte > Plaats > Code"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:982
+#, fuzzy
+#| msgid "Geboorte > Plaats > Omschrijving"
+msgid "Partners > Geboorte > Plaats > Omschrijving"
+msgstr "Geboorte > Plaats > Omschrijving"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:986
+msgid "Partners > Aangaan Huwelijk/Partnerschap > Land > Code"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:990
+msgid "Partners > Aangaan Huwelijk/Partnerschap > Land > Omschrijving"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:994
+msgid "Partners > Aangaan Huwelijk/Partnerschap > Plaats > Code"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:998
+msgid "Partners > Aangaan Huwelijk/Partnerschap > Plaats > Omschrijving"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:1002
+msgid "Partners > Aangaan Huwelijk/Partnerschap > Datum > Type"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:1006
+#, fuzzy
+#| msgid "Overlijden > Datum > Lang Formaat"
+msgid "Partners > Aangaan Huwelijk/Partnerschap > Datum > Lang Formaat"
+msgstr "Overlijden > Datum > Lang Formaat"
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:1010
+msgid "Partners > Aangaan Huwelijk/Partnerschap > Datum > Datum"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:1014
+msgid "Partners > Aangaan Huwelijk/Partnerschap > Datum > Onbekend"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:1018
+msgid "Partners > Aangaan Huwelijk/Partnerschap > Datum > Jaar"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:1022
+msgid "Partners > Aangaan Huwelijk/Partnerschap > Datum > Maand"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:1026
+msgid "Partners > Ontbinding Huwelijk/Partnerschap > Datum > Type"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:1030
+msgid "Partners > Ontbinding Huwelijk/Partnerschap > Datum > Lang Formaat"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:1034
+msgid "Partners > Ontbinding Huwelijk/Partnerschap > Datum > Datum"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:1038
+msgid "Partners > Ontbinding Huwelijk/Partnerschap > Datum > Onbekend"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:1042
+msgid "Partners > Ontbinding Huwelijk/Partnerschap > Datum > Jaar"
+msgstr ""
+
+#: openforms/prefill/contrib/haalcentraal_brp/constants.py:1046
+msgid "Partners > Ontbinding Huwelijk/Partnerschap > Datum > Maand"
+msgstr ""
 
 #: openforms/prefill/contrib/haalcentraal_brp/plugin.py:37
 msgid "Haal Centraal: BRP Personen Bevragen"
@@ -10619,7 +11799,7 @@ msgid "Globally unique identifier"
 msgstr "Unieke identificatie"
 
 #: openforms/products/models/product.py:26
-#: openforms/submissions/models/submission.py:162
+#: openforms/submissions/models/submission.py:160
 msgid "price"
 msgstr "prijs"
 
@@ -10686,10 +11866,10 @@ msgid ""
 "using this field, the mailing will only be sent to this email address. The "
 "email addresses field would then be ignored. "
 msgstr ""
-"Sleutel van de variabele waarvan de waarde gebruikt wordt als ontvanger "
-"(e-mailadres). Als je dit instelt en de variabele heeft een waarde, dan "
-"wordt de e-mail enkel naar dit adres gestuurd - de vaste e-mailaddressen "
-"worden genegeerd."
+"Sleutel van de variabele waarvan de waarde gebruikt wordt als ontvanger (e-"
+"mailadres). Als je dit instelt en de variabele heeft een waarde, dan wordt "
+"de e-mail enkel naar dit adres gestuurd - de vaste e-mailaddressen worden "
+"genegeerd."
 
 #: openforms/registrations/contrib/email/config.py:55
 msgid "The format(s) of the attachment(s) containing the submission details"
@@ -10718,8 +11898,8 @@ msgid ""
 msgstr ""
 "Vink aan om gebruikersbestanden als bijlage aan de registratiemail toe te "
 "voegen. Als een waarde gezet is, dan heeft deze hogere prioriteit dan de "
-"globale configuratie. Formulierbeheerders moeten ervoor zorgen dat de totale"
-" maximale bestandsgrootte onder de maximale e-mailbestandsgrootte blijft."
+"globale configuratie. Formulierbeheerders moeten ervoor zorgen dat de totale "
+"maximale bestandsgrootte onder de maximale e-mailbestandsgrootte blijft."
 
 #: openforms/registrations/contrib/email/config.py:77
 msgid "email subject"
@@ -10916,7 +12096,7 @@ msgstr ""
 "registratie die gebruikt worden als standaardewaarde in de admin."
 
 #: openforms/registrations/contrib/generic_json/apps.py:8
-#: openforms/registrations/contrib/generic_json/plugin.py:38
+#: openforms/registrations/contrib/generic_json/plugin.py:36
 msgid "Generic JSON registration"
 msgstr "Generieke JSON-registratie"
 
@@ -10994,13 +12174,13 @@ msgstr "maplocatie"
 
 #: openforms/registrations/contrib/microsoft_graph/config.py:28
 msgid ""
-"The path of the folder where folders containing Open-Forms related documents"
-" will be created. You can use the expressions {{ year }}, {{ month }} and {{"
-" day }}. It should be an absolute path - i.e. it should start with /"
+"The path of the folder where folders containing Open-Forms related documents "
+"will be created. You can use the expressions {{ year }}, {{ month }} and "
+"{{ day }}. It should be an absolute path - i.e. it should start with /"
 msgstr ""
 "Het pad naar de map waar mappen voor documenten van Open Formulieren "
-"aangemaakt worden. Je kan de expressies {{ year }}, {{ month }} en {{ day }}"
-" gebruiken. Dit moet een absoluut pad zijn (dus beginnen met een /)."
+"aangemaakt worden. Je kan de expressies {{ year }}, {{ month }} en {{ day }} "
+"gebruiken. Dit moet een absoluut pad zijn (dus beginnen met een /)."
 
 #: openforms/registrations/contrib/microsoft_graph/config.py:36
 msgid "drive ID"
@@ -11034,7 +12214,7 @@ msgid "MSGraphService not selected"
 msgstr "Microsoft Graph service is niet ingesteld."
 
 #: openforms/registrations/contrib/microsoft_graph/plugin.py:114
-#: openforms/registrations/contrib/stuf_zds/plugin.py:678
+#: openforms/registrations/contrib/stuf_zds/plugin.py:675
 #, python-brace-format
 msgid "Could not connect: {exception}"
 msgstr "Kan geen verbinding maken: {exception}"
@@ -11050,7 +12230,8 @@ msgstr "verplicht"
 
 #: openforms/registrations/contrib/objects_api/api/serializers.py:18
 msgid "Wether the path is marked as required in the JSON Schema."
-msgstr "Geeft aan of het pad als \"verplicht\" gemarkeerd is in het JSON-schema."
+msgstr ""
+"Geeft aan of het pad als \"verplicht\" gemarkeerd is in het JSON-schema."
 
 #: openforms/registrations/contrib/objects_api/api/serializers.py:28
 msgid "objecttype uuid"
@@ -11084,6 +12265,7 @@ msgstr "v2, variabelekoppelingen"
 #: openforms/registrations/contrib/stuf_zds/options.py:54
 #: openforms/registrations/contrib/zgw_apis/options.py:59
 #: openforms/submissions/models/email_verification.py:53
+#: openforms/submissions/models/submission_files.py:248
 msgid "component key"
 msgstr "componentsleutel"
 
@@ -11099,7 +12281,7 @@ msgstr ""
 
 #: openforms/registrations/contrib/objects_api/config.py:75
 #: openforms/registrations/contrib/zgw_apis/options.py:66
-#: openforms/registrations/contrib/zgw_apis/options.py:132
+#: openforms/registrations/contrib/zgw_apis/options.py:167
 msgid "Document type description"
 msgstr "Documenttypeomschrijving"
 
@@ -11107,14 +12289,14 @@ msgstr "Documenttypeomschrijving"
 #: openforms/registrations/contrib/zgw_apis/options.py:69
 msgid ""
 "The document type will be retrieved from the catalogue and case type "
-"specified in the backend options. The version will automatically be selected"
-" based on the submission completion timestamp. Only document types related "
-"to the case type are valid."
+"specified in the backend options. The version will automatically be selected "
+"based on the submission completion timestamp. Only document types related to "
+"the case type are valid."
 msgstr ""
-"Het documenttype wordt opgehaald binnen de ingestelde catalogus en zaaktype."
-" De juiste versie van het documenttype wordt automatisch bepaald aan de hand"
-" van de inzendingsdatum. Enkel documenttypen die bij het zaaktype horen zijn"
-" geldig."
+"Het documenttype wordt opgehaald binnen de ingestelde catalogus en zaaktype. "
+"De juiste versie van het documenttype wordt automatisch bepaald aan de hand "
+"van de inzendingsdatum. Enkel documenttypen die bij het zaaktype horen zijn "
+"geldig."
 
 #: openforms/registrations/contrib/objects_api/config.py:88
 #: openforms/registrations/contrib/zgw_apis/options.py:79
@@ -11123,7 +12305,7 @@ msgstr "RSIN van de organisatie die het document aanmaakt"
 
 #: openforms/registrations/contrib/objects_api/config.py:92
 #: openforms/registrations/contrib/zgw_apis/options.py:83
-#: openforms/registrations/contrib/zgw_apis/options.py:165
+#: openforms/registrations/contrib/zgw_apis/options.py:200
 msgid "Vertrouwelijkheidaanduiding"
 msgstr "Vertrouwelijkheidaanduiding"
 
@@ -11142,7 +12324,7 @@ msgstr ""
 "gebruikt."
 
 #: openforms/registrations/contrib/objects_api/config.py:122
-#: openforms/registrations/contrib/zgw_apis/options.py:112
+#: openforms/registrations/contrib/zgw_apis/options.py:147
 msgid "catalogue"
 msgstr "catalogus"
 
@@ -11161,8 +12343,8 @@ msgid ""
 "The schema version of the objects API Options. Not to be confused with the "
 "objecttype version."
 msgstr ""
-"De versie van de optiesconfiguratie. Niet te verwarren met de versie van het"
-" objecttype."
+"De versie van de optiesconfiguratie. Niet te verwarren met de versie van het "
+"objecttype."
 
 #: openforms/registrations/contrib/objects_api/config.py:138
 msgid ""
@@ -11170,8 +12352,8 @@ msgid ""
 "objecttype should have the following three attributes: 1) submission_id; 2) "
 "type (the type of productaanvraag); 3) data (the submitted form data)"
 msgstr ""
-"UUID van het OBJECTTYPE voor de 'ProductAanvraag' in de Objecttypen API. Het"
-" objecttype moet de volgende attributen bevatten: 1) submission_id; 2) type "
+"UUID van het OBJECTTYPE voor de 'ProductAanvraag' in de Objecttypen API. Het "
+"objecttype moet de volgende attributen bevatten: 1) submission_id; 2) type "
 "(het type van de 'ProductAanvraag'); 3) data (ingezonden formuliergegevens)"
 
 #: openforms/registrations/contrib/objects_api/config.py:150
@@ -11192,8 +12374,8 @@ msgstr "CSV bestand inzending uploaden"
 
 #: openforms/registrations/contrib/objects_api/config.py:167
 msgid ""
-"Indicates whether or not the submission CSV should be uploaded as a Document"
-" in Documenten API and attached to the ProductAanvraag."
+"Indicates whether or not the submission CSV should be uploaded as a Document "
+"in Documenten API and attached to the ProductAanvraag."
 msgstr ""
 "Geeft aan of de inzendingsgegevens als CSV in de Documenten API moet "
 "geüpload worden en toegevoegd aan de ProductAanvraag."
@@ -11211,8 +12393,7 @@ msgid ""
 msgstr ""
 "Omschrijving van het documenttype in de Catalogi API voor het PDF-document "
 "met inzendingsgegevens. De juiste versie wordt automatisch geselecteerd op "
-"basis van de inzendingsdatum en geldigheidsdatums van de "
-"documenttypeversies."
+"basis van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
 
 #: openforms/registrations/contrib/objects_api/config.py:200
 msgid ""
@@ -11223,8 +12404,7 @@ msgid ""
 msgstr ""
 "Omschrijving van het documenttype in de Catalogi API voor het CSV-document "
 "met inzendingsgegevens. De juiste versie wordt automatisch geselecteerd op "
-"basis van de inzendingsdatum en geldigheidsdatums van de "
-"documenttypeversies."
+"basis van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
 
 #: openforms/registrations/contrib/objects_api/config.py:213
 msgid ""
@@ -11234,29 +12414,29 @@ msgid ""
 "document type versions."
 msgstr ""
 "Omschrijving van het documenttype in de Catalogi API voor "
-"inzendingsbijlagen. De juiste versie wordt automatisch geselecteerd op basis"
-" van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
+"inzendingsbijlagen. De juiste versie wordt automatisch geselecteerd op basis "
+"van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
 
 #: openforms/registrations/contrib/objects_api/config.py:223
 #: openforms/registrations/contrib/stuf_zds/options.py:135
-#: openforms/registrations/contrib/zgw_apis/options.py:289
+#: openforms/registrations/contrib/zgw_apis/options.py:324
 msgid "Files"
 msgstr "Bestanden"
 
 #: openforms/registrations/contrib/objects_api/config.py:226
 #: openforms/registrations/contrib/stuf_zds/options.py:138
-#: openforms/registrations/contrib/zgw_apis/options.py:292
+#: openforms/registrations/contrib/zgw_apis/options.py:327
 msgid ""
-"List of file upload options for file components. Each entry contains the key"
-" of the file component in the form, which may be a child in an edit grid. "
-"Any specified option overrides the equivalent option on the backend level. "
-"If unspecified, the backend configuration is used."
+"List of file upload options for file components. Each entry contains the key "
+"of the file component in the form, which may be a child in an edit grid. Any "
+"specified option overrides the equivalent option on the backend level. If "
+"unspecified, the backend configuration is used."
 msgstr ""
 "Lijst van instellingen voor bestandsupload-componenten. Elk item bevat de "
 "sleutel van het bestandsupload-component in het formulier, wat een item "
 "binnen een herhalende groep kan zijn. De opgegeven instellingen "
-"overschrijven de standaardinstellingen. Indien niet gespecifieerd, worden de"
-" backend-instellingen gebruikt.."
+"overschrijven de standaardinstellingen. Indien niet gespecifieerd, worden de "
+"backend-instellingen gebruikt.."
 
 #: openforms/registrations/contrib/objects_api/config.py:236
 msgid "productaanvraag type"
@@ -11271,7 +12451,7 @@ msgid "JSON content field"
 msgstr "JSON-inhoud sjabloon"
 
 #: openforms/registrations/contrib/objects_api/config.py:244
-#: openforms/registrations/contrib/zgw_apis/options.py:268
+#: openforms/registrations/contrib/zgw_apis/options.py:303
 msgid "JSON template for the body of the request sent to the Objects API."
 msgstr ""
 "JSON-sjabloon voor de inhoud van het verzoek wat naar de Objecten API "
@@ -11350,7 +12530,7 @@ msgstr ""
 "in de registratie-opties onder \"Documenttypen\"."
 
 #: openforms/registrations/contrib/objects_api/config.py:419
-#: openforms/registrations/contrib/zgw_apis/options.py:477
+#: openforms/registrations/contrib/zgw_apis/options.py:519
 msgid ""
 "The specified catalogue does not exist. Maybe you made a typo in the domain "
 "or RSIN?"
@@ -11381,8 +12561,8 @@ msgstr "Productaanvraag type"
 
 #: openforms/registrations/contrib/objects_api/models.py:30
 msgid ""
-"Description of the 'ProductAanvraag' type. This value is saved in the 'type'"
-" attribute of the 'ProductAanvraag'."
+"Description of the 'ProductAanvraag' type. This value is saved in the 'type' "
+"attribute of the 'ProductAanvraag'."
 msgstr ""
 "Omschrijving van het type van de 'Productaanvraag'. Deze waarde wordt "
 "bewaard in het 'type' attribuut van de 'ProductAanvraag'."
@@ -11408,9 +12588,9 @@ msgstr "Objecten API configuratie"
 #: openforms/submissions/models/cosign.py:28
 #: openforms/submissions/models/email_verification.py:47
 #: openforms/submissions/models/post_completion_metadata.py:14
-#: openforms/submissions/models/submission.py:359
-#: openforms/submissions/models/submission_files.py:57
-#: openforms/submissions/models/submission_files.py:148
+#: openforms/submissions/models/submission.py:357
+#: openforms/submissions/models/submission_files.py:55
+#: openforms/submissions/models/submission_files.py:204
 #: openforms/submissions/models/submission_report.py:30
 #: openforms/submissions/models/submission_value_variable.py:448
 msgid "submission"
@@ -11437,7 +12617,7 @@ msgid "The CSV URL of the document on the Documents API."
 msgstr "De resource-URL in de Documenten API van de inzendings-CSV."
 
 #: openforms/registrations/contrib/objects_api/models.py:99
-#: openforms/submissions/models/submission_files.py:207
+#: openforms/submissions/models/submission_files.py:278
 msgid "submission file attachment"
 msgstr "inzendingsbijlage"
 
@@ -11452,8 +12632,7 @@ msgstr "Documenten URL"
 #: openforms/registrations/contrib/objects_api/models.py:106
 msgid "The URL of the submission attachment registered in the Documents API."
 msgstr ""
-"De resource-URL in de Documenten API van de geregistreerde "
-"inzendingsbijlage."
+"De resource-URL in de Documenten API van de geregistreerde inzendingsbijlage."
 
 #: openforms/registrations/contrib/objects_api/plugin.py:44
 msgid "Objects API registration"
@@ -11544,8 +12723,8 @@ msgstr ""
 #: openforms/registrations/contrib/stuf_zds/options.py:64
 #: openforms/registrations/contrib/zgw_apis/options.py:96
 msgid ""
-"Optional custom title for the document. By default, the attachment file name"
-" is used."
+"Optional custom title for the document. By default, the attachment file name "
+"is used."
 msgstr ""
 "Optionele aangepaste documenttitel. Standaard wordt de bijlage-bestandsnaam "
 "gebruikt."
@@ -11564,8 +12743,7 @@ msgstr "Zaaktype status code voor nieuw aangemaakte zaken via StUF-ZDS"
 
 #: openforms/registrations/contrib/stuf_zds/options.py:90
 msgid "Zaaktype status omschrijving for newly created zaken in StUF-ZDS"
-msgstr ""
-"Zaaktype status omschrijving voor nieuw aangemaakte zaken via StUF-ZDS"
+msgstr "Zaaktype status omschrijving voor nieuw aangemaakte zaken via StUF-ZDS"
 
 #: openforms/registrations/contrib/stuf_zds/options.py:96
 msgid "Documenttype description for newly created zaken in StUF-ZDS"
@@ -11594,8 +12772,8 @@ msgid ""
 "is sent to StUF-ZDS. Those keys and the values belonging to them in the "
 "submission data are included in Object/extraElementen."
 msgstr ""
-"Met deze variabelekoppelingen stel je in welke formuliervariabelen als extra"
-" elementen in Object/extraElementen binnen StUF-ZDS meegestuurd worden, en "
+"Met deze variabelekoppelingen stel je in welke formuliervariabelen als extra "
+"elementen in Object/extraElementen binnen StUF-ZDS meegestuurd worden, en "
 "met welke naam."
 
 #: openforms/registrations/contrib/stuf_zds/options.py:123
@@ -11608,15 +12786,15 @@ msgid ""
 "is sent to StUF-ZDS. Those keys and the values belonging to them in the "
 "submission data are included in heeftAlsInitiator/extraElementen."
 msgstr ""
-"Met deze variabelekoppelingen stel je in welke formuliervariabelen als extra"
-" elementen in heeftAlsInitiator/extraElementen binnen StUF-ZDS meegestuurd "
+"Met deze variabelekoppelingen stel je in welke formuliervariabelen als extra "
+"elementen in heeftAlsInitiator/extraElementen binnen StUF-ZDS meegestuurd "
 "worden, en met welke naam."
 
 #: openforms/registrations/contrib/stuf_zds/plugin.py:201
 msgid "StUF-ZDS"
 msgstr "StUF-ZDS"
 
-#: openforms/registrations/contrib/stuf_zds/plugin.py:671
+#: openforms/registrations/contrib/stuf_zds/plugin.py:668
 msgid "StufService not selected"
 msgstr "StUF-service is niet ingesteld"
 
@@ -11718,6 +12896,12 @@ msgstr "JSON-document"
 msgid "PDF document"
 msgstr "PDF-document"
 
+#: openforms/registrations/contrib/zgw_apis/constants.py:11
+#, fuzzy
+#| msgid "Overview"
+msgid "Overige"
+msgstr "Overzicht"
+
 #: openforms/registrations/contrib/zgw_apis/models.py:26
 msgid "A recognisable name for this set of ZGW APIs."
 msgstr "Een herkenbare naam voor deze groep ZGW API's."
@@ -11740,8 +12924,8 @@ msgid ""
 "be overridden in the Registration tab of a given form."
 msgstr ""
 "Aanduiding van de mate waarin het zaakdossier van de ZAAK voor de "
-"openbaarheid bestemd is. Dit kan per formulier in de registratieconfiguratie"
-" overschreven worden."
+"openbaarheid bestemd is. Dit kan per formulier in de registratieconfiguratie "
+"overschreven worden."
 
 #: openforms/registrations/contrib/zgw_apis/models.py:105
 msgid "vertrouwelijkheidaanduiding document"
@@ -11786,7 +12970,7 @@ msgstr ""
 "uitgeschakeld is, dan genereert Open Formulieren de  publieke referentie."
 
 #: openforms/registrations/contrib/zgw_apis/models.py:150
-#: openforms/registrations/contrib/zgw_apis/options.py:109
+#: openforms/registrations/contrib/zgw_apis/options.py:144
 msgid "ZGW API set"
 msgstr "ZGW API-groep"
 
@@ -11812,11 +12996,57 @@ msgid ""
 msgstr ""
 "Naam van de eigenschap op het zaaktype waar de variabele op gemapped wordt."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:108
+#: openforms/registrations/contrib/zgw_apis/options.py:105
+#, fuzzy
+#| msgid "Overview"
+msgid "Overige data"
+msgstr "Overzicht"
+
+#: openforms/registrations/contrib/zgw_apis/options.py:107
+msgid ""
+"Data for the 'overige' object in a free format. You can use form variables "
+"here."
+msgstr ""
+
+#: openforms/registrations/contrib/zgw_apis/options.py:119
+#, fuzzy
+#| msgid "objecttype"
+msgid "Case object type"
+msgstr "objecttype"
+
+#: openforms/registrations/contrib/zgw_apis/options.py:121
+msgid "Type of the case object. Now only 'overige' value is supported."
+msgstr ""
+
+#: openforms/registrations/contrib/zgw_apis/options.py:124
+#, fuzzy
+#| msgid "objecttype version"
+msgid "Case object type overige"
+msgstr "objecttype versie"
+
+#: openforms/registrations/contrib/zgw_apis/options.py:127
+#, fuzzy
+#| msgid "The version of the objecttype."
+msgid "Description of the 'overige' case object type."
+msgstr "De versie van het objecttype."
+
+#: openforms/registrations/contrib/zgw_apis/options.py:130
+#, fuzzy
+#| msgid "Case type identification"
+msgid "Case object identification"
+msgstr "Zaaktype-identificatie"
+
+#: openforms/registrations/contrib/zgw_apis/options.py:132
+msgid ""
+"Data, which describes the object. The shape depends on the "
+"'case_object_type'. Now only 'overige' data shape is supported."
+msgstr ""
+
+#: openforms/registrations/contrib/zgw_apis/options.py:143
 msgid "Which ZGW API set to use."
 msgstr "De gewenste ZGW API-groep."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:115
+#: openforms/registrations/contrib/zgw_apis/options.py:150
 msgid ""
 "The catalogue in the catalogi API from the selected API group. This "
 "overrides the catalogue specified in the API group, if it's set. Case and "
@@ -11826,39 +13056,39 @@ msgstr ""
 "overschrijft de catalogus die in de API-groep ingesteld is. De beschikbare "
 "zaak- en documenttypen worden uit deze catalogus opgevraagd."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:122
+#: openforms/registrations/contrib/zgw_apis/options.py:157
 msgid "Case type identification"
 msgstr "Zaaktype-identificatie"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:124
+#: openforms/registrations/contrib/zgw_apis/options.py:159
 msgid ""
-"The case type will be retrieved in the specified catalogue. The version will"
-" automatically be selected based on the submission completion timestamp. "
-"When you specify this field, you MUST also specify a catalogue."
+"The case type will be retrieved in the specified catalogue. The version will "
+"automatically be selected based on the submission completion timestamp. When "
+"you specify this field, you MUST also specify a catalogue."
 msgstr ""
 "Het zaaktype wordt opgehaald binnen de ingestelde catalogus. De juiste "
 "versie van het zaaktype wordt automatisch bepaald aan de hand van de "
 "inzendingsdatum. Als je een waarde voor dit veld opgeeft, dan moet ook een "
 "catalogus ingesteld zijn."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:134
+#: openforms/registrations/contrib/zgw_apis/options.py:169
 msgid ""
 "The document type will be retrieved in the specified catalogue. The version "
-"will automatically be selected based on the submission completion timestamp."
-" When you specify this field, you MUST also specify the case type via its "
+"will automatically be selected based on the submission completion timestamp. "
+"When you specify this field, you MUST also specify the case type via its "
 "identification. Only document types related to the case type are valid."
 msgstr ""
 "Het documenttype wordt opgehaald binnen de ingestelde catalogus. De juiste "
 "versie van het documenttype wordt automatisch bepaald aan de hand van de "
 "inzendingsdatum. Als je een waarde voor dit veld opgeeft, dan MOET je ook "
-"het zaaktype via haar identificatie opgeven. Enkel documenttypen die bij het"
-" zaaktype horen zijn geldig."
+"het zaaktype via haar identificatie opgeven. Enkel documenttypen die bij het "
+"zaaktype horen zijn geldig."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:143
+#: openforms/registrations/contrib/zgw_apis/options.py:178
 msgid "Product url"
 msgstr "Product-URL"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:145
+#: openforms/registrations/contrib/zgw_apis/options.py:180
 msgid ""
 "The product url will be retrieved from the specified case type and the "
 "version that is active at that moment. "
@@ -11866,19 +13096,19 @@ msgstr ""
 "De product-URL wordt opgehaald uit het opgegeven zaaktype en de versie die "
 "op dat moment geldig is."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:154
+#: openforms/registrations/contrib/zgw_apis/options.py:189
 msgid "Summary documents"
 msgstr "Samenvattingsdocumenten"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:155
+#: openforms/registrations/contrib/zgw_apis/options.py:190
 msgid "Which summary documents to include during registration."
 msgstr "Welke samenvattingsdocumenten aan de zaak worden toegevoegd."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:161
+#: openforms/registrations/contrib/zgw_apis/options.py:196
 msgid "RSIN of organization, which creates the ZAAK"
 msgstr "RSIN van de organisatie, die de ZAAK aanmaakt"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:169
+#: openforms/registrations/contrib/zgw_apis/options.py:204
 msgid ""
 "Indication of the level to which extend the dossier of the ZAAK is meant to "
 "be public."
@@ -11886,7 +13116,7 @@ msgstr ""
 "Aanduiding van de mate waarin het zaakdossier van de ZAAK voor de "
 "openbaarheid bestemd is."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:175
+#: openforms/registrations/contrib/zgw_apis/options.py:210
 msgid ""
 "Description (omschrijving) of the ROLTYPE to use for employees filling in a "
 "form for a citizen/company."
@@ -11894,7 +13124,7 @@ msgstr ""
 "Omschrijving van het ROLTYPE om de medewerker te registreren die het "
 "formulier invult voor de klant (burger/bedrijf)."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:184
+#: openforms/registrations/contrib/zgw_apis/options.py:219
 msgid ""
 "Description (omschrijving) of the ROLTYPE to use for citizens filling in a "
 "form with partners."
@@ -11902,12 +13132,12 @@ msgstr ""
 "Omschrijving van het ROLTYPE te gebruiken voor inwoners voor het invullen "
 "van een formulier met partners."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:192
+#: openforms/registrations/contrib/zgw_apis/options.py:227
 msgid ""
 "Description (omschrijving) that will be used in the partners registration."
 msgstr "De omschrijving welke gebruikt wordt voor partner registraties."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:200
+#: openforms/registrations/contrib/zgw_apis/options.py:235
 msgid ""
 "Description (omschrijving) of the ROLTYPE to use for citizens filling in a "
 "form with children."
@@ -11915,102 +13145,112 @@ msgstr ""
 "Omschrijving van het ROLTYPE te gebruiken voor inwoners voor het invullen "
 "van een formulier met kinderen."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:208
+#: openforms/registrations/contrib/zgw_apis/options.py:243
 msgid ""
 "Description (omschrijving) that will be used in the children registration."
 msgstr "De omschrijving welke gebruikt wordt voor kind registraties."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:212
+#: openforms/registrations/contrib/zgw_apis/options.py:247
 msgid "Omschrijving"
 msgstr "Omschrijving"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:216
+#: openforms/registrations/contrib/zgw_apis/options.py:251
 msgid ""
-"Description (omschrijving) of the case. You can use the expressions like '{{"
-" form_name }}' or other variables here. The resolved string is limited to 80"
-" chars. If empty, the form name is used."
+"Description (omschrijving) of the case. You can use the expressions like "
+"'{{ form_name }}' or other variables here. The resolved string is limited to "
+"80 chars. If empty, the form name is used."
 msgstr ""
 "Omschrijving van de zaak. Je kan hier expressies zoals '{{ form_name }}' of "
 "andere variabelen gebruiken. De resulterende tekst is beperkt tot 80 "
 "karakters. Standaard wordt de formuliernaam gebruikt."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:225
+#: openforms/registrations/contrib/zgw_apis/options.py:260
 msgid "Toelichting"
 msgstr "Toelichting"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:229
+#: openforms/registrations/contrib/zgw_apis/options.py:264
 msgid ""
-"Explanation (toelichting) of the case. You can use the expressions like '{{ "
-"form_name }}' or other variables here."
+"Explanation (toelichting) of the case. You can use the expressions like "
+"'{{ form_name }}' or other variables here."
 msgstr ""
 "Toelichting van de zaak. Je kan hier expressies zoals '{{ form_name }}' of "
 "andere variabelen gebruiken."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:243
+#: openforms/registrations/contrib/zgw_apis/options.py:278
 msgid "Which Objects API set to use."
 msgstr "De gewenste Objecten API-groep."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:244
+#: openforms/registrations/contrib/zgw_apis/options.py:279
 msgid "Objects API set"
 msgstr "Objecten API-groep"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:249
+#: openforms/registrations/contrib/zgw_apis/options.py:284
 msgid "objects API - objecttype"
 msgstr "objecten API - objecttype"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:251
+#: openforms/registrations/contrib/zgw_apis/options.py:286
 msgid ""
 "URL that points to the ProductAanvraag objecttype in the Objecttypes API. "
-"The objecttype should have the following three attributes: 1) submission_id;"
-" 2) type (the type of productaanvraag); 3) data (the submitted form data)"
+"The objecttype should have the following three attributes: 1) submission_id; "
+"2) type (the type of productaanvraag); 3) data (the submitted form data)"
 msgstr ""
-"URL naar het OBJECTTYPE voor de 'ProductAanvraag' in de Objecttypen API. Het"
-" objecttype moet de volgende attributen bevatten: 1) submission_id; 2) type "
+"URL naar het OBJECTTYPE voor de 'ProductAanvraag' in de Objecttypen API. Het "
+"objecttype moet de volgende attributen bevatten: 1) submission_id; 2) type "
 "(het type van de 'ProductAanvraag'); 3) data (ingezonden formuliergegevens)"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:261
+#: openforms/registrations/contrib/zgw_apis/options.py:296
 msgid "objects API - objecttype version"
 msgstr "objecten API - objecttypeversie"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:262
+#: openforms/registrations/contrib/zgw_apis/options.py:297
 msgid "Version of the objecttype in the Objecttypes API"
 msgstr "Versie van het objecttype in de Objecttypen API"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:266
+#: openforms/registrations/contrib/zgw_apis/options.py:301
 msgid "objects API - JSON content field"
 msgstr "objecten API - JSON-inhoud veld"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:282
+#: openforms/registrations/contrib/zgw_apis/options.py:317
 msgid "Variable-to-property mappings"
 msgstr "Variabele-naar-eigenschapkoppelingen"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:409
+#: openforms/registrations/contrib/zgw_apis/options.py:337
+#, fuzzy
+#| msgid "Object"
+msgid "Case Objects"
+msgstr "Sleutel-waarde paar (object)"
+
+#: openforms/registrations/contrib/zgw_apis/options.py:339
+msgid "List of case objects."
+msgstr ""
+
+#: openforms/registrations/contrib/zgw_apis/options.py:451
 msgid "Objects API group must be specified if an objecttype is specified."
 msgstr ""
 "Je moet een Objecten-API-groep selecteren als je een objecttype opgeeft."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:423
+#: openforms/registrations/contrib/zgw_apis/options.py:465
 msgid ""
-"The specified objecttype is not present in the selected Objecttypes API (the"
-" URL does not start with the API root of the Objecttypes API)."
+"The specified objecttype is not present in the selected Objecttypes API (the "
+"URL does not start with the API root of the Objecttypes API)."
 msgstr ""
 "Het gekozen objecttype bestaat niet binnen de gekozen Objecttypen-API (de "
 "URL begint niet met de basis-URL van de Objecttypen-API-service)."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:451
+#: openforms/registrations/contrib/zgw_apis/options.py:493
 #, fuzzy
 #| msgid ""
 #| "You must specify a catalogue when passing a case type identification."
 msgid "You must specify a catalogue (got empty domain and RSIN)."
 msgstr ""
-"Je moet een catalogus aanduiden wanneer je het zaaktype via de identificatie"
-" opgeeft."
+"Je moet een catalogus aanduiden wanneer je het zaaktype via de identificatie "
+"opgeeft."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:461
+#: openforms/registrations/contrib/zgw_apis/options.py:503
 msgid "The provided zaaktype does not exist in the specified Catalogi API."
 msgstr "Het opgegeven zaaktype bestaat niet in de ingestelde Catalogi API."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:466
+#: openforms/registrations/contrib/zgw_apis/options.py:508
 msgid ""
 "The provided informatieobjecttype does not exist in the selected case type "
 "or Catalogi API."
@@ -12018,24 +13258,23 @@ msgstr ""
 "Het opgegeven informatieobjecttype bestaat niet in het geselecteerde "
 "zaaktype of in de ingestelde Catalogi API."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:576
+#: openforms/registrations/contrib/zgw_apis/options.py:618
 #, python-brace-format
 msgid "Could not find a property with the name '{name}' in the case type"
 msgstr ""
 "Kon geen eigenschap met de naam '{name}' vinden binnen het ingestelde "
 "zaaktype."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:629
-msgid ""
-"Could not find a roltype with this description related to the zaaktype."
+#: openforms/registrations/contrib/zgw_apis/options.py:671
+msgid "Could not find a roltype with this description related to the zaaktype."
 msgstr ""
 "Kon geen roltype vinden met deze omschrijving binnen het opgegeven zaaktype."
 
-#: openforms/registrations/contrib/zgw_apis/plugin.py:211
+#: openforms/registrations/contrib/zgw_apis/plugin.py:236
 msgid "ZGW API's"
 msgstr "ZGW API's"
 
-#: openforms/registrations/contrib/zgw_apis/plugin.py:593
+#: openforms/registrations/contrib/zgw_apis/plugin.py:618
 msgid "Employee who registered the case on behalf of the customer."
 msgstr "Medewerker die de zaak registreerde voor de klant."
 
@@ -12045,11 +13284,13 @@ msgstr "Lijst van beschikbare services"
 
 #: openforms/services/api/viewsets.py:17
 msgid ""
-"Return a list of available (JSON) services/registrations configured in the backend.\n"
+"Return a list of available (JSON) services/registrations configured in the "
+"backend.\n"
 "\n"
 "Note that this endpoint is **EXPERIMENTAL**."
 msgstr ""
-"Geef een lijst van beschikbare (JSON) services/registraties die in de backend ingesteld zijn.\n"
+"Geef een lijst van beschikbare (JSON) services/registraties die in de "
+"backend ingesteld zijn.\n"
 "\n"
 "Dit endpoint is **EXPERIMENTEEL**."
 
@@ -12129,38 +13370,37 @@ msgstr "Inzendings-PDF-preview"
 msgid "Registration: email plugin preview"
 msgstr "Registratie: e-mailpluginpreview"
 
-#: openforms/submissions/admin.py:446
+#: openforms/submissions/admin.py:447
 msgid "You can only export the submissions of the same form type."
 msgstr ""
-"Je kan alleen de inzendingen van één enkel formuliertype tegelijk "
-"exporteren."
+"Je kan alleen de inzendingen van één enkel formuliertype tegelijk exporteren."
 
-#: openforms/submissions/admin.py:456
+#: openforms/submissions/admin.py:457
 #, python-format
 msgid "Export selected %(verbose_name_plural)s as CSV-file."
 msgstr "Exporteer geselecteerde %(verbose_name_plural)s als CSV-bestand."
 
-#: openforms/submissions/admin.py:461
+#: openforms/submissions/admin.py:462
 #, python-format
 msgid "Export selected %(verbose_name_plural)s as Excel-file."
 msgstr "Exporteer geselecteerde %(verbose_name_plural)s als Excel-bestand."
 
-#: openforms/submissions/admin.py:467
+#: openforms/submissions/admin.py:468
 #, python-format
 msgid "Export selected %(verbose_name_plural)s as JSON-file."
 msgstr "Exporteer geselecteerde %(verbose_name_plural)s als JSON-bestand."
 
-#: openforms/submissions/admin.py:472
+#: openforms/submissions/admin.py:473
 #, python-format
 msgid "Export selected %(verbose_name_plural)s as XML-file."
 msgstr "Exporteer geselecteerde %(verbose_name_plural)s als XML-bestand."
 
-#: openforms/submissions/admin.py:476
+#: openforms/submissions/admin.py:477
 #, python-format
 msgid "Retry processing %(verbose_name_plural)s."
 msgstr "Probeer %(verbose_name_plural)s opnieuw te verwerken"
 
-#: openforms/submissions/admin.py:482
+#: openforms/submissions/admin.py:483
 #, python-brace-format
 msgid "Retrying processing flow for {count} {verbose_name} object"
 msgid_plural "Retrying processing flow for {count} {verbose_name} objects"
@@ -12169,19 +13409,15 @@ msgstr[0] ""
 msgstr[1] ""
 "Nieuwe verwerkingspoging voor {count} {verbose_name} objecten wordt gestart."
 
-#: openforms/submissions/admin.py:630
-msgid "Form key"
-msgstr "Formuliersleutel"
-
-#: openforms/submissions/admin.py:650
+#: openforms/submissions/admin.py:641
 msgid "is verified"
 msgstr "is geverifieerd"
 
-#: openforms/submissions/admin.py:673
+#: openforms/submissions/admin.py:664
 msgid "is usable"
 msgstr "is bruikbaar"
 
-#: openforms/submissions/admin.py:685
+#: openforms/submissions/admin.py:676
 msgid "OTP email preview"
 msgstr "Toegangscodemail (preview)"
 
@@ -12218,7 +13454,7 @@ msgid "Amount (to be) paid"
 msgstr "Het te betalen bedrag"
 
 #: openforms/submissions/api/serializers.py:147
-#: openforms/submissions/models/submission_step.py:133
+#: openforms/submissions/models/submission_step.py:143
 msgid "Submission steps"
 msgstr "Inzendingsstappen"
 
@@ -12326,35 +13562,34 @@ msgstr ""
 "Vlag die aangeeft of een inzendingsstap afkomstig is van een onderbroken "
 "inzending of een standaard ingezonden stap."
 
-#: openforms/submissions/api/serializers.py:508
+#: openforms/submissions/api/serializers.py:511
 msgid "form data"
 msgstr "Formuliergegevens"
 
-#: openforms/submissions/api/serializers.py:511
+#: openforms/submissions/api/serializers.py:514
 msgid ""
 "The Form.io submission data object. This will be merged with the full form "
-"submission data, including data from other steps, to evaluate the configured"
-" form logic."
+"submission data, including data from other steps, to evaluate the configured "
+"form logic."
 msgstr ""
 "De Form.io inzendingsgegevens. Dit wordt samengevoegd met de "
 "inzendingsgegevens, inclusief de gegevens van de andere stappen, om de "
 "geconfigureerde formulier logica uit te voeren."
 
-#: openforms/submissions/api/serializers.py:522
+#: openforms/submissions/api/serializers.py:525
 msgid "Contact email address"
 msgstr "Contact e-mailadres"
 
-#: openforms/submissions/api/serializers.py:524
+#: openforms/submissions/api/serializers.py:527
 msgid "The email address where the 'magic' resume link should be sent to"
 msgstr ""
-"Het e-mailadres waar de 'magische' vervolg link naar toe gestuurd moet "
-"worden"
+"Het e-mailadres waar de 'magische' vervolg link naar toe gestuurd moet worden"
 
-#: openforms/submissions/api/serializers.py:618
+#: openforms/submissions/api/serializers.py:621
 msgid "background processing status"
 msgstr "achtergrondproces status"
 
-#: openforms/submissions/api/serializers.py:622
+#: openforms/submissions/api/serializers.py:625
 msgid ""
 "The async task state, managed by the async task queue. Once the status is "
 "`done`, check the `result` field for the outcome."
@@ -12362,27 +13597,27 @@ msgstr ""
 "De asynchrone taakstatus, beheerd door de asynchrone taakwachtrij. Zodra de "
 "status 'klaar' is, controleert u het veld 'resultaat' voor de uitkomst."
 
-#: openforms/submissions/api/serializers.py:627
+#: openforms/submissions/api/serializers.py:630
 msgid "background processing result"
 msgstr "achtergrondproces resultaat"
 
-#: openforms/submissions/api/serializers.py:632
+#: openforms/submissions/api/serializers.py:635
 msgid ""
 "The result from the background processing. This field only has a value if "
 "the processing has completed (both successfully or with errors)."
 msgstr ""
-"Het resultaat van de achtergrondverwerking. Dit veld heeft alleen een waarde"
-" als de verwerking is voltooid (zowel met succes als met fouten)."
+"Het resultaat van de achtergrondverwerking. Dit veld heeft alleen een waarde "
+"als de verwerking is voltooid (zowel met succes als met fouten)."
 
-#: openforms/submissions/api/serializers.py:639
+#: openforms/submissions/api/serializers.py:642
 msgid "Error information"
 msgstr "Fout informatie"
 
-#: openforms/submissions/api/serializers.py:643
+#: openforms/submissions/api/serializers.py:646
 msgid "Error feedback in case the processing did not complete successfully."
 msgstr "Foutfeedback in het geval de verwerking niet succesvol is voltooid."
 
-#: openforms/submissions/api/serializers.py:654
+#: openforms/submissions/api/serializers.py:657
 msgid ""
 "The public registration reference, sourced from the registration backend or "
 "otherwise uniquely generated in case the backend could not provide it."
@@ -12391,29 +13626,29 @@ msgstr ""
 "anderszins uniek gegenereerd voor het geval de backend deze niet kan "
 "verstrekken."
 
-#: openforms/submissions/api/serializers.py:660
+#: openforms/submissions/api/serializers.py:663
 msgid "Confirmation page title"
 msgstr "Bevestigingspaginatitel"
 
-#: openforms/submissions/api/serializers.py:662
+#: openforms/submissions/api/serializers.py:665
 msgid "Title of the confirmation page."
 msgstr "Titel op de bevestigingspagina"
 
-#: openforms/submissions/api/serializers.py:666
+#: openforms/submissions/api/serializers.py:669
 msgid "Confirmation page content"
 msgstr "Bevestigingspagina tekst"
 
-#: openforms/submissions/api/serializers.py:668
+#: openforms/submissions/api/serializers.py:671
 msgid "Body text of the confirmation page. May contain HTML!"
 msgstr ""
 "Inhoud van de bevestigingspagina. Hierin mogen HTML-karakers worden "
 "opgenomen."
 
-#: openforms/submissions/api/serializers.py:672
+#: openforms/submissions/api/serializers.py:675
 msgid "Report download URL"
 msgstr "Document download URL"
 
-#: openforms/submissions/api/serializers.py:676
+#: openforms/submissions/api/serializers.py:679
 msgid ""
 "Download URL for the generated PDF report. Note that this contain a "
 "timestamped token generated by the backend."
@@ -12421,11 +13656,11 @@ msgstr ""
 "Download-URL voor het gegenereerde PDF document. Let op: Deze URL bevat een "
 "tijdgebaseerd token dat door de backend wordt gegenereerd."
 
-#: openforms/submissions/api/serializers.py:681
+#: openforms/submissions/api/serializers.py:684
 msgid "Payment URL"
 msgstr "Betaalpagina URL"
 
-#: openforms/submissions/api/serializers.py:685
+#: openforms/submissions/api/serializers.py:688
 msgid ""
 "URL to retrieve the payment information. Note that this (will) contain(s) a "
 "timestamped token generated by the backend."
@@ -12433,69 +13668,69 @@ msgstr ""
 "URL om de betalingsinformatie op te halen. Let op: Deze URL bevat een "
 "tijdgebaseerd token dat door de backend wordt gegenereerd."
 
-#: openforms/submissions/api/serializers.py:714
+#: openforms/submissions/api/serializers.py:717
 msgid "is co-signed?"
 msgstr "Is mede-ondertekend?"
 
-#: openforms/submissions/api/serializers.py:715
+#: openforms/submissions/api/serializers.py:718
 msgid "Indicator whether the submission has been co-signed or not."
 msgstr "Geeft aan of de inzending is mede-ondertekend."
 
-#: openforms/submissions/api/serializers.py:718
+#: openforms/submissions/api/serializers.py:721
 msgid "Co-signer display"
 msgstr "Mede-ondertekenaar weergave"
 
-#: openforms/submissions/api/serializers.py:719
+#: openforms/submissions/api/serializers.py:722
 msgid "Co-signer representation string for the UI."
 msgstr "Mede-ondertekenaar weergave in de UI."
 
-#: openforms/submissions/api/serializers.py:736
+#: openforms/submissions/api/serializers.py:739
 msgid "Display name of the component."
 msgstr "Weergavenaam van de component"
 
-#: openforms/submissions/api/serializers.py:740
+#: openforms/submissions/api/serializers.py:743
 msgid "Raw value of the component."
 msgstr "JSON-waarde van de component"
 
-#: openforms/submissions/api/serializers.py:744
+#: openforms/submissions/api/serializers.py:747
 msgid "Configuration of the component."
 msgstr "Componentconfiguratie"
 
-#: openforms/submissions/api/serializers.py:751
+#: openforms/submissions/api/serializers.py:754
 msgid "Slug of the form definition used in the form step."
 msgstr "Slug van de formulierdefinitie horend bij de stap."
 
-#: openforms/submissions/api/serializers.py:755
+#: openforms/submissions/api/serializers.py:758
 msgid "Name of the form definition used in the form step."
 msgstr "Naam van de formulierdefinitie horend bij de stap."
 
-#: openforms/submissions/api/serializers.py:764
-#: openforms/submissions/models/submission.py:261
+#: openforms/submissions/api/serializers.py:767
+#: openforms/submissions/models/submission.py:259
 msgid "privacy policy accepted"
 msgstr "Privacybeleid geaccepteerd"
 
-#: openforms/submissions/api/serializers.py:765
+#: openforms/submissions/api/serializers.py:768
 msgid "Whether the co-signer has accepted the privacy policy"
 msgstr ""
 "Indicator of de mede-ondertekenaar het privacybeleid geaccepteerd heeft."
 
-#: openforms/submissions/api/serializers.py:768
-#: openforms/submissions/models/submission.py:271
+#: openforms/submissions/api/serializers.py:771
+#: openforms/submissions/models/submission.py:269
 msgid "statement of truth accepted"
 msgstr "verklaring van waarheid geaccepteerd"
 
-#: openforms/submissions/api/serializers.py:770
+#: openforms/submissions/api/serializers.py:773
 msgid ""
 "Whether the co-signer has declared the form to be filled out truthfully."
 msgstr ""
 "Indicator of de mede-ondertekenaar het formulier naar waarheid ingevuld "
 "heeft."
 
-#: openforms/submissions/api/serializers.py:785
+#: openforms/submissions/api/serializers.py:788
 msgid "download report url"
 msgstr "Download-URL PDF"
 
-#: openforms/submissions/api/serializers.py:787
+#: openforms/submissions/api/serializers.py:790
 msgid ""
 "The URL where the submission report can be downloaded. Note that this "
 "contain a timestamped token generated by the backend."
@@ -12503,19 +13738,19 @@ msgstr ""
 "Download-URL voor het gegenereerde PDF document. Let op: deze URL bevat een "
 "tijdgebaseerd token dat door de backend wordt gegenereerd."
 
-#: openforms/submissions/api/serializers.py:847
+#: openforms/submissions/api/serializers.py:850
 #, python-brace-format
 msgid "The key '{key}' does not point to an email component in the form."
 msgstr ""
 "De sleutel '{key}' hoort niet bij een e-mailcomponent in het formulier."
 
-#: openforms/submissions/api/serializers.py:862
+#: openforms/submissions/api/serializers.py:865
 #: openforms/submissions/models/cosign.py:31
 #: openforms/submissions/models/email_verification.py:62
 msgid "verification code"
 msgstr "bevestigingscode"
 
-#: openforms/submissions/api/serializers.py:880
+#: openforms/submissions/api/serializers.py:883
 msgid "The verification code does not match."
 msgstr "De bevestigingscode komt niet overeen."
 
@@ -12552,13 +13787,15 @@ msgid ""
 "\n"
 "This is called by the default Form.io file upload widget. \n"
 "\n"
-"Access to this view requires an active form submission. Unclaimed temporary files automatically expire after {expire_days} day(s). "
+"Access to this view requires an active form submission. Unclaimed temporary "
+"files automatically expire after {expire_days} day(s). "
 msgstr ""
 "Haal tijdelijk bestand op.\n"
 "\n"
 "Deze aanroep wordt gedaan door het standaard Form.io bestandsupload widget.\n"
 "\n"
-"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en)"
+"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet "
+"gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en)"
 
 #: openforms/submissions/api/views.py:41
 msgid "Delete temporary file upload"
@@ -12571,40 +13808,48 @@ msgid ""
 "\n"
 "This is called by the default Form.io file upload widget. \n"
 "\n"
-"Access to this view requires an active form submission. Unclaimed temporary files automatically expire after {expire_days} day(s). "
+"Access to this view requires an active form submission. Unclaimed temporary "
+"files automatically expire after {expire_days} day(s). "
 msgstr ""
 "Verwijder tijdelijk bestand.\n"
 "\n"
 "Deze aanroep wordt gedaan door het standaard Form.io bestandsupload widget.\n"
 "\n"
-"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en)"
+"Toegang tot dit endpoint vereist een actieve formulier inzending. Niet "
+"gekoppelde bestanden worden automatisch verwijderd na {expire_days} dag(en)"
 
-#: openforms/submissions/api/views.py:83
+#: openforms/submissions/api/views.py:84
 msgid "Start email verification"
 msgstr "Start de e-mailverificatie"
 
-#: openforms/submissions/api/views.py:85
+#: openforms/submissions/api/views.py:86
 msgid ""
-"Create an email verification resource to start the verification process. A verification e-mail will be scheduled and sent to the provided email address, containing the verification code to use during verification.\n"
+"Create an email verification resource to start the verification process. A "
+"verification e-mail will be scheduled and sent to the provided email "
+"address, containing the verification code to use during verification.\n"
 "\n"
-"Validations check that the provided component key is present in the form of the submission and that it actually is an `email` component."
+"Validations check that the provided component key is present in the form of "
+"the submission and that it actually is an `email` component."
 msgstr ""
-"Maak een e-mailbevestigingverzoek aan om het verificatieproces te beginnen. Hierna wordt een verificatie-e-mail verstuurd naar het opgegeven e-mailadres die de bevestigingscode bevat die in het proces ingevoerd dient te worden.\n"
+"Maak een e-mailbevestigingverzoek aan om het verificatieproces te beginnen. "
+"Hierna wordt een verificatie-e-mail verstuurd naar het opgegeven e-mailadres "
+"die de bevestigingscode bevat die in het proces ingevoerd dient te worden.\n"
 "\n"
-"De validaties controleren dat de componentsleutel bestaat in het formulier, en dat de component daadwerkelijk een e-mailcomponent is."
+"De validaties controleren dat de componentsleutel bestaat in het formulier, "
+"en dat de component daadwerkelijk een e-mailcomponent is."
 
-#: openforms/submissions/api/views.py:108
+#: openforms/submissions/api/views.py:109
 msgid "Verify email address"
 msgstr "Verifieer een e-mailadres"
 
-#: openforms/submissions/api/views.py:110
+#: openforms/submissions/api/views.py:111
 msgid ""
 "Using the code obtained from the verification email, mark the email address "
-"as verified. Using an invalid code results in validation errors in the error"
-" response."
+"as verified. Using an invalid code results in validation errors in the error "
+"response."
 msgstr ""
-"Gebruik de bevestigingscode uit de verificatie-e-mail om het e-mailadres als"
-" \"geverifieerd\" te markeren. Als geen geldige code gebruikt wordt, dan "
+"Gebruik de bevestigingscode uit de verificatie-e-mail om het e-mailadres als "
+"\"geverifieerd\" te markeren. Als geen geldige code gebruikt wordt, dan "
 "bevat het antwoord validatiefouten."
 
 #: openforms/submissions/api/viewsets.py:97
@@ -12614,8 +13859,8 @@ msgstr "Actieve inzendingen weergeven"
 #: openforms/submissions/api/viewsets.py:99
 msgid ""
 "Active submissions are submissions whose ID is in the user session. This "
-"endpoint returns user-bound submissions. Note that you get different results"
-" on different results because of the differing sessions."
+"endpoint returns user-bound submissions. Note that you get different results "
+"on different results because of the differing sessions."
 msgstr ""
 "Actieve inzendingen zijn inzendingen waarvan het ID zich in de "
 "gebruikerssessie bevindt. Dit endpoint geeft alle inzendingen terug die "
@@ -12628,8 +13873,7 @@ msgstr "Inzending detail weergeven"
 
 #: openforms/submissions/api/viewsets.py:106
 msgid "Get the state of a single submission in the user session."
-msgstr ""
-"Haal de status op van een enkele inzending op van de gebruikerssessie."
+msgstr "Haal de status op van een enkele inzending op van de gebruikerssessie."
 
 #: openforms/submissions/api/viewsets.py:109
 msgid "Start a submission"
@@ -12727,7 +13971,7 @@ msgid "Apply/check the logic rules specified on the form step."
 msgstr ""
 "Pas de logische regels toe die zijn gespecificeerd in de formulierstap."
 
-#: openforms/submissions/attachments.py:190
+#: openforms/submissions/attachments.py:160
 #, python-brace-format
 msgid "Upload {uuid} exceeds the maximum upload size of {max_size}b"
 msgstr ""
@@ -12950,10 +14194,10 @@ msgstr ""
 "afgevuurd wordt."
 
 #: openforms/submissions/models/post_completion_metadata.py:30
-#: openforms/submissions/models/submission.py:148
-#: openforms/submissions/models/submission_files.py:73
-#: openforms/submissions/models/submission_files.py:198
-#: openforms/submissions/models/submission_step.py:102
+#: openforms/submissions/models/submission.py:146
+#: openforms/submissions/models/submission_files.py:71
+#: openforms/submissions/models/submission_files.py:269
+#: openforms/submissions/models/submission_step.py:110
 msgid "created on"
 msgstr "aangemaakt op"
 
@@ -12970,32 +14214,32 @@ msgstr "Soort trigger die de achtergrondtaken aangemaakt heeft."
 msgid "post completion metadata"
 msgstr "bij-voltooiingmetagegevens"
 
-#: openforms/submissions/models/submission.py:141
+#: openforms/submissions/models/submission.py:139
 msgid "form URL"
 msgstr "formulier URL"
 
-#: openforms/submissions/models/submission.py:145
+#: openforms/submissions/models/submission.py:143
 msgid "URL where the user initialized the submission."
 msgstr "URL waar de gebruiker de inzending is gestart."
 
-#: openforms/submissions/models/submission.py:149
-#: openforms/submissions/models/submission_step.py:105
+#: openforms/submissions/models/submission.py:147
+#: openforms/submissions/models/submission_step.py:113
 msgid "completed on"
 msgstr "afgerond op"
 
-#: openforms/submissions/models/submission.py:150
+#: openforms/submissions/models/submission.py:148
 msgid "suspended on"
 msgstr "onderbroken op"
 
-#: openforms/submissions/models/submission.py:153
+#: openforms/submissions/models/submission.py:151
 msgid "co-sign data"
 msgstr "Mede-ondertekenaargegevens"
 
-#: openforms/submissions/models/submission.py:157
+#: openforms/submissions/models/submission.py:155
 msgid "Authentication details of a co-signer."
 msgstr "Authenticatiedetails van een mede-ondertekenaar."
 
-#: openforms/submissions/models/submission.py:169
+#: openforms/submissions/models/submission.py:167
 msgid ""
 "Cost of this submission. Either derived from the related product, or set "
 "through logic rules. The price is calculated and saved on submission "
@@ -13005,11 +14249,11 @@ msgstr ""
 "of bepaald door logicaregels. De prijs wordt berekend en opgeslagen op de "
 "inzending zodra deze is afgerond."
 
-#: openforms/submissions/models/submission.py:177
+#: openforms/submissions/models/submission.py:175
 msgid "last register attempt date"
 msgstr "laatste poging tot doorzetting"
 
-#: openforms/submissions/models/submission.py:181
+#: openforms/submissions/models/submission.py:179
 msgid ""
 "The last time the submission registration was attempted with the backend.  "
 "Note that this date will be updated even if the registration is not "
@@ -13018,21 +14262,21 @@ msgstr ""
 "De laatste poging waarop de inzending is doorgezet naar de registratie "
 "backend. Deze datum wordt ook bijgewerkt als de doorzetting niet is gelukt."
 
-#: openforms/submissions/models/submission.py:186
+#: openforms/submissions/models/submission.py:184
 msgid "registration backend retry counter"
 msgstr "registratiepogingenteller"
 
-#: openforms/submissions/models/submission.py:189
+#: openforms/submissions/models/submission.py:187
 msgid "Counter to track how often we tried calling the registration backend. "
 msgstr ""
 "Teller die bijhoudt hoe vaak we de registratiebackend probeerden aan te "
 "roepen."
 
-#: openforms/submissions/models/submission.py:193
+#: openforms/submissions/models/submission.py:191
 msgid "registration backend result"
 msgstr "registratie backend resultaat"
 
-#: openforms/submissions/models/submission.py:197
+#: openforms/submissions/models/submission.py:195
 msgid ""
 "Contains data returned by the registration backend while registering the "
 "submission data."
@@ -13040,34 +14284,32 @@ msgstr ""
 "Bevat de gegevens zoals teruggegeven door de registratie backend bij het "
 "versturen van de inzending."
 
-#: openforms/submissions/models/submission.py:202
+#: openforms/submissions/models/submission.py:200
 msgid "registration backend status"
 msgstr "registratie backend status"
 
-#: openforms/submissions/models/submission.py:207
+#: openforms/submissions/models/submission.py:205
 msgid ""
-"Indication whether the registration in the configured backend was "
-"successful."
-msgstr ""
-"Indicatie of de doorzetting naar de registratie backend succesvol was."
+"Indication whether the registration in the configured backend was successful."
+msgstr "Indicatie of de doorzetting naar de registratie backend succesvol was."
 
-#: openforms/submissions/models/submission.py:211
+#: openforms/submissions/models/submission.py:209
 msgid "pre-registration completed"
 msgstr "preregistratie voltooid"
 
-#: openforms/submissions/models/submission.py:214
+#: openforms/submissions/models/submission.py:212
 msgid "Indicates whether the pre-registration task completed successfully."
 msgstr "Indicatie of de preregistratietaak succesvol voltooid is."
 
-#: openforms/submissions/models/submission.py:218
+#: openforms/submissions/models/submission.py:216
 msgid "public registration reference"
 msgstr "publieke referentie"
 
-#: openforms/submissions/models/submission.py:222
+#: openforms/submissions/models/submission.py:220
 msgid ""
-"The registration reference communicated to the end-user completing the form."
-" This reference is intended to be unique and the reference the end-user uses"
-" to communicate with the service desk. It should be extracted from the "
+"The registration reference communicated to the end-user completing the form. "
+"This reference is intended to be unique and the reference the end-user uses "
+"to communicate with the service desk. It should be extracted from the "
 "registration result where possible, and otherwise generated to be unique. "
 "Note that this reference is displayed to the end-user and used as payment "
 "reference!"
@@ -13080,27 +14322,27 @@ msgstr ""
 "deze referentie wordt getoond aan de eindgebruiker en gebruikt als "
 "betalingskenmerk!"
 
-#: openforms/submissions/models/submission.py:231
+#: openforms/submissions/models/submission.py:229
 msgid "cosign complete"
 msgstr "mede-ondertekenen voltooid"
 
-#: openforms/submissions/models/submission.py:233
+#: openforms/submissions/models/submission.py:231
 msgid "Indicates whether the submission has been cosigned."
 msgstr "Geeft aan of de inzending is mede-ondertekend."
 
-#: openforms/submissions/models/submission.py:236
+#: openforms/submissions/models/submission.py:234
 msgid "cosign request email sent"
 msgstr "Mede-ondertekenenverzoek-e-mail verstuurd"
 
-#: openforms/submissions/models/submission.py:238
+#: openforms/submissions/models/submission.py:236
 msgid "Has the email to request a co-sign been sent?"
 msgstr "Is de e-mail met het mede-ondertekenenverzoek verstuurd?"
 
-#: openforms/submissions/models/submission.py:241
+#: openforms/submissions/models/submission.py:239
 msgid "cosign confirmation email sent"
 msgstr "Mede-ondertekenenbevestigings-e-mail verstuurd"
 
-#: openforms/submissions/models/submission.py:244
+#: openforms/submissions/models/submission.py:242
 msgid ""
 "Has the confirmation email been sent after the submission has successfully "
 "been cosigned?"
@@ -13108,67 +14350,67 @@ msgstr ""
 "Geeft aan of de bevestigings-e-mail na het succesvol mede-ondertekenen "
 "verstuurd is."
 
-#: openforms/submissions/models/submission.py:249
+#: openforms/submissions/models/submission.py:247
 msgid "confirmation email sent"
 msgstr "Bevestigingse-mail verstuurd"
 
-#: openforms/submissions/models/submission.py:251
+#: openforms/submissions/models/submission.py:249
 msgid "Indicates whether the confirmation email has been sent."
 msgstr "Geeft aan of de bevestigingse-mail al verstuurd is."
 
-#: openforms/submissions/models/submission.py:255
+#: openforms/submissions/models/submission.py:253
 msgid "payment complete confirmation email sent"
 msgstr "Betaling-voltooidbevestigings-e-mail verstuurd"
 
-#: openforms/submissions/models/submission.py:257
+#: openforms/submissions/models/submission.py:255
 msgid "Has the confirmation emails been sent after successful payment?"
 msgstr ""
 "Geeft aan of de bevestigingse-mails na succesvollte betaling al verstuurd "
 "zijn."
 
-#: openforms/submissions/models/submission.py:263
+#: openforms/submissions/models/submission.py:261
 msgid "Has the user accepted the privacy policy?"
 msgstr "Indicator of de gebruiker het privacybeleid geaccepteerd heeft."
 
-#: openforms/submissions/models/submission.py:266
+#: openforms/submissions/models/submission.py:264
 msgid "cosign privacy policy accepted"
 msgstr "Mede-ondertekenenprivacybeleid geaccepteerd"
 
-#: openforms/submissions/models/submission.py:268
+#: openforms/submissions/models/submission.py:266
 msgid "Has the co-signer accepted the privacy policy?"
 msgstr ""
 "Indicator of de mede-ondertekenaar het privacybeleid geaccepteerd heeft."
 
-#: openforms/submissions/models/submission.py:273
+#: openforms/submissions/models/submission.py:271
 msgid "Did the user declare the form to be filled out truthfully?"
 msgstr ""
 "Heeft de gebruiker verklaard dat het formulier naar waarheid ingevuld is?"
 
-#: openforms/submissions/models/submission.py:276
+#: openforms/submissions/models/submission.py:274
 msgid "cosign statement of truth accepted"
 msgstr "mede-ondertekenen verklaring van waarheid geaccepteerd"
 
-#: openforms/submissions/models/submission.py:278
+#: openforms/submissions/models/submission.py:276
 msgid "Did the co-signer declare the form to be filled out truthfully?"
 msgstr ""
 "Heeft de mede-ondertekenaar verklaard dat het formulier naar waarheid "
 "ingevuld is?"
 
-#: openforms/submissions/models/submission.py:282
+#: openforms/submissions/models/submission.py:280
 msgid "is cleaned"
 msgstr "is opgeschoond"
 
-#: openforms/submissions/models/submission.py:285
+#: openforms/submissions/models/submission.py:283
 msgid ""
 "Indicates whether sensitive data (if there was any) has been removed from "
 "this submission."
 msgstr "Geeft aan of gevoelige gegevens verwijders zijn van deze inzending."
 
-#: openforms/submissions/models/submission.py:289
+#: openforms/submissions/models/submission.py:287
 msgid "initial data reference"
 msgstr "startdata-referentie"
 
-#: openforms/submissions/models/submission.py:292
+#: openforms/submissions/models/submission.py:290
 msgid ""
 "An identifier that can be passed as a querystring when the form is started. "
 "Initial form field values are pre-populated from the retrieved data. During "
@@ -13177,32 +14419,32 @@ msgid ""
 msgstr ""
 "Een identificatie die als query-parameter opgegeven kan worden bij het "
 "starten van een formulier. Op basis van deze identificatie worden bestaande "
-"gegevens opgehaald en gebruikt om formuliervelden voor in te vullen. Bij het"
-" registreren kunnen de bestaande gegevens ook weer bijgewerkt worden, indien"
-" gewenst, of de gegevens worden als 'nieuw' geregistreerd. Dit kan "
+"gegevens opgehaald en gebruikt om formuliervelden voor in te vullen. Bij het "
+"registreren kunnen de bestaande gegevens ook weer bijgewerkt worden, indien "
+"gewenst, of de gegevens worden als 'nieuw' geregistreerd. Dit kan "
 "bijvoorbeeld een referentie zijn naar een record in de Objecten API."
 
-#: openforms/submissions/models/submission.py:302
+#: openforms/submissions/models/submission.py:300
 msgid "on completion task ID"
 msgstr "bij voltooiing taak-ID"
 
-#: openforms/submissions/models/submission.py:307
+#: openforms/submissions/models/submission.py:305
 msgid "on completion task IDs"
 msgstr "bij voltooiing taak-ID's"
 
-#: openforms/submissions/models/submission.py:310
+#: openforms/submissions/models/submission.py:308
 msgid ""
-"Celery task IDs of the on_completion workflow. Use this to inspect the state"
-" of the async jobs."
+"Celery task IDs of the on_completion workflow. Use this to inspect the state "
+"of the async jobs."
 msgstr ""
-"Celery-taak-ID's van de on_completion-workflow. Gebruik dit om de status van"
-" de asynchrone taken te inspecteren. "
+"Celery-taak-ID's van de on_completion-workflow. Gebruik dit om de status van "
+"de asynchrone taken te inspecteren. "
 
-#: openforms/submissions/models/submission.py:316
+#: openforms/submissions/models/submission.py:314
 msgid "needs on_completion retry"
 msgstr "verwerking opnieuw proberen"
 
-#: openforms/submissions/models/submission.py:319
+#: openforms/submissions/models/submission.py:317
 msgid ""
 "Flag to track if the on_completion_retry chain should be invoked. This is "
 "scheduled via celery-beat."
@@ -13210,151 +14452,154 @@ msgstr ""
 "Vlag die aangeeft of een nieuwe verwerkingspoging nodig is. Dit wordt "
 "automatisch uitgevoerd op de achtergrond."
 
-#: openforms/submissions/models/submission.py:325
+#: openforms/submissions/models/submission.py:323
 msgid "language code"
 msgstr "taalcode"
 
-#: openforms/submissions/models/submission.py:330
+#: openforms/submissions/models/submission.py:328
 msgid "The code (RFC5646 format) of the language used to fill in the Form."
 msgstr ""
 "De code (RFC5646-formaat) van de taal die gebruikt is tijdens het invullen "
 "van het formulier."
 
-#: openforms/submissions/models/submission.py:335
+#: openforms/submissions/models/submission.py:333
 msgid "final registration backend key"
 msgstr "uiteindelijke registratiebackendsleutel"
 
-#: openforms/submissions/models/submission.py:339
+#: openforms/submissions/models/submission.py:337
 msgid "The key of the registration backend to use."
 msgstr "De sleutel van de backend die voor registratie gebruikt moet worden."
 
-#: openforms/submissions/models/submission.py:360
+#: openforms/submissions/models/submission.py:358
 msgid "submissions"
 msgstr "inzendingen"
 
-#: openforms/submissions/models/submission.py:384
+#: openforms/submissions/models/submission.py:382
 msgid ""
 "Only completed submissions may persist a finalised registration backend key."
 msgstr ""
 "Enkel voltooide inzendingen kunnen een registratiebackendsleutel vastleggen."
 
-#: openforms/submissions/models/submission.py:391
+#: openforms/submissions/models/submission.py:389
 #, python-brace-format
 msgid "{pk} - started on {started}"
 msgstr "{pk} - gestart op {started}"
 
-#: openforms/submissions/models/submission.py:392
+#: openforms/submissions/models/submission.py:390
 msgid "(unsaved)"
 msgstr "(niet bewaard)"
 
-#: openforms/submissions/models/submission.py:393
+#: openforms/submissions/models/submission.py:391
 msgid "(no timestamp yet)"
 msgstr "(nog geen datum)"
 
-#: openforms/submissions/models/submission.py:877
+#: openforms/submissions/models/submission.py:870
 msgid "No registration backends defined on form."
 msgstr "Er zijn geen registratiebackends geconfigureerd op het formulier."
 
-#: openforms/submissions/models/submission.py:885
+#: openforms/submissions/models/submission.py:878
 msgid "Multiple backends defined on form."
 msgstr "Meerdere backends geconfigureerd op het formulier."
 
-#: openforms/submissions/models/submission.py:903
+#: openforms/submissions/models/submission.py:896
 msgid "Unknown registration backend set by form logic. Trying default..."
 msgstr ""
 "Onbekende registratiebackend ingesteld via formulierlogica. We proberen de "
 "standaardbackend..."
 
-#: openforms/submissions/models/submission_files.py:58
+#: openforms/submissions/models/submission_files.py:56
 msgid "Submission the temporary file upload belongs to."
 msgstr "De inzending waarin dit bestand toegevoegd is."
 
-#: openforms/submissions/models/submission_files.py:63
+#: openforms/submissions/models/submission_files.py:61
 msgid "content of the file attachment."
 msgstr "inhoud van de bijlage."
 
-#: openforms/submissions/models/submission_files.py:65
-#: openforms/submissions/models/submission_files.py:195
+#: openforms/submissions/models/submission_files.py:63
+#: openforms/submissions/models/submission_files.py:266
 msgid "original name"
 msgstr "originele naam"
 
-#: openforms/submissions/models/submission_files.py:69
+#: openforms/submissions/models/submission_files.py:67
 msgid "file size"
 msgstr "Bestandsgrootte"
 
-#: openforms/submissions/models/submission_files.py:71
+#: openforms/submissions/models/submission_files.py:69
 msgid "Size in bytes of the uploaded file."
 msgstr "Bestandsgrootte in bytes."
 
-#: openforms/submissions/models/submission_files.py:78
+#: openforms/submissions/models/submission_files.py:76
 msgid "temporary file upload"
 msgstr "tijdelijke bestanden"
 
-#: openforms/submissions/models/submission_files.py:79
+#: openforms/submissions/models/submission_files.py:77
 msgid "temporary file uploads"
 msgstr "tijdelijk bestand"
 
-#: openforms/submissions/models/submission_files.py:149
+#: openforms/submissions/models/submission_files.py:205
 msgid "Submission step the file is attached to."
 msgstr "Inzendingsstap waar het bestand bij hoort."
 
-#: openforms/submissions/models/submission_files.py:157
+#: openforms/submissions/models/submission_files.py:212
 msgid "temporary file"
 msgstr "tijdelijk bestand"
 
-#: openforms/submissions/models/submission_files.py:158
+#: openforms/submissions/models/submission_files.py:213
 msgid "Temporary upload this file is sourced to."
 msgstr "Tijdelijk bestand waar deze bijlage bij hoort."
 
-#: openforms/submissions/models/submission_files.py:162
+#: openforms/submissions/models/submission_files.py:217
 msgid "submission variable"
 msgstr "inzendingsvariabele"
 
-#: openforms/submissions/models/submission_files.py:163
+#: openforms/submissions/models/submission_files.py:218
 msgid "submission value variable for the form component"
 msgstr "variabele-waarde voor het formuliercomponent"
 
-#: openforms/submissions/models/submission_files.py:171
+#: openforms/submissions/models/submission_files.py:226
 msgid "component configuration path"
 msgstr "Componentconfiguratiepad"
 
-#: openforms/submissions/models/submission_files.py:173
+#: openforms/submissions/models/submission_files.py:228
 msgid ""
 "Path to the component in the configuration corresponding to this attachment."
 msgstr ""
 "Pad naar de component in de formulierconfiguratie horend bij deze bijlage."
 
-#: openforms/submissions/models/submission_files.py:180
+#: openforms/submissions/models/submission_files.py:244
 msgid "component data path"
 msgstr "Componentgegevenspad"
 
-#: openforms/submissions/models/submission_files.py:181
+#: openforms/submissions/models/submission_files.py:245
 msgid "Path to the attachment in the submission data."
 msgstr "Pad naar de bijlage in de inzendinsgegevens."
 
-#: openforms/submissions/models/submission_files.py:189
+#: openforms/submissions/models/submission_files.py:250
+msgid ""
+"Key of the file component for which the upload was made. Most of the time "
+"this will be identical to the submission_variable.key, except when the file "
+"component is inside an edit grid - the variable then points to the edit grid."
+msgstr ""
+
+#: openforms/submissions/models/submission_files.py:260
 msgid "Content of the submission file attachment."
 msgstr "Inhoud van de inzendingsbijlage"
 
-#: openforms/submissions/models/submission_files.py:192
+#: openforms/submissions/models/submission_files.py:263
 msgid "file name"
 msgstr "bestandsnaam"
 
-#: openforms/submissions/models/submission_files.py:192
+#: openforms/submissions/models/submission_files.py:263
 msgid "reformatted file name"
 msgstr "veilige bestandsnaam"
 
-#: openforms/submissions/models/submission_files.py:195
+#: openforms/submissions/models/submission_files.py:266
 msgid "original uploaded file name"
 msgstr "originele bestandsnaam"
 
-#: openforms/submissions/models/submission_files.py:208
+#: openforms/submissions/models/submission_files.py:279
 msgid "submission file attachments"
 msgstr "inzendingsbijlagen"
-
-#: openforms/submissions/models/submission_files.py:254
-msgid "form component key"
-msgstr "formulier veld sleutel"
 
 #: openforms/submissions/models/submission_report.py:16
 msgid "title"
@@ -13378,8 +14623,8 @@ msgstr "laatst gedownload"
 
 #: openforms/submissions/models/submission_report.py:39
 msgid ""
-"When the submission report was last accessed. This value is updated when the"
-" report is downloaded."
+"When the submission report was last accessed. This value is updated when the "
+"report is downloaded."
 msgstr ""
 "Datum waarom het document voor het laatst is opgevraagd. Deze waarde wordt "
 "bijgewerkt zodra het document wordt gedownload."
@@ -13404,11 +14649,11 @@ msgstr "document"
 msgid "submission reports"
 msgstr "documenten"
 
-#: openforms/submissions/models/submission_step.py:103
+#: openforms/submissions/models/submission_step.py:111
 msgid "modified on"
 msgstr "gewijzigd op"
 
-#: openforms/submissions/models/submission_step.py:109
+#: openforms/submissions/models/submission_step.py:117
 msgid ""
 "Marks when the step was last submitted. When a submission is being paused, "
 "the field will be empty to signal it wasn't completed yet."
@@ -13417,11 +14662,11 @@ msgstr ""
 "wanneer een inzending is gepauzeerd, als indicatie dat de stap nog niet is "
 "afgerond."
 
-#: openforms/submissions/models/submission_step.py:116
+#: openforms/submissions/models/submission_step.py:124
 msgid "form step (historical)"
 msgstr "formulierstap (historisch)"
 
-#: openforms/submissions/models/submission_step.py:132
+#: openforms/submissions/models/submission_step.py:142
 msgid "Submission step"
 msgstr "Inzendingsstap"
 
@@ -13464,46 +14709,45 @@ msgstr "gevuld vanuit prefill-gegevens"
 #: openforms/submissions/models/submission_value_variable.py:484
 msgid "Can this variable be prefilled at the beginning of a submission?"
 msgstr ""
-"Is de waarde bij het starten van de inzending door een prefill-plugin "
-"gevuld?"
+"Is de waarde bij het starten van de inzending door een prefill-plugin gevuld?"
 
-#: openforms/submissions/models/submission_value_variable.py:490
+#: openforms/submissions/models/submission_value_variable.py:492
 msgid "Form.io component configuration"
 msgstr "Form.io component configuratie"
 
-#: openforms/submissions/models/submission_value_variable.py:491
+#: openforms/submissions/models/submission_value_variable.py:493
 msgid "The component configuration as Form.io JSON schema"
 msgstr "De formulierdefinitie als Form.io JSON schema"
 
-#: openforms/submissions/models/submission_value_variable.py:512
+#: openforms/submissions/models/submission_value_variable.py:514
 msgid "pre-registration status"
 msgstr "pre-registratiestatus"
 
-#: openforms/submissions/models/submission_value_variable.py:514
+#: openforms/submissions/models/submission_value_variable.py:516
 msgid ""
 "Indication whether the pre-registration hook in the component plugin was "
 "successful."
 msgstr "Indicatie of de pre-registratiestap van de component succesvol was."
 
-#: openforms/submissions/models/submission_value_variable.py:521
+#: openforms/submissions/models/submission_value_variable.py:523
 msgid "pre-registration result"
 msgstr "pre-registratieresultaat"
 
-#: openforms/submissions/models/submission_value_variable.py:525
+#: openforms/submissions/models/submission_value_variable.py:527
 msgid "Contains data returned by the pre-registration hook of the component."
 msgstr ""
 "Bevat de gegevens zoals teruggegeven door de pre-registratie van de "
 "component."
 
-#: openforms/submissions/models/submission_value_variable.py:535
+#: openforms/submissions/models/submission_value_variable.py:537
 msgid "Submission value variable"
 msgstr "Inzendingswaarde"
 
-#: openforms/submissions/models/submission_value_variable.py:536
+#: openforms/submissions/models/submission_value_variable.py:538
 msgid "Submission values variables"
 msgstr "Inzendingswaarden"
 
-#: openforms/submissions/models/submission_value_variable.py:553
+#: openforms/submissions/models/submission_value_variable.py:555
 #, python-brace-format
 msgid "Submission value variable {key}"
 msgstr "Inzendingswaarde {key}"
@@ -13535,8 +14779,8 @@ msgid ""
 "This PDF was generated before submission processing has started because it "
 "needs to be cosigned first. The cosign request email was sent to {email}."
 msgstr ""
-"Deze samenvatting is gemaakt vóór de inzending in behandeling genomen wordt."
-" De inzending wordt pas verwerkt als deze mede-ondertekend is. Het verzoek "
+"Deze samenvatting is gemaakt vóór de inzending in behandeling genomen wordt. "
+"De inzending wordt pas verwerkt als deze mede-ondertekend is. Het verzoek "
 "hiervoor is verstuurd naar {email}."
 
 #: openforms/submissions/tasks/emails.py:142
@@ -13549,8 +14793,10 @@ msgstr "Mede-ondertekenverzoek voor {form_name}"
 msgid "%(title)s: Submission report (%(reference)s)"
 msgstr "%(title)s: Document (%(reference)s)"
 
-#: openforms/submissions/templates/admin/submissions/submission/change_form.html:8
-msgid "Attachments:"
+#: openforms/submissions/templates/admin/submissions/submission/change_form.html:6
+#, fuzzy
+#| msgid "Attachments:"
+msgid "Attachments"
 msgstr "Bijlage:"
 
 #: openforms/submissions/templates/report/submission_report.html:11
@@ -13648,8 +14894,8 @@ msgstr "Sorry, u hebt geen toegang tot deze pagina (403)"
 
 #: openforms/templates/403.html:15
 msgid ""
-"You don't appear to have sufficient permissions to view this content. Please"
-" contact an administrator if you believe this to be an error."
+"You don't appear to have sufficient permissions to view this content. Please "
+"contact an administrator if you believe this to be an error."
 msgstr ""
 "U lijkt onvoldoende rechten te hebben om deze inhoud te bekijken. Gelieve "
 "contact op te nemen met uw beheerder indien dit onterecht is."
@@ -13813,8 +15059,8 @@ msgstr "RFC5646 taalcode, bijvoorbeeld `en` of `en-us`"
 
 #: openforms/translations/api/serializers.py:25
 msgid ""
-"Language name in its local representation. e.g. \"fy\" = \"frysk\", \"nl\" ="
-" \"Nederlands\""
+"Language name in its local representation. e.g. \"fy\" = \"frysk\", \"nl\" = "
+"\"Nederlands\""
 msgstr ""
 "Taalnaam in de lokale weergave. Bijvoorbeeld \"fy\" = \"frysk\", \"nl\" = "
 "\"Nederlands\""
@@ -13848,8 +15094,8 @@ msgid ""
 "custom translations exist, an empty object `{}` is returned."
 msgstr ""
 "Haal de nieuwe aangepaste (gecompileerde) vertalingen op nadat de "
-"wijzigingen zijn toegepast. Dit gebeurt op basis van de taalcode in het pad."
-" Als er geen aangepaste vertalingen bestaan, wordt een leeg object `{}` "
+"wijzigingen zijn toegepast. Dit gebeurt op basis van de taalcode in het pad. "
+"Als er geen aangepaste vertalingen bestaan, wordt een leeg object `{}` "
 "geretourneerd."
 
 #: openforms/translations/api/views.py:108
@@ -13894,8 +15140,8 @@ msgid ""
 "JSON file containing user's custom translations after it has been "
 "successfully compiled."
 msgstr ""
-"JSON-bestand met aangepaste vertalingen van de gebruiker nadat het succesvol"
-" is gecompileerd."
+"JSON-bestand met aangepaste vertalingen van de gebruiker nadat het succesvol "
+"is gecompileerd."
 
 #: openforms/translations/models.py:48
 msgid "The status of the uploaded custom translations JSON file."
@@ -13927,8 +15173,8 @@ msgstr "aantal aangepaste berichten"
 
 #: openforms/translations/models.py:73
 msgid ""
-"How many custom messages are included, this is set once processing completes"
-" successfully."
+"How many custom messages are included, this is set once processing completes "
+"successfully."
 msgstr ""
 "Geeft aan hoeveel aangepaste berichten zijn opgenomen. Dit wordt ingesteld "
 "zodra de verwerking succesvol is voltooid."
@@ -14185,6 +15431,11 @@ msgstr "{years}j, {months}m, {days}d, {hours}u, {minutes}min"
 msgid "{years}y, {months}m, {days}d, {hours}h, {minutes}min, {seconds}s"
 msgstr "{years}j, {months}m, {days}d, {hours}u, {minutes}min, {seconds}s"
 
+#: openforms/utils/json_logic/descriptions.py:366
+#, python-brace-format
+msgid "a substring of {text}"
+msgstr ""
+
 #: openforms/utils/validators.py:14
 msgid "Expected a numerical value."
 msgstr "Waarde moet numeriek zijn."
@@ -14295,11 +15546,11 @@ msgstr "Waarde om te valideren."
 
 #: openforms/validations/api/views.py:84
 msgid ""
-"ID of the validation plugin, see the "
-"[`validation_plugin_list`](./#operation/validation_plugin_list) operation"
+"ID of the validation plugin, see the [`validation_plugin_list`](./#operation/"
+"validation_plugin_list) operation"
 msgstr ""
-"ID van de validatie plugin. Zie de "
-"[`validation_plugin_list`](./#operation/validation_plugin_list) operatie"
+"ID van de validatie plugin. Zie de [`validation_plugin_list`](./#operation/"
+"validation_plugin_list) operatie"
 
 #: openforms/validations/registry.py:78
 #, python-brace-format
@@ -14399,7 +15650,8 @@ msgstr "Geef een lijst van beschikbare servicebevragingconfiguraties"
 
 #: openforms/variables/api/viewsets.py:19
 msgid ""
-"Return a list of available services fetch configurations configured in the backend.\n"
+"Return a list of available services fetch configurations configured in the "
+"backend.\n"
 "\n"
 "Note that this endpoint is **EXPERIMENTAL**."
 msgstr ""
@@ -14562,8 +15814,7 @@ msgstr "{header!s}: waarde '{value!s}' moet een string zijn maar is dat niet."
 
 #: openforms/variables/validators.py:84
 msgid ""
-"{header!s}: value '{value!s}' contains {illegal_chars}, which is not "
-"allowed."
+"{header!s}: value '{value!s}' contains {illegal_chars}, which is not allowed."
 msgstr ""
 "{header!s}: waarde '{value!s}' bevat {illegal_chars}, deze karakters zijn "
 "niet toegestaan."
@@ -14576,15 +15827,13 @@ msgstr ""
 "{header!s}: waarde '{value!s}' mag niet starten of eindigen met whitespace."
 
 #: openforms/variables/validators.py:101
-msgid ""
-"{header!s}: value '{value!s}' contains characters that are not allowed."
+msgid "{header!s}: value '{value!s}' contains characters that are not allowed."
 msgstr ""
 "{header!s}: waarde '{value!s}' bevat karakters die niet toegestaan zijn."
 
 #: openforms/variables/validators.py:108
 msgid "{header!s}: header '{header!s}' should be a string, but isn't."
-msgstr ""
-"{header!s}: header '{header!s}' moet een string zijn maar is dat niet."
+msgstr "{header!s}: header '{header!s}' moet een string zijn maar is dat niet."
 
 #: openforms/variables/validators.py:114
 msgid ""
@@ -14614,8 +15863,8 @@ msgstr ""
 msgid ""
 "{parameter!s}: value '{value!s}' should be a list of strings, but isn't."
 msgstr ""
-"{parameter!s}: de waarde '{value!s}' moet een lijst van strings zijn maar is"
-" dat niet."
+"{parameter!s}: de waarde '{value!s}' moet een lijst van strings zijn maar is "
+"dat niet."
 
 #: openforms/variables/validators.py:165
 msgid "query parameter key '{parameter!s}' should be a string, but isn't."
@@ -14814,11 +16063,11 @@ msgstr "endpoint VrijeBerichten"
 
 #: stuf/models.py:84
 msgid ""
-"Endpoint for synchronous free messages, usually "
-"'[...]/VerwerkSynchroonVrijBericht' or '[...]/VrijeBerichten'."
+"Endpoint for synchronous free messages, usually '[...]/"
+"VerwerkSynchroonVrijBericht' or '[...]/VrijeBerichten'."
 msgstr ""
-"Endpoint voor synchrone vrije berichten, typisch "
-"'[...]/VerwerkSynchroonVrijBericht' of '[...]/VrijeBerichten'."
+"Endpoint voor synchrone vrije berichten, typisch '[...]/"
+"VerwerkSynchroonVrijBericht' of '[...]/VrijeBerichten'."
 
 #: stuf/models.py:88
 msgid "endpoint OntvangAsynchroon"
@@ -14973,11 +16222,11 @@ msgstr ""
 
 #: stuf/stuf_zds/models.py:60
 msgid ""
-"The 'zaakbetrokkene.omschrijving' value for the person who cosigned the form"
-" submission."
+"The 'zaakbetrokkene.omschrijving' value for the person who cosigned the form "
+"submission."
 msgstr ""
-"De waarde van 'zaakbetrokkene.omschrijving' voor de persoon die de inzending"
-" heeft mede-ondertekend."
+"De waarde van 'zaakbetrokkene.omschrijving' voor de persoon die de inzending "
+"heeft mede-ondertekend."
 
 #: stuf/stuf_zds/models.py:68
 msgid "StUF-ZDS configuration"
@@ -14989,11 +16238,11 @@ msgstr "Binding address Bijstandsregelingen"
 
 #: suwinet/models.py:33
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/Bijstandsregelingen/v0500}BijstandsregelingenBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/Bijstandsregelingen/"
+"v0500}BijstandsregelingenBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/Bijstandsregelingen/v0500}BijstandsregelingenBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/Bijstandsregelingen/"
+"v0500}BijstandsregelingenBinding"
 
 #: suwinet/models.py:39
 msgid "BRPDossierPersoonGSD Binding Address"
@@ -15001,11 +16250,11 @@ msgstr "Binding address BRPDossierPersoonGSD"
 
 #: suwinet/models.py:41
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/BRPDossierPersoonGSD/v0200}BRPBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/BRPDossierPersoonGSD/"
+"v0200}BRPBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/BRPDossierPersoonGSD/v0200}BRPBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/BRPDossierPersoonGSD/"
+"v0200}BRPBinding"
 
 #: suwinet/models.py:46
 msgid "DUODossierPersoonGSD Binding Address"
@@ -15013,11 +16262,11 @@ msgstr "Binding address DUODossierPersoonGSD"
 
 #: suwinet/models.py:48
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/DUODossierPersoonGSD/v0300}DUOBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/DUODossierPersoonGSD/"
+"v0300}DUOBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/DUODossierPersoonGSD/v0300}DUOBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/DUODossierPersoonGSD/"
+"v0300}DUOBinding"
 
 #: suwinet/models.py:53
 msgid "DUODossierStudiefinancieringGSD Binding Address"
@@ -15025,11 +16274,11 @@ msgstr "Binding address DUODossierStudiefinancieringGSD"
 
 #: suwinet/models.py:55
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/DUODossierStudiefinancieringGSD/v0200}DUOBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/"
+"DUODossierStudiefinancieringGSD/v0200}DUOBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/DUODossierStudiefinancieringGSD/v0200}DUOBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/"
+"DUODossierStudiefinancieringGSD/v0200}DUOBinding"
 
 #: suwinet/models.py:60
 msgid "GSDDossierReintegratie Binding Address"
@@ -15037,11 +16286,11 @@ msgstr "Binding address GSDDossierReintegratie"
 
 #: suwinet/models.py:62
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/GSDDossierReintegratie/v0200}GSDReintegratieBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/GSDDossierReintegratie/"
+"v0200}GSDReintegratieBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/GSDDossierReintegratie/v0200}GSDReintegratieBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/GSDDossierReintegratie/"
+"v0200}GSDReintegratieBinding"
 
 #: suwinet/models.py:67
 msgid "IBVerwijsindex Binding Address"
@@ -15049,11 +16298,11 @@ msgstr "Binding address IBVerwijsindex"
 
 #: suwinet/models.py:69
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/IBVerwijsindex/v0300}IBVerwijsindexBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/IBVerwijsindex/v0300}"
+"IBVerwijsindexBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/IBVerwijsindex/v0300}IBVerwijsindexBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/IBVerwijsindex/v0300}"
+"IBVerwijsindexBinding"
 
 #: suwinet/models.py:74
 msgid "KadasterDossierGSD Binding Address"
@@ -15061,11 +16310,11 @@ msgstr "Binding address KadasterDossierGSD"
 
 #: suwinet/models.py:76
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/KadasterDossierGSD/v0300}KadasterBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/KadasterDossierGSD/v0300}"
+"KadasterBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/KadasterDossierGSD/v0300}KadasterBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/KadasterDossierGSD/"
+"v0300}KadasterBinding"
 
 #: suwinet/models.py:81
 msgid "RDWDossierDigitaleDiensten Binding Address"
@@ -15073,11 +16322,11 @@ msgstr "Binding address RDWDossierDigitaleDiensten"
 
 #: suwinet/models.py:83
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/RDWDossierDigitaleDiensten/v0200}RDWBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/"
+"RDWDossierDigitaleDiensten/v0200}RDWBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/RDWDossierDigitaleDiensten/v0200}RDWBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/"
+"RDWDossierDigitaleDiensten/v0200}RDWBinding"
 
 #: suwinet/models.py:88
 msgid "RDWDossierGSD Binding Address"
@@ -15085,11 +16334,11 @@ msgstr "Binding address RDWDossierGSD"
 
 #: suwinet/models.py:90
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/RDWDossierGSD/v0200}RDWBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/RDWDossierGSD/v0200}"
+"RDWBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/RDWDossierGSD/v0200}RDWBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/RDWDossierGSD/v0200}"
+"RDWBinding"
 
 #: suwinet/models.py:95
 msgid "SVBDossierPersoonGSD Binding Address"
@@ -15097,11 +16346,11 @@ msgstr "Binding address SVBDossierPersoonGSD"
 
 #: suwinet/models.py:97
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/SVBDossierPersoonGSD/v0200}SVBBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/SVBDossierPersoonGSD/"
+"v0200}SVBBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/SVBDossierPersoonGSD/v0200}SVBBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/SVBDossierPersoonGSD/"
+"v0200}SVBBinding"
 
 #: suwinet/models.py:102
 msgid "UWVDossierAanvraagUitkeringStatusGSD Binding Address"
@@ -15109,11 +16358,11 @@ msgstr "Binding address UWVDossierAanvraagUitkeringStatusGSD"
 
 #: suwinet/models.py:104
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/UWVDossierAanvraagUitkeringStatusGSD/v0200}UWVAanvraagUitkeringStatusBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/"
+"UWVDossierAanvraagUitkeringStatusGSD/v0200}UWVAanvraagUitkeringStatusBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/UWVDossierAanvraagUitkeringStatusGSD/v0200}UWVAanvraagUitkeringStatusBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/"
+"UWVDossierAanvraagUitkeringStatusGSD/v0200}UWVAanvraagUitkeringStatusBinding"
 
 #: suwinet/models.py:109
 msgid "UWVDossierInkomstenGSDDigitaleDiensten Binding Address"
@@ -15121,11 +16370,11 @@ msgstr "Binding address UWVDossierInkomstenGSDDigitaleDiensten"
 
 #: suwinet/models.py:111
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/UWVDossierInkomstenGSDDigitaleDiensten/v0200}UWVIkvBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/"
+"UWVDossierInkomstenGSDDigitaleDiensten/v0200}UWVIkvBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/UWVDossierInkomstenGSDDigitaleDiensten/v0200}UWVIkvBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/"
+"UWVDossierInkomstenGSDDigitaleDiensten/v0200}UWVIkvBinding"
 
 #: suwinet/models.py:116
 msgid "UWVDossierInkomstenGSD Binding Address"
@@ -15133,11 +16382,11 @@ msgstr "Binding address UWVDossierInkomstenGSD"
 
 #: suwinet/models.py:118
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/UWVDossierInkomstenGSD/v0200}UWVIkvBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/UWVDossierInkomstenGSD/"
+"v0200}UWVIkvBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/UWVDossierInkomstenGSD/v0200}UWVIkvBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/UWVDossierInkomstenGSD/"
+"v0200}UWVIkvBinding"
 
 #: suwinet/models.py:123
 msgid "UWVDossierQuotumArbeidsbeperktenGSD Binding Address"
@@ -15145,11 +16394,11 @@ msgstr "Binding address UWVDossierQuotumArbeidsbeperktenGSD"
 
 #: suwinet/models.py:125
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/UWVDossierQuotumArbeidsbeperktenGSD/v0300}UWVArbeidsbeperktenBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/"
+"UWVDossierQuotumArbeidsbeperktenGSD/v0300}UWVArbeidsbeperktenBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/UWVDossierQuotumArbeidsbeperktenGSD/v0300}UWVArbeidsbeperktenBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/"
+"UWVDossierQuotumArbeidsbeperktenGSD/v0300}UWVArbeidsbeperktenBinding"
 
 #: suwinet/models.py:130
 msgid "UWVDossierWerknemersverzekeringenGSDDigitaleDiensten Binding Address"
@@ -15157,11 +16406,11 @@ msgstr "Binding address UWVDossierWerknemersverzekeringenGSDDigitaleDiensten"
 
 #: suwinet/models.py:133
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/UWVDossierWerknemersverzekeringenGSDDigitaleDiensten/v0200}UWVBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/"
+"UWVDossierWerknemersverzekeringenGSDDigitaleDiensten/v0200}UWVBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/UWVDossierWerknemersverzekeringenGSDDigitaleDiensten/v0200}UWVBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/"
+"UWVDossierWerknemersverzekeringenGSDDigitaleDiensten/v0200}UWVBinding"
 
 #: suwinet/models.py:138
 msgid "UWVDossierWerknemersverzekeringenGSD Binding Address"
@@ -15169,11 +16418,11 @@ msgstr "Binding address UWVDossierWerknemersverzekeringenGSD"
 
 #: suwinet/models.py:140
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/UWVDossierWerknemersverzekeringenGSD/v0200}UWVBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/"
+"UWVDossierWerknemersverzekeringenGSD/v0200}UWVBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/UWVDossierWerknemersverzekeringenGSD/v0200}UWVBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/"
+"UWVDossierWerknemersverzekeringenGSD/v0200}UWVBinding"
 
 #: suwinet/models.py:145
 msgid "UWVWbDossierPersoonGSD Binding Address"
@@ -15181,11 +16430,11 @@ msgstr "Binding address UWVWbDossierPersoonGSD"
 
 #: suwinet/models.py:147
 msgid ""
-"Binding address for "
-"{http://bkwi.nl/SuwiML/Diensten/UWVWbDossierPersoonGSD/v0200}UwvWbBinding"
+"Binding address for {http://bkwi.nl/SuwiML/Diensten/UWVWbDossierPersoonGSD/"
+"v0200}UwvWbBinding"
 msgstr ""
-"Binding address voor "
-"{http://bkwi.nl/SuwiML/Diensten/UWVWbDossierPersoonGSD/v0200}UwvWbBinding"
+"Binding address voor {http://bkwi.nl/SuwiML/Diensten/UWVWbDossierPersoonGSD/"
+"v0200}UwvWbBinding"
 
 #: suwinet/models.py:154
 msgid "Suwinet configuration"
@@ -15205,49 +16454,75 @@ msgstr ""
 msgid "English"
 msgstr "Engels"
 
+#~ msgid "There are template syntax errors in the expression."
+#~ msgstr "Er zijn sjabloonsyntaxfouten in de expressie."
+
+#, python-brace-format
+#~ msgid ""
+#~ "The component '{key}' (at JSON path '{path}') has template syntax errors "
+#~ "in the field '{field}'."
+#~ msgstr ""
+#~ "De component  '{key}' (op JSON-pad '{path}') heeft sjabloonsyntaxfouten "
+#~ "in het veld '{field}'."
+
+#~ msgid "Geboorte > Land"
+#~ msgstr "Geboorte > Land"
+
+#~ msgid "Geboorte > Plaats"
+#~ msgstr "Geboorte > Plaats"
+
+#~ msgid "Form key"
+#~ msgstr "Formuliersleutel"
+
+#~ msgid "form component key"
+#~ msgstr "formulier veld sleutel"
+
 #, python-format
 #~ msgid "version %(version)s"
 #~ msgstr "versie %(version)s"
 
 #~ msgid ""
 #~ "\n"
-#~ "            Once your request has been processed, you will be sent an email (at the address configured in your admin\n"
-#~ "            profile) containing a link where you can download a zip file with all the exported forms.\n"
+#~ "            Once your request has been processed, you will be sent an "
+#~ "email (at the address configured in your admin\n"
+#~ "            profile) containing a link where you can download a zip file "
+#~ "with all the exported forms.\n"
 #~ "            "
 #~ msgstr ""
 #~ "\n"
-#~ "Zodra uw verzoek verwerkt is, ontvangt u een e-mail met een link naar het ZIP-bestand dat alle geëxporteerde formulieren bevat."
+#~ "Zodra uw verzoek verwerkt is, ontvangt u een e-mail met een link naar het "
+#~ "ZIP-bestand dat alle geëxporteerde formulieren bevat."
 
 #~ msgid ""
 #~ "The catalogue in the catalogi API from the selected API group. This "
 #~ "overrides the catalogue specified in the API group, if it's set. When "
 #~ "specified, the document types specified on the API group are ignored."
 #~ msgstr ""
-#~ "De catalogus in de Catalogi API uit de geselecteerde API-groep. Deze waarde "
-#~ "overschrijft de catalogus die in de API-groep ingesteld is. Als je de "
-#~ "catalogus hier instelt, dan worden eventuele ingestelde documenttypen in de "
-#~ "API-groep genegeerd."
+#~ "De catalogus in de Catalogi API uit de geselecteerde API-groep. Deze "
+#~ "waarde overschrijft de catalogus die in de API-groep ingesteld is. Als je "
+#~ "de catalogus hier instelt, dan worden eventuele ingestelde documenttypen "
+#~ "in de API-groep genegeerd."
 
 #~ msgid "submission report PDF informatieobjecttype"
 #~ msgstr "inzendings PDF document informatieobjecttype"
 
 #~ msgid ""
-#~ "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used "
-#~ "for the submission report PDF."
+#~ "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be "
+#~ "used for the submission report PDF."
 #~ msgstr ""
 #~ "URL naar het INFORMATIEOBJECTTYPE in een Catalogi API dat wordt gebruikt "
 #~ "voor het PDF-document."
 
 #~ msgid ""
-#~ "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used "
-#~ "for the submission report CSV."
+#~ "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be "
+#~ "used for the submission report CSV."
 #~ msgstr ""
 #~ "URL naar het INFORMATIEOBJECTTYPE in een Catalogi API dat wordt gebruikt "
 #~ "voor het CSV-document."
 
 #~ msgid ""
-#~ "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used "
-#~ "for the submission attachments."
+#~ "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be "
+#~ "used for the submission attachments."
 #~ msgstr ""
 #~ "URL naar het INFORMATIEOBJECTTYPE in een Catalogi API dat wordt gebruikt "
 #~ "voor de bijlagen."
@@ -15281,8 +16556,8 @@ msgstr "Engels"
 #~ "validated against the catalogue."
 #~ msgstr ""
 #~ "Selecteer de catalogus (uit de ingestelde Catalogi API-service) waar de "
-#~ "documenttypen gedefinieerd zijn. Wanneer documenttypen ingesteld zijn, dan "
-#~ "worden deze tegen de catalogus gevalideerd."
+#~ "documenttypen gedefinieerd zijn. Wanneer documenttypen ingesteld zijn, "
+#~ "dan worden deze tegen de catalogus gevalideerd."
 
 #~ msgid "Default values (deprecated)"
 #~ msgstr "Standaardwaarden (verouderd)"
@@ -15313,14 +16588,14 @@ msgstr "Engels"
 #~ "Please verify the selected forms have the ogone-legacy payment backend "
 #~ "configured."
 #~ msgstr ""
-#~ "Een of meerdere formulieren konden niet gemigreerd worden naar de Worldline "
-#~ "betalingsprovider. Controleer dat de geselecteerde formulieren de Ogone "
-#~ "Backend geconfigueerd hebben."
+#~ "Een of meerdere formulieren konden niet gemigreerd worden naar de "
+#~ "Worldline betalingsprovider. Controleer dat de geselecteerde formulieren "
+#~ "de Ogone Backend geconfigueerd hebben."
 
 #, python-brace-format
 #~ msgid ""
-#~ "The following forms reference a merchant that is non-existent: "
-#~ "{form_ids}Please select a new merchant for these forms."
+#~ "The following forms reference a merchant that is non-existent: {form_ids}"
+#~ "Please select a new merchant for these forms."
 #~ msgstr ""
 #~ "De volgende formulieren refereren naar een merchant die niet bestaat: "
 #~ "{form_ids}. Selecteer een nieuwe merchant voor deze formulieren."
@@ -15358,15 +16633,17 @@ msgstr "Engels"
 
 #~ msgid ""
 #~ "API Key created for the specified PSPID. This value will be used when "
-#~ "upgrading to a Open Forms version supporting the Worldline payment provider."
+#~ "upgrading to a Open Forms version supporting the Worldline payment "
+#~ "provider."
 #~ msgstr ""
-#~ "API Key aangemaakt voor de specifieke PSPID. Deze waarde zal gebruikt worden"
-#~ " tijdens het upgraden naar een Open Forms versie die de nieuwe Worldline "
-#~ "betalingsprovider ondersteunt."
+#~ "API Key aangemaakt voor de specifieke PSPID. Deze waarde zal gebruikt "
+#~ "worden tijdens het upgraden naar een Open Forms versie die de nieuwe "
+#~ "Worldline betalingsprovider ondersteunt."
 
 #~ msgid ""
 #~ "API Secret created for the specified PSPID. This value will be used when "
-#~ "upgrading to a Open Forms version supporting the Worldline payment provider."
+#~ "upgrading to a Open Forms version supporting the Worldline payment "
+#~ "provider."
 #~ msgstr ""
 #~ "API Secret aangemaakt voor de specifieke PSPID. Deze waarde zal gebruikt "
 #~ "worden tijdens het upgraden naar een Open Forms versie die de nieuwe "
@@ -15383,15 +16660,15 @@ msgstr "Engels"
 
 #~ msgid ""
 #~ "Optional custom template for the title displayed on the payment page. You "
-#~ "can include all form variables (using their keys) and the 'public_reference'"
-#~ " variable (using expression '{{ public_reference }}'). If unspecified, a "
-#~ "default description is used."
+#~ "can include all form variables (using their keys) and the "
+#~ "'public_reference' variable (using expression '{{ public_reference }}'). "
+#~ "If unspecified, a default description is used."
 #~ msgstr ""
 #~ "Sjabloon voor de titel die op de betaalpagina getoond wordt. Je kan alle "
-#~ "formuliervariabelen gebruiken (gebruik de variabelesleutel als naam) en de "
-#~ "'public_reference' sjabloonvariabele (gebruik de expressie '{{ "
-#~ "public_reference }}'). Indien geen sjabloon opgegeven is, dan wordt een "
-#~ "standaardomschrijving gebruikt."
+#~ "formuliervariabelen gebruiken (gebruik de variabelesleutel als naam) en "
+#~ "de 'public_reference' sjabloonvariabele (gebruik de expressie "
+#~ "'{{ public_reference }}'). Indien geen sjabloon opgegeven is, dan wordt "
+#~ "een standaardomschrijving gebruikt."
 
 #~ msgid "COM template"
 #~ msgstr "COM-sjabloon"
@@ -15399,20 +16676,20 @@ msgstr "Engels"
 #~ msgid ""
 #~ "Optional custom template for the description, included in the payment "
 #~ "overviews for the backoffice. Use this to link the payment back to a "
-#~ "particular process or form. You can include all form variables (using their "
-#~ "keys) and the 'public_reference' variable (using expression '{{ "
-#~ "public_reference }}'). If unspecified, a default description is used. Note "
-#~ "that the length of the result is capped to 100 characters and only alpha-"
-#~ "numeric characters are allowed."
+#~ "particular process or form. You can include all form variables (using "
+#~ "their keys) and the 'public_reference' variable (using expression "
+#~ "'{{ public_reference }}'). If unspecified, a default description is used. "
+#~ "Note that the length of the result is capped to 100 characters and only "
+#~ "alpha-numeric characters are allowed."
 #~ msgstr ""
-#~ "Sjabloon voor de omschrijving van de betaling in de afschriften die je bij "
-#~ "Ogone kan ophalen. Gebruik dit om betalingen aan processen/afdelingen te "
-#~ "koppelen. Je kan alle formuliervariabelen gebruiken (gebruik de "
+#~ "Sjabloon voor de omschrijving van de betaling in de afschriften die je "
+#~ "bij Ogone kan ophalen. Gebruik dit om betalingen aan processen/afdelingen "
+#~ "te koppelen. Je kan alle formuliervariabelen gebruiken (gebruik de "
 #~ "variabelesleutel als naam) en de 'public_reference' sjabloonvariabele "
 #~ "(gebruik de expressie '{{ public_reference }}'). Indien geen sjabloon "
-#~ "opgegeven is, dan wordt een standaardomschrijving gebruikt. Merk op dat het "
-#~ "resultaat op 100 karakters afgekapt wordt en enkel alfanumerieke tekens "
-#~ "toegestaan zijn."
+#~ "opgegeven is, dan wordt een standaardomschrijving gebruikt. Merk op dat "
+#~ "het resultaat op 100 karakters afgekapt wordt en enkel alfanumerieke "
+#~ "tekens toegestaan zijn."
 
 #~ msgid "Ogone legacy"
 #~ msgstr "Ogone legacy"
@@ -15425,8 +16702,8 @@ msgstr "Engels"
 #~ "zaak- en documenttypen gedefinieerd zijn."
 
 #~ msgid ""
-#~ "You must create a valid ZGW API Group config (with the necessary services) "
-#~ "before importing."
+#~ "You must create a valid ZGW API Group config (with the necessary "
+#~ "services) before importing."
 #~ msgstr ""
 #~ "Je moet eerst een werkende ZGW API-groep aanmaken voor dit formulier "
 #~ "geïmporteerd kan worden."

--- a/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
+++ b/src/openforms/conf/locale/nl/LC_MESSAGES/django.po
@@ -4,9 +4,9 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Open Forms\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2026-06-23 09:34+0200\n"
-"PO-Revision-Date: 2026-03-30 16:56+0200\n"
-"Last-Translator: robinvandermolen <robin@maykinmedia.nl>\n"
+"POT-Creation-Date: 2026-07-20 22:26+0200\n"
+"PO-Revision-Date: 2026-07-20 22:36+0200\n"
+"Last-Translator:   <admin@admin.com>\n"
 "Language-Team: Dutch <support@maykinmedia.nl>\n"
 "Language: nl\n"
 "MIME-Version: 1.0\n"
@@ -36,11 +36,11 @@ msgstr ""
 "functionaliteit te verliezen. We raden echter aan om het nonce-mechanisme te"
 " gebruiken."
 
-#: openforms/accounts/admin.py:36
+#: openforms/accounts/admin.py:38
 msgid "Groups"
 msgstr "Groepen"
 
-#: openforms/accounts/admin.py:41
+#: openforms/accounts/admin.py:43
 msgid "Personal info"
 msgstr "Persoonlijke informatie"
 
@@ -62,7 +62,7 @@ msgstr "Een gebruiker met deze gebruikersnaam bestaat al."
 msgid "first name"
 msgstr "voornaam"
 
-#: openforms/accounts/models.py:40 openforms/formio/components/custom.py:762
+#: openforms/accounts/models.py:40 openforms/formio/components/custom.py:768
 msgid "last name"
 msgstr "achternaam"
 
@@ -115,7 +115,7 @@ msgstr ""
 "De voorkeurstaal voor de (beheer) gebruikersinterface. Wanneer geen waarde "
 "ingesteld is, worden de browserinstellingen gebruikt."
 
-#: openforms/accounts/models.py:85 openforms/forms/models/form.py:838
+#: openforms/accounts/models.py:85 openforms/forms/models/form.py:841
 #: openforms/forms/models/form_version.py:64 soap/models.py:53
 msgid "user"
 msgstr "gebruiker"
@@ -733,7 +733,7 @@ msgstr "Unieke sleutel van het product"
 #: openforms/config/models/map.py:70 openforms/config/models/theme.py:21
 #: openforms/contrib/customer_interactions/models.py:14
 #: openforms/contrib/objects_api/models.py:16
-#: openforms/dmn/api/serializers.py:76 openforms/forms/admin/form.py:268
+#: openforms/dmn/api/serializers.py:76 openforms/forms/admin/form.py:271
 #: openforms/forms/admin/form_definition.py:69
 #: openforms/forms/models/category.py:13 openforms/forms/models/form.py:80
 #: openforms/forms/models/form_definition.py:40
@@ -794,7 +794,7 @@ msgstr "Locatienaam"
 
 #: openforms/appointments/api/serializers.py:88
 #: openforms/contrib/kadaster/api/serializers.py:20
-#: openforms/formio/components/custom.py:570
+#: openforms/formio/components/custom.py:576
 msgid "city"
 msgstr "stad"
 
@@ -805,6 +805,7 @@ msgid "City"
 msgstr "Stad"
 
 #: openforms/appointments/api/serializers.py:93
+#: openforms/formio/components/custom.py:1208
 msgid "address"
 msgstr "adres"
 
@@ -884,13 +885,13 @@ msgid "Products"
 msgstr "Producten"
 
 #: openforms/appointments/api/serializers.py:173
-#: openforms/submissions/api/serializers.py:606
+#: openforms/submissions/api/serializers.py:605
 #: openforms/submissions/api/validation.py:63
 msgid "status check endpoint"
 msgstr "status controle endpoint"
 
 #: openforms/appointments/api/serializers.py:176
-#: openforms/submissions/api/serializers.py:608
+#: openforms/submissions/api/serializers.py:607
 #: openforms/submissions/api/validation.py:65
 msgid ""
 "The API endpoint where the background processing status can be checked. "
@@ -1102,7 +1103,7 @@ msgid "First name"
 msgstr "Voornaam"
 
 #: openforms/appointments/contrib/jcc_rest/constants.py:39
-#: openforms/formio/rendering/default.py:439 stuf/stuf_bg/constants.py:29
+#: openforms/formio/rendering/default.py:440 stuf/stuf_bg/constants.py:29
 msgid "Initials"
 msgstr "Voorletters"
 
@@ -1112,8 +1113,8 @@ msgid "Last name prefix"
 msgstr "Voorvoegsel"
 
 #: openforms/appointments/contrib/jcc_rest/constants.py:54
-#: openforms/formio/rendering/default.py:454
-#: openforms/formio/rendering/default.py:575 stuf/stuf_bg/constants.py:50
+#: openforms/formio/rendering/default.py:455
+#: openforms/formio/rendering/default.py:576 stuf/stuf_bg/constants.py:50
 msgid "Date of birth"
 msgstr "Geboortedatum"
 
@@ -1239,7 +1240,7 @@ msgstr "Ongeldige pluginconfiguratie: {exc}"
 #: openforms/prefill/contrib/suwinet/plugin.py:98
 #: openforms/registrations/contrib/microsoft_graph/plugin.py:130
 #: openforms/registrations/contrib/stuf_zds/plugin.py:684
-#: openforms/submissions/api/serializers.py:314
+#: openforms/submissions/api/serializers.py:313
 msgid "Configuration"
 msgstr "Configuratie"
 
@@ -1523,7 +1524,7 @@ msgid "The authentication attribute provided by this plugin."
 msgstr "Het authenticatie attribuut geleverd door deze plugin."
 
 #: openforms/authentication/api/serializers.py:28
-#: openforms/forms/api/viewsets.py:637
+#: openforms/forms/api/viewsets.py:659
 #: openforms/payments/api/serializers.py:18
 #: openforms/registrations/api/serializers.py:13
 msgid "JSON schema"
@@ -1536,9 +1537,9 @@ msgid "The generated JSON schema for the plugin options."
 msgstr "Het gegenereerde JSON-schema voor de pluginopties."
 
 #: openforms/authentication/api/serializers.py:35
-#: openforms/registrations/contrib/objects_api/config.py:105
+#: openforms/registrations/contrib/objects_api/config.py:102
 #: openforms/registrations/contrib/stuf_zds/options.py:61
-#: openforms/registrations/contrib/zgw_apis/options.py:94
+#: openforms/registrations/contrib/zgw_apis/options.py:93
 msgid "Title"
 msgstr "Titel"
 
@@ -1645,8 +1646,8 @@ msgstr "Authenticatiemodule"
 #: openforms/authentication/constants.py:34
 #: openforms/authentication/constants.py:38
 #: openforms/authentication/contrib/demo/plugin.py:32
-#: openforms/formio/rendering/default.py:434
-#: openforms/formio/rendering/default.py:565 stuf/stuf_bg/constants.py:26
+#: openforms/formio/rendering/default.py:435
+#: openforms/formio/rendering/default.py:566 stuf/stuf_bg/constants.py:26
 msgid "BSN"
 msgstr "BSN"
 
@@ -1694,7 +1695,7 @@ msgstr "Opaak"
 
 #: openforms/authentication/constants.py:40
 #: openforms/contrib/kvk/validators.py:117
-#: openforms/contrib/zgw/serializers.py:35
+#: openforms/contrib/zgw/serializers.py:34
 msgid "RSIN"
 msgstr "RSIN"
 
@@ -2075,7 +2076,7 @@ msgstr ""
 #: openforms/config/models/map.py:64 openforms/config/models/theme.py:26
 #: openforms/forms/api/serializers/logic/action_serializers.py:214
 #: openforms/forms/models/category.py:10 openforms/forms/models/form.py:79
-#: openforms/forms/models/form.py:825
+#: openforms/forms/models/form.py:828
 #: openforms/forms/models/form_definition.py:39
 #: openforms/forms/models/form_step.py:27
 #: openforms/forms/models/form_version.py:44
@@ -2261,7 +2262,7 @@ msgid "Name of the attribute returned by the authentication plugin."
 msgstr "Naam van het attribuut voorzien door de authenticatieplugin"
 
 #: openforms/authentication/models.py:49 openforms/config/models/csp.py:70
-#: openforms/submissions/models/submission_value_variable.py:451
+#: openforms/submissions/models/submission_value_variable.py:458
 #: openforms/validations/api/views.py:72
 msgid "value"
 msgstr "waarde"
@@ -2288,7 +2289,7 @@ msgstr "Authenticatiedetails"
 #: openforms/authentication/models.py:416 openforms/emails/constants.py:17
 #: openforms/formio/api/serializers.py:33
 #: openforms/payments/contrib/worldline/plugin.py:110
-#: openforms/submissions/api/serializers.py:808
+#: openforms/submissions/api/serializers.py:807
 msgid "Submission"
 msgstr "Inzending"
 
@@ -2760,7 +2761,8 @@ msgid ""
 "to accept before submitting a form."
 msgstr ""
 "Eén enkel Form.io selectievakjecomponent voor de verklaring die een "
-"gebruiker mogelijks moet accepteren voor het formulier ingestuurd kan worden."
+"gebruiker mogelijks moet accepteren voor het formulier ingestuurd kan "
+"worden."
 
 #: openforms/config/api/constants.py:19
 msgid "Component type (checkbox)"
@@ -2790,8 +2792,8 @@ msgid ""
 "The formatted label to use next to the checkbox when asking the user to "
 "agree to the privacy policy."
 msgstr ""
-"Het opgemaakte label dat naast het selectievakje moet worden getoond wanneer "
-"de gebruiker wordt gevraagd akkoord te gaan met het privacybeleid."
+"Het opgemaakte label dat naast het selectievakje moet worden getoond wanneer"
+" de gebruiker wordt gevraagd akkoord te gaan met het privacybeleid."
 
 #: openforms/config/api/viewsets.py:11
 msgid "List available themes"
@@ -2962,14 +2964,15 @@ msgstr "Paginatitel inzendingsbevestiging"
 
 #: openforms/config/models/config.py:67
 msgid ""
-"The content of the confirmation page title. You can (and should) include the "
-"'public_reference' variable (using expression '{{ public_reference }}') so "
-"the users have a reference in case they need to contact the customer service."
+"The content of the confirmation page title. You can (and should) include the"
+" 'public_reference' variable (using expression '{{ public_reference }}') so "
+"the users have a reference in case they need to contact the customer "
+"service."
 msgstr ""
 "De inhoud van de bevestigingspaginatitel. De 'public_reference' "
-"sjablooninstructie is beschikbaar (gebruik de expressie "
-"'{{ public_reference }}') en we adviseren om deze weer te geven zodat "
-"gebruikers een referentie hebben als ze de klantenservice moeten contacteren."
+"sjablooninstructie is beschikbaar (gebruik de expressie '{{ public_reference"
+" }}') en we adviseren om deze weer te geven zodat gebruikers een referentie "
+"hebben als ze de klantenservice moeten contacteren."
 
 #: openforms/config/models/config.py:72
 msgid "Confirmation: {{ public_reference }}"
@@ -2984,8 +2987,8 @@ msgid ""
 "The content of the submission confirmation page. It can contain variables "
 "that will be templated from the submitted form data."
 msgstr ""
-"De inhoud van bevestigingspagina kan variabelen bevatten die op basis van de "
-"ingediende formuliergegevens worden weergegeven. "
+"De inhoud van bevestigingspagina kan variabelen bevatten die op basis van de"
+" ingediende formuliergegevens worden weergegeven. "
 
 #: openforms/config/models/config.py:81
 msgid "Thank you for submitting this form."
@@ -2997,7 +3000,8 @@ msgstr "titel downloadlink inzendings-PDF"
 
 #: openforms/config/models/config.py:87
 msgid "The title of the link to download the report of a submission."
-msgstr "Titel/tekst van de downloadlink om de inzending als PDF te downloaden."
+msgstr ""
+"Titel/tekst van de downloadlink om de inzending als PDF te downloaden."
 
 #: openforms/config/models/config.py:88
 msgid "Download PDF"
@@ -3027,15 +3031,15 @@ msgstr "Mede-ondertekenenbevestigingspagina tekst"
 msgid ""
 "The content of the submission confirmation page for submissions requiring "
 "cosigning. The variables 'public_reference' and 'cosigner_email' are "
-"available (using expressions '{{ public_reference }}' and "
-"'{{ cosigner_email }}', respectively). We strongly advise you to include the "
+"available (using expressions '{{ public_reference }}' and '{{ cosigner_email"
+" }}', respectively). We strongly advise you to include the "
 "'public_reference' in case users need to contact the customer service."
 msgstr ""
 "De inhoud van de bevestigingspagina wanneer de inzending mede-ondertekend "
 "moet worden. Je kan de variabelen 'public_reference' en 'cosigner_email' "
-"gebruiken (gebruik de expressies '{{ public_reference }}' en "
-"'{{ cosigner_email }}'). We raden sterk aan om de publieke referentie weer "
-"te geven zodat gebruikers hiernaar kunnen verwijzen als ze de klantenservice "
+"gebruiken (gebruik de expressies '{{ public_reference }}' en '{{ "
+"cosigner_email }}'). We raden sterk aan om de publieke referentie weer te "
+"geven zodat gebruikers hiernaar kunnen verwijzen als ze de klantenservice "
 "moeten contacteren."
 
 #: openforms/config/models/config.py:120 openforms/config/models/config.py:146
@@ -3131,8 +3135,8 @@ msgid ""
 "without any initiator. Otherwise, a fake initiator is added with BSN "
 "111222333."
 msgstr ""
-"Indien aangevinkt en de inzender is niet geauthenticeerd, dan wordt een zaak "
-"aangemaakt zonder initiator. Indien uitgevinkt, dan zal een nep-initiator "
+"Indien aangevinkt en de inzender is niet geauthenticeerd, dan wordt een zaak"
+" aangemaakt zonder initiator. Indien uitgevinkt, dan zal een nep-initiator "
 "worden toegevoegd met BSN 111222333."
 
 #: openforms/config/models/config.py:231
@@ -3160,7 +3164,8 @@ msgstr "Wijzigen"
 
 #: openforms/config/models/config.py:244
 msgid ""
-"The text that will be displayed in the overview page to change a certain step"
+"The text that will be displayed in the overview page to change a certain "
+"step"
 msgstr ""
 "Het label de link op de overzichtspagina om een bepaalde stap te wijzigen"
 
@@ -3204,7 +3209,8 @@ msgid ""
 msgstr ""
 "Het label van de knop om naar de vorige stap binnen het formulier te gaan"
 
-#: openforms/config/models/config.py:276 openforms/forms/models/form_step.py:51
+#: openforms/config/models/config.py:276
+#: openforms/forms/models/form_step.py:51
 msgid "step save text"
 msgstr "Opslaan-label"
 
@@ -3218,7 +3224,8 @@ msgid ""
 "information"
 msgstr "Het label van de knop om het formulier tussentijds op te slaan"
 
-#: openforms/config/models/config.py:284 openforms/forms/models/form_step.py:60
+#: openforms/config/models/config.py:284
+#: openforms/forms/models/form_step.py:60
 msgid "step next text"
 msgstr "Volgende stap-label"
 
@@ -3227,7 +3234,8 @@ msgid "Next"
 msgstr "Volgende"
 
 #: openforms/config/models/config.py:288
-msgid "The text that will be displayed in the form step to go to the next step"
+msgid ""
+"The text that will be displayed in the form step to go to the next step"
 msgstr ""
 "Het label van de knop om naar de volgende stap binnen het formulier te gaan"
 
@@ -3249,11 +3257,11 @@ msgstr "Markeer verplichte velden met een asterisk"
 #: openforms/config/models/config.py:302
 msgid ""
 "If checked, required fields are marked with an asterisk and optional fields "
-"are unmarked. If unchecked, optional fields will be marked with '(optional)' "
-"and required fields are unmarked."
+"are unmarked. If unchecked, optional fields will be marked with '(optional)'"
+" and required fields are unmarked."
 msgstr ""
-"Indien aangevinkt, dan zijn verplichte velden gemarkeerd met een asterisk en "
-"optionele velden niet gemarkeerd. Indien uitgevinkt, dan zijn optionele "
+"Indien aangevinkt, dan zijn verplichte velden gemarkeerd met een asterisk en"
+" optionele velden niet gemarkeerd. Indien uitgevinkt, dan zijn optionele "
 "velden gemarkeerd met '(niet verplicht)' en verplichte velden ongemarkeerd."
 
 #: openforms/config/models/config.py:309
@@ -3279,8 +3287,8 @@ msgid ""
 "displayed but marked as non-applicable.)"
 msgstr ""
 "Indien aangevinkt, dan worden stappen die (via logicaregels) niet van "
-"toepassing zijn verborgen. Standaard zijn deze zichtbaar maar gemarkeerd als "
-"n.v.t."
+"toepassing zijn verborgen. Standaard zijn deze zichtbaar maar gemarkeerd als"
+" n.v.t."
 
 #: openforms/config/models/config.py:326
 msgid "The default zoom level for the leaflet map."
@@ -3295,8 +3303,8 @@ msgstr ""
 #: openforms/config/models/config.py:339
 msgid "The default longitude for the leaflet map."
 msgstr ""
-"Standaard longitude voor kaartmateriaal (in coördinatenstelsel EPSG:4326/WGS "
-"84)."
+"Standaard longitude voor kaartmateriaal (in coördinatenstelsel EPSG:4326/WGS"
+" 84)."
 
 #: openforms/config/models/config.py:352
 msgid "default theme"
@@ -3329,8 +3337,8 @@ msgstr "hoofdsite link"
 msgid ""
 "URL to the main website. Used for the 'back to municipality website' link."
 msgstr ""
-"URL naar de hoofdsite van de organisatie. Wordt gebruikt voor 'terug naar de "
-"gemeentewebsite' link."
+"URL naar de hoofdsite van de organisatie. Wordt gebruikt voor 'terug naar de"
+" gemeentewebsite' link."
 
 #: openforms/config/models/config.py:375 openforms/config/models/theme.py:32
 msgid "organization name"
@@ -3372,7 +3380,8 @@ msgid ""
 "Due to DigiD requirements this value has to be less than or equal to "
 "%(limit_value)s minutes."
 msgstr ""
-"Om veiligheidsredenen mag de waarde niet groter zijn %(limit_value)s minuten."
+"Om veiligheidsredenen mag de waarde niet groter zijn %(limit_value)s "
+"minuten."
 
 #: openforms/config/models/config.py:415
 msgid ""
@@ -3388,8 +3397,8 @@ msgstr "Betaling: bestellingsnummersjabloon"
 #, python-brace-format
 msgid ""
 "Template to use when generating payment order IDs. It should be alpha-"
-"numerical and can contain the '/._-' characters. You can use the placeholder "
-"tokens: {year}, {public_reference}, {uid}."
+"numerical and can contain the '/._-' characters. You can use the placeholder"
+" tokens: {year}, {public_reference}, {uid}."
 msgstr ""
 "Sjabloon voor de generatie van unieke betalingsreferenties. Het sjabloon "
 "moet alfanumeriek zijn en mag de karakters '/._-' bevatten. De placeholder "
@@ -3433,8 +3442,8 @@ msgid ""
 "Yes, I have read the {% privacy_policy %} and explicitly agree to the "
 "processing of my submitted information."
 msgstr ""
-"Ja, ik heb kennis genomen van het {% privacy_policy %} en geef uitdrukkelijk "
-"toestemming voor het verwerken van de door mij opgegeven gegevens."
+"Ja, ik heb kennis genomen van het {% privacy_policy %} en geef uitdrukkelijk"
+" toestemming voor het verwerken van de door mij opgegeven gegevens."
 
 #: openforms/config/models/config.py:467 openforms/forms/models/form.py:239
 msgid "ask statement of truth"
@@ -3567,9 +3576,9 @@ msgid ""
 "selected services will be shown as options when configuring select or "
 "selectboxes components to be populated from Referentielijsten."
 msgstr ""
-"Selecteer de services die referentielijsten ontsluiten. Je kan vervolgens in "
-"de formuliercomponenten uit deze lijst van services een optie selecteren om "
-"de keuzeopties uit de referentielijsten op te halen."
+"Selecteer de services die referentielijsten ontsluiten. Je kan vervolgens in"
+" de formuliercomponenten uit deze lijst van services een optie selecteren om"
+" de keuzeopties uit de referentielijsten op te halen."
 
 #: openforms/config/models/config.py:573
 msgid "family members data api"
@@ -3670,8 +3679,8 @@ msgstr "Publiek referentiesjabloon"
 #, python-brace-format
 msgid ""
 "Template to use when generating public reference of the submission. It "
-"should be alpha-numerical and can contain the '/._-' characters. You can use "
-"the placeholder tokens: {year}, {uid}."
+"should be alpha-numerical and can contain the '/._-' characters. You can use"
+" the placeholder tokens: {year}, {uid}."
 msgstr ""
 "Sjabloon voor de generatie van de publieke referentie voor een inzending. "
 "Het sjabloon moet alfanumeriek zijn en mag de karakters '/._-' bevatten. De "
@@ -3747,15 +3756,15 @@ msgstr "achtergrondlaag-URL"
 #: openforms/config/models/map.py:29
 #, python-brace-format
 msgid ""
-"URL to the tile layer image, used to define the map component background. To "
-"ensure correct functionality of the map, EPSG 28992 projection should be "
-"used. Example value: https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/"
-"standaard/EPSG:28992/{z}/{x}/{y}.png"
+"URL to the tile layer image, used to define the map component background. To"
+" ensure correct functionality of the map, EPSG 28992 projection should be "
+"used. Example value: "
+"https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png"
 msgstr ""
-"URL naar de tegels van de achtergrondlaag van de kaart. Om de juiste werking "
-"te garanderen moet de laag de EPSG:28992-projectie gebruiken. Bijvoorbeeld: "
-"https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/"
-"{z}/{x}/{y}.png"
+"URL naar de tegels van de achtergrondlaag van de kaart. Om de juiste werking"
+" te garanderen moet de laag de EPSG:28992-projectie gebruiken. Bijvoorbeeld:"
+" "
+"https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png"
 
 #: openforms/config/models/map.py:39
 msgid "An easily recognizable name for the tile layer, used to identify it."
@@ -3782,13 +3791,12 @@ msgstr ""
 msgid ""
 "URL to collect the WMS tile layer capabilities. To ensure correct "
 "functionality of the map, EPSG 28992 projection should be available on the "
-"WMS tile layer. Example value: https://service.pdok.nl/lv/bag/wms/v2_0?"
-"request=getCapabilities&service=WMS"
+"WMS tile layer. Example value: "
+"https://service.pdok.nl/lv/bag/wms/v2_0?request=getCapabilities&service=WMS"
 msgstr ""
 "URL naar de tegels van de WMS-kaartlaag. Om de juiste werking te garanderen "
-"moet de laag de EPSG:28992-projectie gebruiken. Bijvoorbeeld: https://"
-"service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/"
-"{y}.png"
+"moet de laag de EPSG:28992-projectie gebruiken. Bijvoorbeeld: "
+"https://service.pdok.nl/brt/achtergrondkaart/wmts/v2_0/standaard/EPSG:28992/{z}/{x}/{y}.png"
 
 #: openforms/config/models/map.py:91
 msgid "WMS layer"
@@ -3818,15 +3826,15 @@ msgid ""
 "If left blank, the matching configuration option from the global "
 "configuration is used."
 msgstr ""
-"URL naar de hoofdsite van de organisatie. Wordt gebruikt voor de 'terug naar "
-"de gemeentewebsite' link. Als je dit leeglaat, dan wordt de algemene "
+"URL naar de hoofdsite van de organisatie. Wordt gebruikt voor de 'terug naar"
+" de gemeentewebsite' link. Als je dit leeglaat, dan wordt de algemene "
 "instelling gebruikt."
 
 #: openforms/config/models/theme.py:55
 msgid ""
-"Allow the uploading of a favicon, .png .jpg .svg and .ico are compatible. If "
-"left blank, the matching configuration option from the global configuration "
-"is used."
+"Allow the uploading of a favicon, .png .jpg .svg and .ico are compatible. If"
+" left blank, the matching configuration option from the global configuration"
+" is used."
 msgstr ""
 "Upload het favicon voor de applicatie. Enkel .png, .jpg, .svg en .ico "
 "bestanden zijn toegestaan. Als je dit leeglaat, dan wordt de algemene "
@@ -3853,8 +3861,8 @@ msgid ""
 "Upload the email logo, visible to users who receive an email. We advise "
 "dimensions around 150px by 75px. SVG's are not permitted."
 msgstr ""
-"Upload het logo van de gemeente dat zichtbaar is in e-mails. We adviseren de "
-"dimensies van 150 x 75 pixels. SVG-bestanden zijn niet toegestaan."
+"Upload het logo van de gemeente dat zichtbaar is in e-mails. We adviseren de"
+" dimensies van 150 x 75 pixels. SVG-bestanden zijn niet toegestaan."
 
 #: openforms/config/models/theme.py:93
 msgid "theme CSS class name"
@@ -3863,7 +3871,8 @@ msgstr "Thema CSS class name"
 #: openforms/config/models/theme.py:95
 msgid "If provided, this class name will be set on the <html> element."
 msgstr ""
-"Indien ingevuld, dan wordt deze class name aan het <html> element toegevoegd."
+"Indien ingevuld, dan wordt deze class name aan het <html> element "
+"toegevoegd."
 
 #: openforms/config/models/theme.py:98
 msgid "theme stylesheet URL"
@@ -3878,14 +3887,14 @@ msgid ""
 "The URL stylesheet with theme-specific rules for your organization. This "
 "will be included as final stylesheet, overriding previously defined styles. "
 "Note that you also have to include the host to the `style-src` CSP "
-"directive. Example value: https://unpkg.com/@utrecht/design-tokens@1.0.0-"
-"alpha.20/dist/index.css."
+"directive. Example value: https://unpkg.com/@utrecht/design-"
+"tokens@1.0.0-alpha.20/dist/index.css."
 msgstr ""
-"URL naar de stylesheet met thema-specifieke regels voor uw organisatie. Deze "
-"stylesheet wordt als laatste ingeladen, waarbij eerdere stijlregels dus "
+"URL naar de stylesheet met thema-specifieke regels voor uw organisatie. Deze"
+" stylesheet wordt als laatste ingeladen, waarbij eerdere stijlregels dus "
 "overschreven worden. Vergeet niet dat u ook de host van deze URL aan de "
-"`style-src` CSP configuratie moet toevoegen. Voorbeeldwaarde: https://"
-"unpkg.com/@utrecht/design-tokens@1.0.0-alpha.20/dist/index.css."
+"`style-src` CSP configuratie moet toevoegen. Voorbeeldwaarde: "
+"https://unpkg.com/@utrecht/design-tokens@1.0.0-alpha.20/dist/index.css."
 
 #: openforms/config/models/theme.py:115
 msgid "theme stylesheet"
@@ -3915,14 +3924,14 @@ msgid ""
 "forms.readthedocs.io/en/latest/installation/form_hosting.html#run-time-"
 "configuration for documentation."
 msgstr ""
-"Waarden met diverse stijl parameters, zoals randen, achtergrondkleuren, etc. "
-"Dit is voor geavanceerde gebruikers. Attributen die niet zijn opgegeven "
-"vallen terug op standaardwaarden. Zie https://open-forms.readthedocs.io/en/"
-"latest/installation/form_hosting.html#run-time-configuration voor "
-"documentatie."
+"Waarden met diverse stijl parameters, zoals randen, achtergrondkleuren, etc."
+" Dit is voor geavanceerde gebruikers. Attributen die niet zijn opgegeven "
+"vallen terug op standaardwaarden. Zie https://open-"
+"forms.readthedocs.io/en/latest/installation/form_hosting.html#run-time-"
+"configuration voor documentatie."
 
 #: openforms/config/models/theme.py:156
-#: openforms/forms/api/serializers/form.py:178
+#: openforms/forms/api/serializers/form.py:182
 msgid "theme"
 msgstr "stijl"
 
@@ -3932,7 +3941,7 @@ msgstr "stijlen"
 
 #: openforms/config/templates/admin/config/overview.html:8
 #: openforms/config/templates/admin/config/theme/preview.html:13
-#: openforms/forms/templates/admin/forms/form/export.html:12
+#: openforms/forms/templates/admin/forms/form/export.html:13
 #: openforms/forms/templates/admin/forms/form/import_form.html:13
 #: openforms/forms/templates/admin/forms/form/migrate-payment-backend.html:18
 #: openforms/forms/templates/admin/forms/formsubmissionstatistics/export_form.html:19
@@ -3952,9 +3961,9 @@ msgid "Status"
 msgstr "Status"
 
 #: openforms/config/templates/admin/config/overview.html:25
-#: openforms/forms/admin/category.py:37 openforms/forms/admin/form.py:261
-#: openforms/forms/api/serializers/logic/form_logic.py:129
-#: openforms/submissions/api/serializers.py:241
+#: openforms/forms/admin/category.py:37 openforms/forms/admin/form.py:264
+#: openforms/forms/api/serializers/logic/form_logic.py:132
+#: openforms/submissions/api/serializers.py:244
 msgid "Actions"
 msgstr "Acties"
 
@@ -3990,10 +3999,11 @@ msgstr "Medeondertekening nodig"
 
 #: openforms/config/templates/config/default_cosign_submission_confirmation.html:8
 msgid ""
-"You can start the cosigning process immediately by clicking the button below."
+"You can start the cosigning process immediately by clicking the button "
+"below."
 msgstr ""
-"Je kan het mede-ondertekenen meteen starten door de onderstaande knop aan te "
-"klikken."
+"Je kan het mede-ondertekenen meteen starten door de onderstaande knop aan te"
+" klikken."
 
 #: openforms/config/templates/config/default_cosign_submission_confirmation.html:9
 #: openforms/submissions/templatetags/cosign.py:17
@@ -4007,14 +4017,14 @@ msgstr "Alternatieve instructies"
 #: openforms/config/templates/config/default_cosign_submission_confirmation.html:12
 #, python-format
 msgid ""
-"We've sent an email with a cosign request to <a href=\"mailto:"
-"%(tt_openvariable)s cosigner_email "
+"We've sent an email with a cosign request to <a "
+"href=\"mailto:%(tt_openvariable)s cosigner_email "
 "%(tt_closevariable)s\">%(tt_openvariable)s cosigner_email "
 "%(tt_closevariable)s</a>. Once the submission has been cosigned we will "
 "start processing your request."
 msgstr ""
-"Wij hebben een e-mail gestuurd voor medeondertekening naar <a href=\"mailto:"
-"%(tt_openvariable)s cosigner_email "
+"Wij hebben een e-mail gestuurd voor medeondertekening naar <a "
+"href=\"mailto:%(tt_openvariable)s cosigner_email "
 "%(tt_closevariable)s\">%(tt_openvariable)s cosigner_email "
 "%(tt_closevariable)s</a>. Als deze ondertekend is, nemen wij je aanvraag in "
 "behandeling."
@@ -4257,7 +4267,7 @@ msgid "House number to use in search"
 msgstr "Huisnummer om naar te zoeken"
 
 #: openforms/contrib/kadaster/api/serializers.py:18
-#: openforms/formio/components/custom.py:564
+#: openforms/formio/components/custom.py:570
 msgid "street name"
 msgstr "straatnaam"
 
@@ -4270,12 +4280,12 @@ msgid "Found city"
 msgstr "Gevonden stad"
 
 #: openforms/contrib/kadaster/api/serializers.py:22
-#: openforms/formio/components/custom.py:576
+#: openforms/formio/components/custom.py:582
 msgid "city and street name secret"
 msgstr "gedeeld geheim straatnaam en stad"
 
 #: openforms/contrib/kadaster/api/serializers.py:23
-#: openforms/formio/components/custom.py:577
+#: openforms/formio/components/custom.py:583
 msgid "Secret for the combination of city and street name"
 msgstr "Gedeeld geheim voor de combinatie van stad en straatnaam"
 
@@ -4563,14 +4573,14 @@ msgstr ""
 "worden uit de Catalogi API van deze groep opgehaald."
 
 #: openforms/contrib/objects_api/api/filters.py:24
-#: openforms/contrib/objects_api/models.py:173
+#: openforms/contrib/objects_api/models.py:178
 msgid "Objects API group"
 msgstr "Objecten API-groep"
 
 #: openforms/contrib/objects_api/api/serializers.py:15
 #: openforms/prefill/contrib/objects_api/api/serializers.py:57
 #: openforms/prefill/contrib/objects_api/api/views.py:23
-#: openforms/registrations/contrib/objects_api/config.py:122
+#: openforms/registrations/contrib/objects_api/config.py:119
 msgid "Which Objects API group to use."
 msgstr "De gewenste Objecten API-groep."
 
@@ -4669,44 +4679,44 @@ msgstr "Documenten API"
 msgid "Catalogi API"
 msgstr "Catalogi API"
 
-#: openforms/contrib/objects_api/models.py:70
-#: openforms/registrations/contrib/zgw_apis/models.py:64
+#: openforms/contrib/objects_api/models.py:71
+#: openforms/registrations/contrib/zgw_apis/models.py:65
 msgid "catalogus domain"
 msgstr "catalogusdomein"
 
-#: openforms/contrib/objects_api/models.py:76
-#: openforms/contrib/zgw/serializers.py:29
-#: openforms/registrations/contrib/zgw_apis/models.py:70
+#: openforms/contrib/objects_api/models.py:77
+#: openforms/contrib/zgw/serializers.py:28
+#: openforms/registrations/contrib/zgw_apis/models.py:71
 msgid "The 'domein' attribute for the Catalogus resource in the Catalogi API."
 msgstr "Het 'domein'-attribuut van de Catalogus-entiteit in de Catalogi API."
 
-#: openforms/contrib/objects_api/models.py:80
-#: openforms/registrations/contrib/zgw_apis/models.py:74
+#: openforms/contrib/objects_api/models.py:82
+#: openforms/registrations/contrib/zgw_apis/models.py:76
 msgid "catalogus RSIN"
 msgstr "catalogus-RSIN"
 
-#: openforms/contrib/objects_api/models.py:86
-#: openforms/contrib/zgw/serializers.py:40
-#: openforms/registrations/contrib/zgw_apis/models.py:80
+#: openforms/contrib/objects_api/models.py:88
+#: openforms/contrib/zgw/serializers.py:39
+#: openforms/registrations/contrib/zgw_apis/models.py:82
 msgid "The 'rsin' attribute for the Catalogus resource in the Catalogi API."
 msgstr "Het 'rsin'-attribuut van de catalogus-entiteit in de Catalogi API."
 
-#: openforms/contrib/objects_api/models.py:92
-#: openforms/registrations/contrib/objects_api/config.py:179
-#: openforms/registrations/contrib/zgw_apis/models.py:86
+#: openforms/contrib/objects_api/models.py:94
+#: openforms/registrations/contrib/objects_api/config.py:173
+#: openforms/registrations/contrib/zgw_apis/models.py:88
 msgid "organisation RSIN"
 msgstr "organisatie RSIN"
 
-#: openforms/contrib/objects_api/models.py:96
+#: openforms/contrib/objects_api/models.py:98
 msgid "Default RSIN of organization, which creates the INFORMATIEOBJECT"
 msgstr "Standaard RSIN van de organisatie, die het INFORMATIEOBJECT aanmaakt"
 
-#: openforms/contrib/objects_api/models.py:101
-#: openforms/registrations/contrib/objects_api/config.py:187
+#: openforms/contrib/objects_api/models.py:104
+#: openforms/registrations/contrib/objects_api/config.py:181
 msgid "submission report document type description"
 msgstr "omschrijving van het documenttype voor het PDF-document"
 
-#: openforms/contrib/objects_api/models.py:106
+#: openforms/contrib/objects_api/models.py:109
 msgid ""
 "Description of the document type in the Catalogi API to be used for the "
 "submission report PDF (i.e. the INFORMATIEOBJECTTYPE.omschrijving "
@@ -4718,12 +4728,12 @@ msgstr ""
 "inzendingsgegevens. De juiste versie wordt automatisch geselecteerd op basis"
 " van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
 
-#: openforms/contrib/objects_api/models.py:115
-#: openforms/registrations/contrib/objects_api/config.py:200
+#: openforms/contrib/objects_api/models.py:119
+#: openforms/registrations/contrib/objects_api/config.py:194
 msgid "submission report CSV document type description"
 msgstr "omschrijving van het documenttype voor het CSV-document"
 
-#: openforms/contrib/objects_api/models.py:120
+#: openforms/contrib/objects_api/models.py:124
 msgid ""
 "Description of the document type in the Catalogi API to be used for the "
 "submission report CSV (i.e. the INFORMATIEOBJECTTYPE.omschrijving "
@@ -4735,12 +4745,12 @@ msgstr ""
 "inzendingsgegevens. De juiste versie wordt automatisch geselecteerd op basis"
 " van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
 
-#: openforms/contrib/objects_api/models.py:129
-#: openforms/registrations/contrib/objects_api/config.py:213
+#: openforms/contrib/objects_api/models.py:134
+#: openforms/registrations/contrib/objects_api/config.py:207
 msgid "attachment document type description"
 msgstr "omschrijving bijlage-documenttype"
 
-#: openforms/contrib/objects_api/models.py:134
+#: openforms/contrib/objects_api/models.py:139
 msgid ""
 "Description of the document type in the Catalogi API to be used for the "
 "submission attachments (i.e. the INFORMATIEOBJECTTYPE.omschrijving "
@@ -4752,11 +4762,11 @@ msgstr ""
 "juiste versie wordt automatisch geselecteerd op basis van de inzendingsdatum"
 " en geldigheidsdatums van de documenttypeversies."
 
-#: openforms/contrib/objects_api/models.py:145
+#: openforms/contrib/objects_api/models.py:150
 msgid "submission report informatieobjecttype"
 msgstr "inzendings PDF document informatieobjecttype"
 
-#: openforms/contrib/objects_api/models.py:149
+#: openforms/contrib/objects_api/models.py:154
 msgid ""
 "Default URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to "
 "be used for the submission report PDF"
@@ -4764,12 +4774,11 @@ msgstr ""
 "URL naar het standaard INFORMATIEOBJECTTYPE in een Catalogi API dat wordt "
 "gebruikt voor het PDF document."
 
-#: openforms/contrib/objects_api/models.py:154
-#: openforms/registrations/contrib/objects_api/config.py:237
+#: openforms/contrib/objects_api/models.py:159
 msgid "submission report CSV informatieobjecttype"
 msgstr "inzendings CSV document informatieobjecttype"
 
-#: openforms/contrib/objects_api/models.py:158
+#: openforms/contrib/objects_api/models.py:163
 msgid ""
 "Default URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to "
 "be used for the submission report CSV"
@@ -4777,12 +4786,11 @@ msgstr ""
 "URL naar het standaard INFORMATIEOBJECTTYPE in een Catalogi API dat wordt "
 "gebruikt voor het CSV document."
 
-#: openforms/contrib/objects_api/models.py:163
-#: openforms/registrations/contrib/objects_api/config.py:246
+#: openforms/contrib/objects_api/models.py:168
 msgid "attachment informatieobjecttype"
 msgstr "bijlage informatieobjecttype"
 
-#: openforms/contrib/objects_api/models.py:167
+#: openforms/contrib/objects_api/models.py:172
 msgid ""
 "Default URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to "
 "be used for the submission attachments"
@@ -4790,19 +4798,19 @@ msgstr ""
 "URL naar het standaard INFORMATIEOBJECTTYPE in een Catalogi API dat wordt "
 "gebruikt voor de bijlagen."
 
-#: openforms/contrib/objects_api/models.py:174
+#: openforms/contrib/objects_api/models.py:179
 msgid "Objects API groups"
 msgstr "Objecten API-groepen"
 
-#: openforms/contrib/objects_api/models.py:180
-#: openforms/registrations/contrib/zgw_apis/models.py:155
+#: openforms/contrib/objects_api/models.py:185
+#: openforms/registrations/contrib/zgw_apis/models.py:157
 msgid ""
 "You must specify both domain and RSIN to uniquely identify a catalogue."
 msgstr ""
 "Je moet het domein én RSIN beide opgeven om een catalogus uniek te "
 "identificeren."
 
-#: openforms/contrib/objects_api/models.py:191
+#: openforms/contrib/objects_api/models.py:196
 msgid ""
 "You must specify a catalogue when specifying the submission report PDF "
 "document type."
@@ -4810,7 +4818,7 @@ msgstr ""
 "Je moet een catalogus aanduiden wanneer je het documenttype voor het PDF-"
 "document opgeeft."
 
-#: openforms/contrib/objects_api/models.py:202
+#: openforms/contrib/objects_api/models.py:207
 msgid ""
 "You must specify a catalogue when specifying the submission report CSV "
 "document type."
@@ -4818,7 +4826,7 @@ msgstr ""
 "Je moet een catalogus aanduiden wanneer je het documenttype voor het CSV-"
 "document opgeeft."
 
-#: openforms/contrib/objects_api/models.py:213
+#: openforms/contrib/objects_api/models.py:218
 msgid ""
 "You must specify a catalogue when specifying the submission attachment "
 "document type."
@@ -4888,7 +4896,7 @@ msgid "A catalogue URL is required when filtering for a case type."
 msgstr "Je moet een catalogus-URL opgeven als je filtert binnen een zaaktype."
 
 #: openforms/contrib/zgw/api/serializers.py:20
-#: openforms/contrib/zgw/serializers.py:25 openforms/multidomain/models.py:28
+#: openforms/contrib/zgw/serializers.py:24 openforms/multidomain/models.py:28
 msgid "domain"
 msgstr "domein"
 
@@ -6160,118 +6168,156 @@ msgstr ""
 msgid "Formio integration"
 msgstr "Form.io-integratie"
 
-#: openforms/formio/components/custom.py:114
+#: openforms/formio/components/custom.py:120
 msgid "dd-mm-yyyy"
 msgstr "dd-mm-jjjj"
 
-#: openforms/formio/components/custom.py:207
+#: openforms/formio/components/custom.py:213
 msgid "dd-mm-yyyy HH:mm"
 msgstr "dd-mm-jjjj HH:mm"
 
-#: openforms/formio/components/custom.py:378
-#: openforms/formio/components/custom.py:1148
+#: openforms/formio/components/custom.py:384
+#: openforms/formio/components/custom.py:1154
 #: openforms/formio/components/vanilla.py:134
 #: openforms/formio/components/vanilla.py:361
 msgid "This value does not match the required pattern."
 msgstr "De waarde komt niet overeen met het verwachte patroon."
 
-#: openforms/formio/components/custom.py:451
+#: openforms/formio/components/custom.py:457
 msgid "Selecting family members is currently not available."
 msgstr "Het selecteren van gezinsleden is momenteel niet beschikbaar."
 
-#: openforms/formio/components/custom.py:565
+#: openforms/formio/components/custom.py:571
 msgid "Derived street name"
 msgstr "Afgeleide straatnaam"
 
-#: openforms/formio/components/custom.py:571
+#: openforms/formio/components/custom.py:577
 msgid "Derived city"
 msgstr "Afgeleide stad"
 
-#: openforms/formio/components/custom.py:603
+#: openforms/formio/components/custom.py:609
 msgid "City does not match the specified pattern."
 msgstr "De stad komt niet overeen met het verwachtte patroon."
 
-#: openforms/formio/components/custom.py:625
+#: openforms/formio/components/custom.py:631
 msgid "Postcode does not match the specified pattern."
 msgstr "De postcode komt niet overeen met het verwachtte patroon."
 
-#: openforms/formio/components/custom.py:652
+#: openforms/formio/components/custom.py:658
 msgid "Invalid secret city - street name combination"
 msgstr "Ongeldige waarde voor sleutel voor de stad/straat-combinatie."
 
-#: openforms/formio/components/custom.py:746
-#: openforms/formio/components/custom.py:889
+#: openforms/formio/components/custom.py:752
+#: openforms/formio/components/custom.py:895
 msgid "bsn"
 msgstr "BSN"
 
-#: openforms/formio/components/custom.py:748
+#: openforms/formio/components/custom.py:754
 msgid "The BSN of the partner"
 msgstr "Het BSN van de partner"
 
-#: openforms/formio/components/custom.py:752
+#: openforms/formio/components/custom.py:758
 msgid "initials"
 msgstr "Initialen"
 
-#: openforms/formio/components/custom.py:753
+#: openforms/formio/components/custom.py:759
 msgid "The initials of the partner"
 msgstr "De initialen van de partner"
 
-#: openforms/formio/components/custom.py:757
+#: openforms/formio/components/custom.py:763
 msgid "affixes"
 msgstr "voorvoegsels"
 
-#: openforms/formio/components/custom.py:758
+#: openforms/formio/components/custom.py:764
 msgid "The affixes of the partner"
 msgstr "De voorvoegsels van de partner"
 
-#: openforms/formio/components/custom.py:763
+#: openforms/formio/components/custom.py:769
 msgid "The last name of the partner"
 msgstr "Achternaam van de partner"
 
-#: openforms/formio/components/custom.py:767
-#: openforms/formio/components/custom.py:900
+#: openforms/formio/components/custom.py:773
+#: openforms/formio/components/custom.py:906
 msgid "date of birth"
 msgstr "Geboortedatum"
 
-#: openforms/formio/components/custom.py:768
+#: openforms/formio/components/custom.py:774
 msgid "The date of birth of the partner"
 msgstr "De geboortedatum van de partner"
 
-#: openforms/formio/components/custom.py:831
-#: openforms/formio/components/custom.py:991
+#: openforms/formio/components/custom.py:837
+#: openforms/formio/components/custom.py:997
 msgid "The family members prefill data may not be altered."
 msgstr "Je mag de familieleden prefill-gegevens niet wijzigen."
 
-#: openforms/formio/components/custom.py:891
+#: openforms/formio/components/custom.py:897
 msgid "The BSN of the child"
 msgstr "Het BSN van het kind"
 
-#: openforms/formio/components/custom.py:895
+#: openforms/formio/components/custom.py:901
 msgid "firstNames"
 msgstr "voornamen"
 
-#: openforms/formio/components/custom.py:896
+#: openforms/formio/components/custom.py:902
 msgid "The first names of the child"
 msgstr "De voornamen  van het kind"
 
-#: openforms/formio/components/custom.py:901
+#: openforms/formio/components/custom.py:907
 msgid "The date of birth of the child"
 msgstr "De geboortedatum van het kind"
 
-#: openforms/formio/components/custom.py:904
+#: openforms/formio/components/custom.py:910
 msgid "selected"
 msgstr "geselecteerd"
 
-#: openforms/formio/components/custom.py:907
+#: openforms/formio/components/custom.py:913
 msgid ""
 "Whether the child is selected by the user or not for further processing"
 msgstr ""
 "Ongeacht of het kind is geselecteerd door de gebruiker voor verdere "
 "behandeling"
 
-#: openforms/formio/components/custom.py:980
+#: openforms/formio/components/custom.py:986
 msgid "Invalid data."
 msgstr "Incorrecte data."
+
+#: openforms/formio/components/custom.py:1197
+#, python-brace-format
+msgid "You cannot submit multiple digital addresses for the type '{type}'."
+msgstr ""
+
+#: openforms/formio/components/custom.py:1208
+msgid "The digital address value."
+msgstr ""
+
+#: openforms/formio/components/custom.py:1211
+#: openforms/forms/api/serializers/logic/action_serializers.py:38
+#: openforms/prefill/contrib/family_members/config.py:49
+#: openforms/submissions/admin.py:45
+msgid "type"
+msgstr "type"
+
+#: openforms/formio/components/custom.py:1213
+#, fuzzy
+#| msgid "The type of the value field"
+msgid "The type of digital address."
+msgstr "Het type van het waardeveld"
+
+#: openforms/formio/components/custom.py:1216
+#, fuzzy
+#| msgid "Public reference template"
+msgid "preference update"
+msgstr "Publiek referentiesjabloon"
+
+#: openforms/formio/components/custom.py:1219
+msgid "Indicates if it is a one-off address or not."
+msgstr ""
+
+#: openforms/formio/components/custom.py:1256
+#, fuzzy
+#| msgid "International phone number"
+msgid "Enter a valid phone number."
+msgstr "Internationaal telefoonnummer"
 
 #: openforms/formio/components/vanilla.py:171
 #, python-brace-format
@@ -6328,21 +6374,21 @@ msgid ""
 msgstr ""
 "Zorg dat dit veld {max_selected_count} of minder opties aangevinkt heeft."
 
-#: openforms/formio/components/vanilla.py:1059
+#: openforms/formio/components/vanilla.py:1062
 #, python-brace-format
 msgid "Expected a list of items but got type \"{input_type}\"."
 msgstr "Een lijst van waarden was verwacht, maar kreeg \"{input_type}\"."
 
-#: openforms/formio/components/vanilla.py:1060
+#: openforms/formio/components/vanilla.py:1063
 msgid "This list may not be empty."
 msgstr "De lijst mag niet leeg zijn."
 
-#: openforms/formio/components/vanilla.py:1061
+#: openforms/formio/components/vanilla.py:1064
 #, python-brace-format
 msgid "Ensure this field has at least {min_length} elements."
 msgstr "Zorg dat dit veld {min_length} of meer waarden heeft."
 
-#: openforms/formio/components/vanilla.py:1062
+#: openforms/formio/components/vanilla.py:1065
 #, python-brace-format
 msgid "Ensure this field has no more than {max_length} elements."
 msgstr "Zorg dat dit veld {max_length} of minder waarden heeft."
@@ -6429,7 +6475,7 @@ msgstr "bijlage: %s"
 msgid "signature added"
 msgstr "handtekening toegevoegd"
 
-#: openforms/formio/registry.py:130
+#: openforms/formio/registry.py:133
 #, python-brace-format
 msgid "{type} component"
 msgstr "{type} component"
@@ -6446,27 +6492,27 @@ msgstr "Weergeven in PDF"
 msgid "Show in confirmation email"
 msgstr "Weergeven in bevestigingsmail"
 
-#: openforms/formio/rendering/default.py:313
+#: openforms/formio/rendering/default.py:314
 msgid "Item"
 msgstr "Item"
 
-#: openforms/formio/rendering/default.py:419
+#: openforms/formio/rendering/default.py:420
 msgid "Partner"
 msgstr "Partner"
 
-#: openforms/formio/rendering/default.py:444
+#: openforms/formio/rendering/default.py:445
 msgid "Affixes"
 msgstr "Voorvoegsels"
 
-#: openforms/formio/rendering/default.py:449
+#: openforms/formio/rendering/default.py:450
 msgid "Lastname"
 msgstr "Achternaam"
 
-#: openforms/formio/rendering/default.py:550
+#: openforms/formio/rendering/default.py:551
 msgid "Child"
 msgstr "Kind"
 
-#: openforms/formio/rendering/default.py:570
+#: openforms/formio/rendering/default.py:571
 msgid "Firstnames"
 msgstr "Voornamen"
 
@@ -6499,93 +6545,95 @@ msgstr "aantal formulieren"
 msgid "Show forms"
 msgstr "Toon formulieren"
 
-#: openforms/forms/admin/form.py:51
+#: openforms/forms/admin/form.py:54
 msgid "has reached submission limit"
 msgstr "status inzendingslimiet"
 
-#: openforms/forms/admin/form.py:56
+#: openforms/forms/admin/form.py:59
 msgid "Available for submission"
 msgstr "Accepteert nieuwe inzendingen"
 
-#: openforms/forms/admin/form.py:57
+#: openforms/forms/admin/form.py:60
 msgid "Unavailable for submission"
 msgstr "Limiet bereikt"
 
-#: openforms/forms/admin/form.py:75
+#: openforms/forms/admin/form.py:78
 msgid "is deleted"
 msgstr "is verwijderd"
 
-#: openforms/forms/admin/form.py:103
+#: openforms/forms/admin/form.py:106
 msgid "Available forms"
 msgstr "Beschikbare formulieren"
 
-#: openforms/forms/admin/form.py:110
+#: openforms/forms/admin/form.py:113
 msgid "Deleted forms"
 msgstr "Verwijderde formulieren"
 
-#: openforms/forms/admin/form.py:265
+#: openforms/forms/admin/form.py:268
 msgid "Show form"
 msgstr "Toon formulier"
 
-#: openforms/forms/admin/form.py:272
+#: openforms/forms/admin/form.py:275
 msgid "Live"
 msgstr "Live"
 
-#: openforms/forms/admin/form.py:296
+#: openforms/forms/admin/form.py:299
+#, python-brace-format
 msgid "{} {} was successfully copied"
 msgstr "{} {} is met succes gekopieerd"
 
-#: openforms/forms/admin/form.py:315
+#: openforms/forms/admin/form.py:334
+#, python-brace-format
 msgid "{} {} was successfully exported"
 msgstr "{} {} is met succes geëxporteerd"
 
-#: openforms/forms/admin/form.py:338
+#: openforms/forms/admin/form.py:357
 #: openforms/forms/admin/form_definition.py:82
 #, python-format
 msgid "Copy selected %(verbose_name_plural)s"
 msgstr "Kopieer geselecteerde %(verbose_name_plural)s"
 
-#: openforms/forms/admin/form.py:346
+#: openforms/forms/admin/form.py:365
 #, python-brace-format
 msgid "Copied {count} {verbose_name} object."
 msgid_plural "Copied {count} {verbose_name} objects."
 msgstr[0] "{count} {verbose_name} object gekopieerd"
 msgstr[1] "{count} {verbose_name}objecten gekopieerd"
 
-#: openforms/forms/admin/form.py:356
+#: openforms/forms/admin/form.py:375
 #, python-format
 msgid "Set selected %(verbose_name_plural)s to maintenance mode"
 msgstr ""
 "Schakel de onderhoudsmodus in voor geselecteerde %(verbose_name_plural)s"
 
-#: openforms/forms/admin/form.py:363
+#: openforms/forms/admin/form.py:382
 #, python-brace-format
 msgid "Set {count} {verbose_name} object to maintenance mode"
 msgid_plural "Set {count} {verbose_name} objects to maintenance mode"
 msgstr[0] "Onderhoudsmodus aangezet voor {count} {verbose_name} object "
 msgstr[1] "Onderhoudsmodus aangezet voor {count} {verbose_name} objecten"
 
-#: openforms/forms/admin/form.py:372
+#: openforms/forms/admin/form.py:391
 #, python-format
 msgid "Remove %(verbose_name_plural)s from maintenance mode"
 msgstr ""
 "Schakel de onderhoudsmodus uit voor geselecteerde %(verbose_name_plural)s."
 
-#: openforms/forms/admin/form.py:378
+#: openforms/forms/admin/form.py:397
 #, python-brace-format
 msgid "Removed {count} {verbose_name} object from maintenance mode"
 msgid_plural "Removed {count} {verbose_name} objects from maintenance mode"
 msgstr[0] "Onderhoudsmodus uitgezet voor {count} {verbose_name} object"
 msgstr[1] "Onderhoudsmodus uitgezet voor {count} {verbose_name} objecten"
 
-#: openforms/forms/admin/form.py:427
-#: openforms/forms/templates/admin/forms/form/export.html:14
-#: openforms/forms/templates/admin/forms/form/export.html:18
-#: openforms/forms/templates/admin/forms/form/export.html:21
+#: openforms/forms/admin/form.py:446
+#: openforms/forms/templates/admin/forms/form/export.html:15
+#: openforms/forms/templates/admin/forms/form/export.html:19
+#: openforms/forms/templates/admin/forms/form/export.html:22
 msgid "Export forms"
 msgstr "Formulieren exporteren"
 
-#: openforms/forms/admin/form.py:433
+#: openforms/forms/admin/form.py:452
 msgid ""
 "Please configure your email address in your admin profile before requesting "
 "a bulk export"
@@ -6617,27 +6665,68 @@ msgstr "ingezonden tussen"
 msgid "Red"
 msgstr "Rood"
 
-#: openforms/forms/admin/tasks.py:70
+#: openforms/forms/admin/tasks.py:74
 msgid "Forms export ready"
 msgstr "Export formulieren gereed"
 
-#: openforms/forms/admin/views.py:39
+#: openforms/forms/admin/views.py:43
+#| msgid "Form.io configuration"
+msgid "Anonymize form configuration"
+msgstr "Formulierconfiguratie anonimiseren"
+
+#: openforms/forms/admin/views.py:47
+#: openforms/forms/api/serializers/form.py:666
+#| msgid ""
+#| "Whether the step progression should be displayed in the UI or not."
+msgid ""
+"Whether sensative form configuration should be anonymized during exporting."
+msgstr ""
+"Geeft aan of gevoelige informatie bij het exporteren automatisch "
+"geanonimiseerd worden."
+
+#: openforms/forms/admin/views.py:51
+#| msgid "Form.io configuration"
+msgid "Form configuration"
+msgstr "Formulierconfiguratie"
+
+#: openforms/forms/admin/views.py:61
+#: openforms/forms/api/serializers/form.py:673
+msgid ""
+"Which form configuration should be included in the export file content."
+msgstr "Welke formulierconfiguratie meegenomen worden bij het exporteren."
+
+#: openforms/forms/admin/views.py:65
+#| msgid "Organization configuration"
+msgid "Additional form configuration"
+msgstr "Ondersteunende formulierconfiguratie"
+
+#: openforms/forms/admin/views.py:70
+#: openforms/forms/api/serializers/form.py:680
+msgid ""
+"Which additional form configuration should be included in the export file "
+"content."
+msgstr ""
+"Welke ondersteunende formulierconfiguratie meegenomen worden bij het "
+"exporteren."
+
+#: openforms/forms/admin/views.py:76
 msgid "Invalid form uuids."
 msgstr "Ongeldige formulier-IDs."
 
-#: openforms/forms/admin/views.py:52
+#: openforms/forms/admin/views.py:89
 msgid "Success! You will receive an email when your export is ready."
 msgstr "Gelukt! U ontvangt een e-mail zodra de export gereed is."
 
-#: openforms/forms/admin/views.py:98
+#: openforms/forms/admin/views.py:146
+#, python-brace-format
 msgid "Something went wrong while importing form: {}"
 msgstr "Er is iets foutgegaan bij het importeren van formulier: {}"
 
-#: openforms/forms/admin/views.py:111
+#: openforms/forms/admin/views.py:159
 msgid "Form successfully imported!"
 msgstr "Formulier is succesvol geïmporteerd"
 
-#: openforms/forms/admin/views.py:113
+#: openforms/forms/admin/views.py:161
 msgid ""
 "The bulk import is being processed! The imported forms will soon be "
 "available."
@@ -6650,7 +6739,7 @@ msgid "UUID of the form the definition is used in."
 msgstr "UUID van het formulier waarin de definitie gebruikt wordt."
 
 #: openforms/forms/api/public_api/views.py:17
-#: openforms/forms/api/viewsets.py:228
+#: openforms/forms/api/viewsets.py:230
 msgid "List forms"
 msgstr "Formulieren weergeven"
 
@@ -6663,21 +6752,21 @@ msgstr ""
 "informatie. Formulieren die als \"verwijderd\" gemarkeerd zijn, komen niet "
 "terug."
 
-#: openforms/forms/api/serializers/form.py:70
+#: openforms/forms/api/serializers/form.py:74
 #: openforms/forms/models/form_authentication_backend.py:21
 msgid "authentication backend options"
 msgstr "authenticatie-backend-instellingen"
 
-#: openforms/forms/api/serializers/form.py:95
+#: openforms/forms/api/serializers/form.py:99
 #: openforms/forms/models/form_registration_backend.py:29
 msgid "registration backend options"
 msgstr "registratie backend opties"
 
-#: openforms/forms/api/serializers/form.py:152
+#: openforms/forms/api/serializers/form.py:156
 msgid "cosign request has links in email"
 msgstr "mede-ondertekenenverzoek-e-mail bevat links"
 
-#: openforms/forms/api/serializers/form.py:154
+#: openforms/forms/api/serializers/form.py:158
 msgid ""
 "Indicates whether deep links are included in the cosign request emails or "
 "not."
@@ -6685,7 +6774,7 @@ msgstr ""
 "Geeft aan of er links gebruikt worden in de e-mail voor mede-"
 "ondertekenverzoek."
 
-#: openforms/forms/api/serializers/form.py:162
+#: openforms/forms/api/serializers/form.py:166
 msgid ""
 "The authentication backend to which the user will be automatically "
 "redirected upon starting the form. The chosen backend must be present in "
@@ -6695,45 +6784,45 @@ msgstr ""
 "bij het starten van het formulier. De gekozen plugin moet aanwezig zijn in "
 "`auth_backends`"
 
-#: openforms/forms/api/serializers/form.py:169
+#: openforms/forms/api/serializers/form.py:173
 #: openforms/forms/models/category.py:19
 msgid "category"
 msgstr "categorie"
 
-#: openforms/forms/api/serializers/form.py:175
+#: openforms/forms/api/serializers/form.py:179
 msgid "URL to the category in the Open Forms API"
 msgstr "URL naar de formuliercategorie in de Open Forms API"
 
-#: openforms/forms/api/serializers/form.py:184
+#: openforms/forms/api/serializers/form.py:188
 msgid "URL to the theme in the Open Forms API"
 msgstr "URL naar de stijl in de Open Forms API"
 
-#: openforms/forms/api/serializers/form.py:187
+#: openforms/forms/api/serializers/form.py:191
 msgid "product"
 msgstr "product"
 
-#: openforms/forms/api/serializers/form.py:193
+#: openforms/forms/api/serializers/form.py:197
 msgid "URL to the product in the Open Forms API"
 msgstr "URL van het product in de Open Formulieren API"
 
-#: openforms/forms/api/serializers/form.py:201
+#: openforms/forms/api/serializers/form.py:205
 #: openforms/forms/models/form.py:133
 msgid "payment backend options"
 msgstr "betaalprovider backend opties"
 
-#: openforms/forms/api/serializers/form.py:223
+#: openforms/forms/api/serializers/form.py:227
 msgid "Resume link lifetime"
 msgstr "Geldigheidsduur \"formulier hervatten\"-link"
 
-#: openforms/forms/api/serializers/form.py:225
+#: openforms/forms/api/serializers/form.py:229
 msgid "The number of days that the resume link is valid for."
 msgstr "Het aantal dagen dat de link geldig blijft."
 
-#: openforms/forms/api/serializers/form.py:233
+#: openforms/forms/api/serializers/form.py:237
 msgid "submission statements configuration"
 msgstr "Verklaringenconfiguratie voor inzending"
 
-#: openforms/forms/api/serializers/form.py:235
+#: openforms/forms/api/serializers/form.py:239
 msgid ""
 "A list of statements that need to be accepted by the user before they can "
 "submit a form. Returns a list of formio component definitions, all of type "
@@ -6743,7 +6832,7 @@ msgstr ""
 " te kunnen inzenden. Deze worden teruggegeven als lijst van Form.io-"
 "componentdefinities, allemaal van het type 'checkbox'."
 
-#: openforms/forms/api/serializers/form.py:570
+#: openforms/forms/api/serializers/form.py:574
 msgid ""
 "The `auto_login_authentication_backend` must be one of the selected backends"
 " from `auth_backends`"
@@ -6751,39 +6840,39 @@ msgstr ""
 "De `auto_login_authentication_backend` moet één van de backends uit "
 "`auth_backends` zijn."
 
-#: openforms/forms/api/serializers/form.py:671
+#: openforms/forms/api/serializers/form.py:687
 msgid "The file that contains the form, form definitions and form steps."
 msgstr ""
 "Het bestand dat het formulier, de formulierdefinities en de formulierstappen"
 " bevat."
 
-#: openforms/forms/api/serializers/form.py:676
+#: openforms/forms/api/serializers/form.py:692
 msgid "The uuid of the imported form."
 msgstr "ID van het geïmporteerde formulier."
 
-#: openforms/forms/api/serializers/form.py:681
+#: openforms/forms/api/serializers/form.py:697
 msgid "Registration backend key"
 msgstr "Registratiebackend-sleutel"
 
-#: openforms/forms/api/serializers/form.py:683
+#: openforms/forms/api/serializers/form.py:699
 msgid "The registration backend key for which to generate the schema."
 msgstr ""
 "De registratiebackend-sleutel waarvoor het schema moet worden gegenereerd."
 
-#: openforms/forms/api/serializers/form.py:688
+#: openforms/forms/api/serializers/form.py:704
 msgid "Registration backend identifier"
 msgstr "Registratiebackend-identificatie"
 
-#: openforms/forms/api/serializers/form.py:693
+#: openforms/forms/api/serializers/form.py:709
 msgid "Registration backend options"
 msgstr "Registratiebackend-instellingen"
 
-#: openforms/forms/api/serializers/form.py:705
+#: openforms/forms/api/serializers/form.py:721
 #, python-brace-format
 msgid "Backend with key '{key}' does not exist for form '{form}'"
 msgstr "Backend met sleutel '{key}' bestaat niet voor formulier '{form}'"
 
-#: openforms/forms/api/serializers/form.py:722
+#: openforms/forms/api/serializers/form.py:738
 #, python-brace-format
 msgid "Backend with id '{backend}' does not allow JSON schema generation"
 msgstr ""
@@ -6829,23 +6918,23 @@ msgstr "admin URL"
 msgid "Link to the change/view page in the admin interface"
 msgstr "Link naar de wijzigen/weergave pagina in de beheeromgeving"
 
-#: openforms/forms/api/serializers/form_definition.py:71
+#: openforms/forms/api/serializers/form_definition.py:72
 #: openforms/forms/api/v3/serializers/form_definition.py:29
 #: openforms/forms/models/form_definition.py:49
 msgid "Form.io configuration"
 msgstr "Form.io configuratie"
 
-#: openforms/forms/api/serializers/form_definition.py:72
+#: openforms/forms/api/serializers/form_definition.py:73
 #: openforms/forms/api/v3/serializers/form_definition.py:30
 #: openforms/forms/models/form_definition.py:50
 msgid "The form definition as Form.io JSON schema"
 msgstr "De formulierdefinitie als Form.io JSON schema"
 
-#: openforms/forms/api/serializers/form_definition.py:163
+#: openforms/forms/api/serializers/form_definition.py:162
 msgid "Used in forms"
 msgstr "Gebruikt in formulieren"
 
-#: openforms/forms/api/serializers/form_definition.py:165
+#: openforms/forms/api/serializers/form_definition.py:164
 msgid ""
 "The collection of forms making use of this definition. This includes both "
 "active and inactive forms."
@@ -6921,12 +7010,6 @@ msgid "The Form.io component property to alter, identified by `component.key`"
 msgstr ""
 "Het Form.io component attribute dat gewijzigd moet worden, geïdentificeerd "
 "door `component.key`"
-
-#: openforms/forms/api/serializers/logic/action_serializers.py:38
-#: openforms/prefill/contrib/family_members/config.py:49
-#: openforms/submissions/admin.py:45
-msgid "type"
-msgstr "type"
 
 #: openforms/forms/api/serializers/logic/action_serializers.py:39
 msgid "The type of the value field"
@@ -7094,29 +7177,29 @@ msgstr ""
 msgid "Invalid form step specified in logic action."
 msgstr "Ongeldige formulierstapverwijzing."
 
-#: openforms/forms/api/serializers/logic/form_logic.py:36
+#: openforms/forms/api/serializers/logic/form_logic.py:39
 msgid "Appointment forms cannot have logic rules."
 msgstr "Afspraakformulieren kunnen geen logicaregels bevatten."
 
-#: openforms/forms/api/serializers/logic/form_logic.py:62
+#: openforms/forms/api/serializers/logic/form_logic.py:65
 #, python-brace-format
 msgid "Rule contains cycles through variable(s): {variables}."
 msgstr ""
 "De regel bevat verwijzingen naar zichzelf, via de variabele(n): {variables}."
 
-#: openforms/forms/api/serializers/logic/form_logic.py:131
-#: openforms/submissions/api/serializers.py:243
+#: openforms/forms/api/serializers/logic/form_logic.py:134
+#: openforms/submissions/api/serializers.py:246
 msgid "Actions triggered when the trigger expression evaluates to 'truthy'."
 msgstr ""
 "Acties die worden geactiveerd wanneer de trigger-expressie wordt geëvalueerd"
 " als 'truthy'."
 
-#: openforms/forms/api/serializers/logic/form_logic.py:140
+#: openforms/forms/api/serializers/logic/form_logic.py:143
 #: openforms/forms/models/form_step.py:85 openforms/forms/models/logic.py:36
 msgid "form steps"
 msgstr "formulierstappen"
 
-#: openforms/forms/api/serializers/logic/form_logic.py:142
+#: openforms/forms/api/serializers/logic/form_logic.py:145
 msgid ""
 "Form steps on which the rule will be executed, determined by logic rule "
 "analysis."
@@ -7124,7 +7207,7 @@ msgstr ""
 "Formulierstappen waarop de logicaregel wordt toegepast, bepaald door de "
 "logicaregel-analyse."
 
-#: openforms/forms/api/serializers/logic/form_logic.py:165
+#: openforms/forms/api/serializers/logic/form_logic.py:168
 msgid ""
 "The trigger expression to determine if the actions should execute or not. "
 "Note that this must be a valid JsonLogic expression, and the first operand "
@@ -7134,7 +7217,7 @@ msgstr ""
 "op dat dit een valide JSON-logic expressie moet zijn en de eerste operand "
 "moet een verwijzing zijn naar een variabele in het formulier."
 
-#: openforms/forms/api/serializers/logic/form_logic.py:179
+#: openforms/forms/api/serializers/logic/form_logic.py:182
 msgid ""
 "Order of the rule relative to the form it belongs to. Logic rules are "
 "evaluated in this order. Note that specifying a value for the order here "
@@ -7232,39 +7315,39 @@ msgstr "Afspraakformulieren vereisen de configuratie van een afspraakplugin."
 msgid "There are template syntax errors in the expression."
 msgstr "Er zijn sjabloonsyntaxfouten in de expressie."
 
-#: openforms/forms/api/viewsets.py:78 openforms/forms/api/viewsets.py:220
+#: openforms/forms/api/viewsets.py:80 openforms/forms/api/viewsets.py:222
 msgid "Either a UUID4 or a slug identifiying the form."
 msgstr "Een UUID4 of een slug die het formulier identificeert."
 
-#: openforms/forms/api/viewsets.py:83
+#: openforms/forms/api/viewsets.py:85
 msgid "List form steps"
 msgstr "Formulierstappen weergeven"
 
-#: openforms/forms/api/viewsets.py:84
+#: openforms/forms/api/viewsets.py:86
 msgid "Retrieve form step details"
 msgstr "Formulierstap details weergeven"
 
-#: openforms/forms/api/viewsets.py:85
+#: openforms/forms/api/viewsets.py:87
 msgid "Create a form step"
 msgstr "Formulierstap aanmaken"
 
-#: openforms/forms/api/viewsets.py:86
+#: openforms/forms/api/viewsets.py:88
 msgid "Update all details of a form step"
 msgstr "Formulierstap in zijn geheel bijwerken"
 
-#: openforms/forms/api/viewsets.py:87
+#: openforms/forms/api/viewsets.py:89
 msgid "Update some details of a form step"
 msgstr "Formulierstap gedeeltelijk bijwerken"
 
-#: openforms/forms/api/viewsets.py:88
+#: openforms/forms/api/viewsets.py:90
 msgid "Delete a form step"
 msgstr "Formulierstap verwijderen"
 
-#: openforms/forms/api/viewsets.py:131
+#: openforms/forms/api/viewsets.py:133
 msgid "List form step definitions"
 msgstr "Formulierstap definities weergeven"
 
-#: openforms/forms/api/viewsets.py:133
+#: openforms/forms/api/viewsets.py:135
 #, python-brace-format
 msgid ""
 "Get a list of existing form definitions, where a single item may be a re-usable or single-use definition. This includes form definitions not currently used in any form(s) at all.\n"
@@ -7291,31 +7374,31 @@ msgstr ""
 "\n"
 "{admin_fields}"
 
-#: openforms/forms/api/viewsets.py:148
+#: openforms/forms/api/viewsets.py:150
 msgid "Retrieve form step definition details"
 msgstr "Formulierstap definitie details weergeven"
 
-#: openforms/forms/api/viewsets.py:152
+#: openforms/forms/api/viewsets.py:154
 msgid "Create a form definition"
 msgstr "Formulierdefinitie toevoegen"
 
-#: openforms/forms/api/viewsets.py:156
+#: openforms/forms/api/viewsets.py:158
 msgid "Update all details of a form definition"
 msgstr "Formulierdefinitie in zijn geheel bijwerken"
 
-#: openforms/forms/api/viewsets.py:160
+#: openforms/forms/api/viewsets.py:162
 msgid "Update some details of a form definition"
 msgstr "formulierdefinitie gedeeltelijk bijwerken"
 
-#: openforms/forms/api/viewsets.py:164
+#: openforms/forms/api/viewsets.py:166
 msgid "Delete a form definition"
 msgstr "Verwijder een formulierdefinitie"
 
-#: openforms/forms/api/viewsets.py:195
+#: openforms/forms/api/viewsets.py:197
 msgid "Retrieve form definition JSON schema"
 msgstr "Formulierdefinitie JSON schema weergeven"
 
-#: openforms/forms/api/viewsets.py:230
+#: openforms/forms/api/viewsets.py:232
 #, python-brace-format
 msgid ""
 "List the active forms, including the pointers to the form steps. Form steps are included in order as they should appear.\n"
@@ -7334,18 +7417,18 @@ msgstr ""
 "\n"
 "{admin_fields}"
 
-#: openforms/forms/api/viewsets.py:239
+#: openforms/forms/api/viewsets.py:241
 msgid "Retrieve form details"
 msgstr "Formulier details weergeven"
 
-#: openforms/forms/api/viewsets.py:247
+#: openforms/forms/api/viewsets.py:249
 msgid ""
 "If used, then all authorization methods are visible when the form starts"
 msgstr ""
 "Indien gebruikt, zijn alle autorisatieopties zichtbaar wanneer het formulier"
 " wordt gestart."
 
-#: openforms/forms/api/viewsets.py:253
+#: openforms/forms/api/viewsets.py:255
 #, python-brace-format
 msgid ""
 "Retrieve the details/configuration of a particular form. \n"
@@ -7372,23 +7455,23 @@ msgstr ""
 "\n"
 "Wanneer meertaligheid niet ingeschakeld is voor het formulier, dan wordt de standaardtaal (`settings.LANGUAGE_CODE`) geforceerd gezet in een language cookie. De actieve taal wordt gecommuniceerd in de Content-Language response header. De gebruikelijke HTTP Content Negotiation principes zijn van toepassing."
 
-#: openforms/forms/api/viewsets.py:267
+#: openforms/forms/api/viewsets.py:269
 msgid "Create form"
 msgstr "Formulier aanmaken"
 
-#: openforms/forms/api/viewsets.py:269
+#: openforms/forms/api/viewsets.py:271
 msgid "Update all details of a form"
 msgstr "Formulier in zijn geheel bijwerken"
 
-#: openforms/forms/api/viewsets.py:273
+#: openforms/forms/api/viewsets.py:275
 msgid "Update given details of a form"
 msgstr "Formulier gedeeltelijk bijwerken"
 
-#: openforms/forms/api/viewsets.py:277
+#: openforms/forms/api/viewsets.py:279
 msgid "Mark form as deleted"
 msgstr "Formulier markeren als verwijderd"
 
-#: openforms/forms/api/viewsets.py:279
+#: openforms/forms/api/viewsets.py:281
 msgid ""
 "Destroying a form leads to a soft-delete to protect related submissions. "
 "These deleted forms are no longer visible in the API endpoints."
@@ -7397,11 +7480,11 @@ msgstr ""
 "verwijderd om gerelateerde inzendingen te beschermen. Formulieren die "
 "gemarkeerd zijn als verwijderd komen niet meer in de API naar voren."
 
-#: openforms/forms/api/viewsets.py:285
+#: openforms/forms/api/viewsets.py:287
 msgid "Bulk configure form variables"
 msgstr "Configureer formuliervariabelen in bulk"
 
-#: openforms/forms/api/viewsets.py:287
+#: openforms/forms/api/viewsets.py:289
 msgid ""
 "By sending a list of FormVariables to this endpoint, all the FormVariables "
 "related to the form will be replaced with the data sent to the endpoint."
@@ -7409,11 +7492,11 @@ msgstr ""
 "Alle variabelen van het formulier worden vervangen met de toegestuurde "
 "variabelen."
 
-#: openforms/forms/api/viewsets.py:302
+#: openforms/forms/api/viewsets.py:304
 msgid "Bulk configure logic rules"
 msgstr "Configureer logicaregels in bulk"
 
-#: openforms/forms/api/viewsets.py:304
+#: openforms/forms/api/viewsets.py:306
 msgid ""
 "By sending a list of LogicRules to this endpoint, all the LogicRules related"
 " to the form will be replaced with the data sent to the endpoint."
@@ -7421,60 +7504,60 @@ msgstr ""
 "Alle logicaregels van het formulier worden vervangen met de toegestuurde "
 "regels."
 
-#: openforms/forms/api/viewsets.py:413
+#: openforms/forms/api/viewsets.py:415
 msgid "Export form"
 msgstr "Formulier exporteren"
 
-#: openforms/forms/api/viewsets.py:448
+#: openforms/forms/api/viewsets.py:470
 msgid "Prepare form edit admin message"
 msgstr "Admin berichten voor formulier bewerken voorbereiden"
 
-#: openforms/forms/api/viewsets.py:540
+#: openforms/forms/api/viewsets.py:562
 msgid "List form variables"
 msgstr "Formuliervariabelen weergeven"
 
-#: openforms/forms/api/viewsets.py:541
+#: openforms/forms/api/viewsets.py:563
 msgid "List all variables defined for a form."
 msgstr "Geef alle variabelen terug die bij een formulier horen"
 
-#: openforms/forms/api/viewsets.py:554
+#: openforms/forms/api/viewsets.py:576
 msgid "Filter by form variable source"
 msgstr "Filteren op oorsprong formuliervariabele"
 
-#: openforms/forms/api/viewsets.py:611
+#: openforms/forms/api/viewsets.py:633
 msgid "List logic rules"
 msgstr "Logicaregels weergeven"
 
-#: openforms/forms/api/viewsets.py:612
+#: openforms/forms/api/viewsets.py:634
 msgid "List all logic rules defined for a form."
 msgstr "Geef een lijst van alle logicaregels van een formulier."
 
-#: openforms/forms/api/viewsets.py:638
+#: openforms/forms/api/viewsets.py:660
 msgid "Generate the JSON schema for a form."
 msgstr "Genereer een JSON-schema voor een formulier."
 
-#: openforms/forms/api/viewsets.py:685 openforms/forms/api/viewsets.py:702
-#: openforms/forms/api/viewsets.py:721
+#: openforms/forms/api/viewsets.py:707 openforms/forms/api/viewsets.py:724
+#: openforms/forms/api/viewsets.py:743
 msgid "Either a UUID4 or a slug identifying the form."
 msgstr "Een UUID4 of een slug die het formulier identificeert."
 
-#: openforms/forms/api/viewsets.py:691
+#: openforms/forms/api/viewsets.py:713
 msgid "Save form version"
 msgstr "Formulierversie opslaan"
 
-#: openforms/forms/api/viewsets.py:695
+#: openforms/forms/api/viewsets.py:717
 msgid "Restore form version"
 msgstr "Formulierversie terugzetten"
 
-#: openforms/forms/api/viewsets.py:708
+#: openforms/forms/api/viewsets.py:730
 msgid "The UUID of the form version"
 msgstr "Het UUID van de formulierversie"
 
-#: openforms/forms/api/viewsets.py:714
+#: openforms/forms/api/viewsets.py:736
 msgid "List form versions"
 msgstr "Formulierversies weergeven"
 
-#: openforms/forms/api/viewsets.py:762
+#: openforms/forms/api/viewsets.py:784
 #: openforms/forms/templates/admin/forms/form/import_form.html:15
 #: openforms/forms/templates/admin/forms/form/import_form.html:20
 msgid "Import form"
@@ -7616,7 +7699,7 @@ msgid "Export form submission that were submitted before or on this date."
 msgstr "Exporteer inzendingen die op of voor deze datum ingestuurd zijn."
 
 #: openforms/forms/forms/form_statistics.py:72
-#: openforms/forms/templates/admin/forms/form/export.html:13
+#: openforms/forms/templates/admin/forms/form/export.html:14
 #: openforms/forms/templates/admin/forms/form/import_form.html:14
 #: openforms/forms/templates/admin/forms/form/migrate-payment-backend.html:19
 msgid "Forms"
@@ -8071,35 +8154,35 @@ msgstr "{slug}-kopie"
 msgid "Restored form version {version} (from {created})."
 msgstr "Formulierversie {version} hersteld (van {created})."
 
-#: openforms/forms/models/form.py:827
+#: openforms/forms/models/form.py:830
 msgid "export content"
 msgstr "Exportinhoud"
 
-#: openforms/forms/models/form.py:829
+#: openforms/forms/models/form.py:832
 msgid "Zip file containing all the exported forms."
 msgstr "Het ZIP-bestand met daarin alle geëxporteerde formulieren."
 
-#: openforms/forms/models/form.py:832
+#: openforms/forms/models/form.py:835
 msgid "date time requested"
 msgstr "Moment van aanvraag"
 
-#: openforms/forms/models/form.py:833
+#: openforms/forms/models/form.py:836
 msgid "The date and time on which the bulk export was requested."
 msgstr "De datum en tijdstip waarop de bulk export aangevraagd is."
 
-#: openforms/forms/models/form.py:839
+#: openforms/forms/models/form.py:842
 msgid "The user that requested the download."
 msgstr "De gebruiker die de download heeft aangevraagd."
 
-#: openforms/forms/models/form.py:846
+#: openforms/forms/models/form.py:849
 msgid "forms export"
 msgstr "formulierenexport"
 
-#: openforms/forms/models/form.py:847
+#: openforms/forms/models/form.py:850
 msgid "forms exports"
 msgstr "Formulierexports"
 
-#: openforms/forms/models/form.py:850
+#: openforms/forms/models/form.py:853
 #, python-format
 msgid "Bulk export requested by %(username)s on %(datetime)s"
 msgstr "Bulk-export aangevraagd door %(username)s op %(datetime)s"
@@ -8157,7 +8240,7 @@ msgstr ""
 
 #: openforms/forms/models/form_registration_backend.py:18
 #: openforms/forms/models/form_variable.py:261
-#: openforms/submissions/models/submission_value_variable.py:447
+#: openforms/submissions/models/submission_value_variable.py:454
 msgid "key"
 msgstr "sleutel"
 
@@ -8247,7 +8330,7 @@ msgid "Key of the variable, should be unique with the form."
 msgstr "Sleutel van de variabele, uniek binnen het formulier."
 
 #: openforms/forms/models/form_variable.py:266
-#: openforms/submissions/models/submission_value_variable.py:458
+#: openforms/submissions/models/submission_value_variable.py:465
 msgid "source"
 msgstr "bron"
 
@@ -8298,22 +8381,22 @@ msgid "prefill options"
 msgstr "prefillopties"
 
 #: openforms/forms/models/form_variable.py:310
-#: openforms/submissions/models/submission_value_variable.py:489
+#: openforms/submissions/models/submission_value_variable.py:496
 msgid "data type"
 msgstr "datatype"
 
 #: openforms/forms/models/form_variable.py:311
-#: openforms/submissions/models/submission_value_variable.py:490
+#: openforms/submissions/models/submission_value_variable.py:497
 msgid "The type of the value that will be associated with this variable"
 msgstr "Datatype van de waarden voor deze variabele"
 
 #: openforms/forms/models/form_variable.py:316
-#: openforms/submissions/models/submission_value_variable.py:495
+#: openforms/submissions/models/submission_value_variable.py:502
 msgid "data subtype"
 msgstr "data subtype"
 
 #: openforms/forms/models/form_variable.py:318
-#: openforms/submissions/models/submission_value_variable.py:497
+#: openforms/submissions/models/submission_value_variable.py:504
 msgid ""
 "This field represents the data type of the values inside the container for "
 "components that are configured as 'multiple'."
@@ -8493,7 +8576,7 @@ msgstr "Afgeronde inzendingen van {start} tot en met {end}"
 #: openforms/forms/statistics.py:52
 #: openforms/registrations/contrib/generic_json/registration_variables.py:27
 #: openforms/registrations/contrib/objects_api/registration_variables.py:31
-#: openforms/submissions/api/serializers.py:650
+#: openforms/submissions/api/serializers.py:649
 msgid "Public reference"
 msgstr "Publieke referentie"
 
@@ -8534,17 +8617,28 @@ msgstr "Sorteren in/uitschakelen"
 msgid "Forms without category"
 msgstr "Formulieren zonder categorie"
 
-#: openforms/forms/templates/admin/forms/form/export.html:24
+#: openforms/forms/templates/admin/forms/form/export.html:34
 msgid ""
-"\n"
-"            Once your request has been processed, you will be sent an email (at the address configured in your admin\n"
-"            profile) containing a link where you can download a zip file with all the exported forms.\n"
-"            "
+"<p> Here you can control how the previously selected forms will be exported."
+" Using these options, sensitive information can be anonymized, certain form "
+"configuration can be left out, and additional information can be included. "
+"</p> <p> These export options will be used for each form that will be "
+"exported. </p> <p> After you've clicked the \"Export\" button, the forms "
+"will be exported in the background. <br/> Once your request has been "
+"processed, you will be sent an email (at the address configured in your "
+"admin profile) containing a link where you can download a zip file with all "
+"the exported forms. </p>"
 msgstr ""
-"\n"
-"Zodra uw verzoek verwerkt is, ontvangt u een e-mail met een link naar het ZIP-bestand dat alle geëxporteerde formulieren bevat."
+"<p>Hier kan je bepalen hoe de eerder geselecteerde formuliere geëxporteerd "
+"worden. Met deze opties kan gevoelige informatie geanonimiseerd worden, "
+"kunnen formulierinstellingen uitgesloten worden en ondersteunende gegevens "
+"toegevoegd worden. </p><p>Deze exporteeropties worden gebruikt voor ieder "
+"formulier dat geëxporteerd zal worden. </p><p> Nadat je op de \"Export\" "
+"knop hebt gedrukt, worden de formulieren in de achtergrond geëxporteerd. "
+"<br/> Zodra uw verzoek verwerkt is, ontvangt u een e-mail met een link naar "
+"het ZIP-bestand dat alle geëxporteerde formulieren bevat.</p>"
 
-#: openforms/forms/templates/admin/forms/form/export.html:41
+#: openforms/forms/templates/admin/forms/form/export.html:72
 #: openforms/forms/templates/admin/forms/formsubmissionstatistics/export_form.html:62
 msgid "Export"
 msgstr "Exporteren"
@@ -8668,6 +8762,55 @@ msgid ""
 msgstr ""
 "De component  '{key}' (op JSON-pad '{path}') heeft sjabloonsyntaxfouten in "
 "het veld '{field}'."
+
+#: openforms/import_export/typing.py:11
+#| msgid "Registration backend"
+msgid "Registration backends"
+msgstr "Registratiebackends"
+
+#: openforms/import_export/typing.py:12 openforms/prefill/apps.py:7
+#: openforms/submissions/constants.py:52
+msgid "Prefill"
+msgstr "Prefill"
+
+#: openforms/import_export/typing.py:13 openforms/payments/models.py:105
+msgid "Payment backend"
+msgstr "Betaalprovider backend"
+
+#: openforms/import_export/typing.py:14
+#| msgid "authentication backends"
+msgid "Authentication backends"
+msgstr "Inlogmethoden"
+
+#: openforms/import_export/typing.py:30
+#: openforms/products/models/product.py:43
+msgid "Product"
+msgstr "Product"
+
+#: openforms/import_export/typing.py:31
+#| msgid "WMS layers"
+msgid "WMS-tile layers"
+msgstr "WMS-kaartlagen"
+
+#: openforms/import_export/typing.py:32
+#| msgid "WMS layers"
+msgid "WMTS-tile layers"
+msgstr "WMTS-kaartlagen"
+
+#: openforms/import_export/typing.py:33
+#| msgid "yivi attribute groups"
+msgid "Yivi attribute groups"
+msgstr "Yivi-attribuutgroepen"
+
+#: openforms/import_export/typing.py:34
+#| msgid "Themes"
+msgid "Theme"
+msgstr "Stijl"
+
+#: openforms/import_export/typing.py:35
+#| msgid "category"
+msgid "Category"
+msgstr "Categorie"
 
 #: openforms/logging/apps.py:7
 msgid "Logging"
@@ -9567,10 +9710,6 @@ msgid ""
 msgstr ""
 "[Open Formulieren] {form_name} - betaling ontvangen {public_reference}"
 
-#: openforms/payments/models.py:105
-msgid "Payment backend"
-msgstr "Betaalprovider backend"
-
 #: openforms/payments/models.py:107
 msgid "Payment options"
 msgstr "Betaalopties"
@@ -9861,10 +10000,6 @@ msgstr "Lijst van beschikbare attributen"
 msgid "No plugin with ID '{plugin}' found"
 msgstr "Geen plugin met ID '{plugin}' gevonden"
 
-#: openforms/prefill/apps.py:7 openforms/submissions/constants.py:52
-msgid "Prefill"
-msgstr "Prefill"
-
 #: openforms/prefill/constants.py:6
 msgid "Main"
 msgstr "Main/machtiger"
@@ -9931,7 +10066,7 @@ msgstr "Communicatievoorkeuren (klantinteracties API)"
 #: openforms/prefill/contrib/customer_interactions/plugin.py:107
 #: openforms/prefill/contrib/objects_api/plugin.py:88
 #: openforms/registrations/contrib/objects_api/plugin.py:155
-#: openforms/registrations/contrib/zgw_apis/plugin.py:882
+#: openforms/registrations/contrib/zgw_apis/plugin.py:862
 msgid "Manage API groups"
 msgstr "API-groepen beheren"
 
@@ -10291,22 +10426,22 @@ msgstr "Antwoord is geen object"
 #: openforms/prefill/contrib/objects_api/api/serializers.py:41
 #: openforms/prefill/contrib/objects_api/api/serializers.py:78
 #: openforms/registrations/contrib/objects_api/api/serializers.py:10
-#: openforms/registrations/contrib/objects_api/config.py:54
-#: openforms/registrations/contrib/objects_api/config.py:163
+#: openforms/registrations/contrib/objects_api/config.py:51
+#: openforms/registrations/contrib/objects_api/config.py:157
 msgid "Segment of a JSON path"
 msgstr "Segment van een JSON-pad"
 
 #: openforms/prefill/contrib/objects_api/api/serializers.py:17
 #: openforms/prefill/contrib/objects_api/api/serializers.py:42
 #: openforms/registrations/contrib/objects_api/api/serializers.py:11
-#: openforms/registrations/contrib/objects_api/config.py:55
+#: openforms/registrations/contrib/objects_api/config.py:52
 msgid "target path"
 msgstr "bestemmingspad"
 
 #: openforms/prefill/contrib/objects_api/api/serializers.py:19
 #: openforms/prefill/contrib/objects_api/api/serializers.py:44
 #: openforms/registrations/contrib/objects_api/api/serializers.py:13
-#: openforms/registrations/contrib/objects_api/config.py:57
+#: openforms/registrations/contrib/objects_api/config.py:54
 msgid ""
 "Representation of the JSON target location as a list of string segments."
 msgstr ""
@@ -10324,12 +10459,12 @@ msgid "Corresponding (sub) JSON Schema of the target path."
 msgstr "Stukje JSON-schema voor dit specifieke bestemmingspad."
 
 #: openforms/prefill/contrib/objects_api/api/serializers.py:34
-#: openforms/registrations/contrib/objects_api/config.py:48
+#: openforms/registrations/contrib/objects_api/config.py:45
 msgid "variable key"
 msgstr "sleutel variabele"
 
 #: openforms/prefill/contrib/objects_api/api/serializers.py:36
-#: openforms/registrations/contrib/objects_api/config.py:50
+#: openforms/registrations/contrib/objects_api/config.py:47
 msgid ""
 "The 'dotted' path to a form variable key. The format should comply to how "
 "Formio handles nested component keys."
@@ -10338,7 +10473,7 @@ msgstr ""
 "Formio omgaat met geneste paden."
 
 #: openforms/prefill/contrib/objects_api/api/serializers.py:60
-#: openforms/registrations/contrib/objects_api/config.py:142
+#: openforms/registrations/contrib/objects_api/config.py:136
 msgid "objecttype"
 msgstr "objecttype"
 
@@ -10348,12 +10483,12 @@ msgstr "UUID van het objecttype in de Objecttypen-API."
 
 #: openforms/prefill/contrib/objects_api/api/serializers.py:65
 #: openforms/registrations/contrib/objects_api/api/serializers.py:31
-#: openforms/registrations/contrib/objects_api/config.py:152
+#: openforms/registrations/contrib/objects_api/config.py:146
 msgid "objecttype version"
 msgstr "objecttype versie"
 
 #: openforms/prefill/contrib/objects_api/api/serializers.py:67
-#: openforms/registrations/contrib/objects_api/config.py:153
+#: openforms/registrations/contrib/objects_api/config.py:147
 msgid "Version of the objecttype in the Objecttypes API."
 msgstr "Versie van het objecttype in de Objecttypen API."
 
@@ -10370,12 +10505,12 @@ msgstr ""
 "opgehaalde object."
 
 #: openforms/prefill/contrib/objects_api/api/serializers.py:79
-#: openforms/registrations/contrib/objects_api/config.py:164
+#: openforms/registrations/contrib/objects_api/config.py:158
 msgid "Path to auth attribute (e.g. BSN/KVK) in objects"
 msgstr "Bronpad van het autorisatiekenmerk (bijv. BSN/KVK)"
 
 #: openforms/prefill/contrib/objects_api/api/serializers.py:81
-#: openforms/registrations/contrib/objects_api/config.py:166
+#: openforms/registrations/contrib/objects_api/config.py:160
 msgid ""
 "This is used to perform validation to verify that the authenticated user is "
 "the owner of the object."
@@ -10384,7 +10519,7 @@ msgstr ""
 "gebruiker bij het object hoort waarnaar verwezen wordt."
 
 #: openforms/prefill/contrib/objects_api/api/serializers.py:89
-#: openforms/registrations/contrib/objects_api/config.py:306
+#: openforms/registrations/contrib/objects_api/config.py:271
 msgid "variables mapping"
 msgstr "variabelekoppelingen"
 
@@ -10499,10 +10634,6 @@ msgid ""
 msgstr ""
 "Informatietekst die moet worden weergegeven op de bevestigingspagina en "
 "bevestigingsmail. "
-
-#: openforms/products/models/product.py:43
-msgid "Product"
-msgstr "Product"
 
 #: openforms/registrations/api/views.py:19
 msgid "List available registration plugins"
@@ -10941,24 +11072,24 @@ msgstr "De JSON-schemadefinitie van de formuliervariabele."
 msgid "Objects API plugin"
 msgstr "Objecten API plugin"
 
-#: openforms/registrations/contrib/objects_api/config.py:29
+#: openforms/registrations/contrib/objects_api/config.py:26
 msgid "v1, template based"
 msgstr "v1, op basis van sjabloon"
 
-#: openforms/registrations/contrib/objects_api/config.py:30
+#: openforms/registrations/contrib/objects_api/config.py:27
 msgid "v2, variables mapping"
 msgstr "v2, variabelekoppelingen"
 
-#: openforms/registrations/contrib/objects_api/config.py:71
+#: openforms/registrations/contrib/objects_api/config.py:68
 #: openforms/registrations/contrib/stuf_zds/options.py:54
-#: openforms/registrations/contrib/zgw_apis/options.py:60
+#: openforms/registrations/contrib/zgw_apis/options.py:59
 #: openforms/submissions/models/email_verification.py:53
 msgid "component key"
 msgstr "componentsleutel"
 
-#: openforms/registrations/contrib/objects_api/config.py:73
+#: openforms/registrations/contrib/objects_api/config.py:70
 #: openforms/registrations/contrib/stuf_zds/options.py:56
-#: openforms/registrations/contrib/zgw_apis/options.py:62
+#: openforms/registrations/contrib/zgw_apis/options.py:61
 msgid ""
 "Literal component key value of the file component for which the options "
 "apply."
@@ -10966,19 +11097,14 @@ msgstr ""
 "Componentsleutel van het bestandsupload-component waarop de opties van "
 "toepassing zijn."
 
-#: openforms/registrations/contrib/objects_api/config.py:78
-#: openforms/registrations/contrib/zgw_apis/options.py:67
-#: openforms/registrations/contrib/zgw_apis/options.py:137
+#: openforms/registrations/contrib/objects_api/config.py:75
+#: openforms/registrations/contrib/zgw_apis/options.py:66
+#: openforms/registrations/contrib/zgw_apis/options.py:132
 msgid "Document type description"
 msgstr "Documenttypeomschrijving"
 
-#: openforms/registrations/contrib/objects_api/config.py:81
-#: openforms/registrations/contrib/zgw_apis/options.py:70
-#| msgid ""
-#| "The document type will be retrieved in the specified catalogue. The version "
-#| "will automatically be selected based on the submission completion timestamp."
-#| " When you specify this field, you MUST also specify the case type via its "
-#| "identification. Only document types related to the case type are valid."
+#: openforms/registrations/contrib/objects_api/config.py:78
+#: openforms/registrations/contrib/zgw_apis/options.py:69
 msgid ""
 "The document type will be retrieved from the catalogue and case type "
 "specified in the backend options. The version will automatically be selected"
@@ -10990,56 +11116,47 @@ msgstr ""
 " van de inzendingsdatum. Enkel documenttypen die bij het zaaktype horen zijn"
 " geldig."
 
-#: openforms/registrations/contrib/objects_api/config.py:91
-#: openforms/registrations/contrib/zgw_apis/options.py:80
-#| msgid "RSIN of organization, which creates the ZAAK"
+#: openforms/registrations/contrib/objects_api/config.py:88
+#: openforms/registrations/contrib/zgw_apis/options.py:79
 msgid "RSIN of the organization that creates the document."
 msgstr "RSIN van de organisatie die het document aanmaakt"
 
-#: openforms/registrations/contrib/objects_api/config.py:95
-#: openforms/registrations/contrib/zgw_apis/options.py:84
-#: openforms/registrations/contrib/zgw_apis/options.py:186
+#: openforms/registrations/contrib/objects_api/config.py:92
+#: openforms/registrations/contrib/zgw_apis/options.py:83
+#: openforms/registrations/contrib/zgw_apis/options.py:165
 msgid "Vertrouwelijkheidaanduiding"
 msgstr "Vertrouwelijkheidaanduiding"
 
-#: openforms/registrations/contrib/objects_api/config.py:99
-#: openforms/registrations/contrib/zgw_apis/options.py:88
-#| msgid ""
-#| "Indication of the level to which extend the dossier of the ZAAK is meant to "
-#| "be public."
+#: openforms/registrations/contrib/objects_api/config.py:96
+#: openforms/registrations/contrib/zgw_apis/options.py:87
 msgid ""
 "Indication of the level to which extend the document is meant to be public."
 msgstr ""
 "Aanduiding van de mate waarin het document voor de openbaarheid bestemd is."
 
-#: openforms/registrations/contrib/objects_api/config.py:108
+#: openforms/registrations/contrib/objects_api/config.py:105
 msgid ""
 "Optional custom title for the document. By default, the form name is used."
 msgstr ""
 "Optionele aangepaste documenttitel. Standaard wordt de formuliernaam "
 "gebruikt."
 
-#: openforms/registrations/contrib/objects_api/config.py:125
-#: openforms/registrations/contrib/zgw_apis/options.py:116
+#: openforms/registrations/contrib/objects_api/config.py:122
+#: openforms/registrations/contrib/zgw_apis/options.py:112
 msgid "catalogue"
 msgstr "catalogus"
 
-#: openforms/registrations/contrib/objects_api/config.py:128
-msgid ""
-"The catalogue in the catalogi API from the selected API group. This "
-"overrides the catalogue specified in the API group, if it's set. When "
-"specified, the document types specified on the API group are ignored."
-msgstr ""
-"De catalogus in de Catalogi API uit de geselecteerde API-groep. Deze waarde "
-"overschrijft de catalogus die in de API-groep ingesteld is. Als je de "
-"catalogus hier instelt, dan worden eventuele ingestelde documenttypen in de "
-"API-groep genegeerd."
+#: openforms/registrations/contrib/objects_api/config.py:124
+#, fuzzy
+#| msgid "List available Catalogi from the provided Objects API group"
+msgid "The catalogue in the catalogi API from the selected API group."
+msgstr "Lijst van beschikbare catalogi (Objecten API)"
 
-#: openforms/registrations/contrib/objects_api/config.py:134
+#: openforms/registrations/contrib/objects_api/config.py:128
 msgid "options version"
 msgstr "configuratieversie"
 
-#: openforms/registrations/contrib/objects_api/config.py:136
+#: openforms/registrations/contrib/objects_api/config.py:130
 msgid ""
 "The schema version of the objects API Options. Not to be confused with the "
 "objecttype version."
@@ -11047,7 +11164,7 @@ msgstr ""
 "De versie van de optiesconfiguratie. Niet te verwarren met de versie van het"
 " objecttype."
 
-#: openforms/registrations/contrib/objects_api/config.py:144
+#: openforms/registrations/contrib/objects_api/config.py:138
 msgid ""
 "UUID of the ProductAanvraag objecttype in the Objecttypes API. The "
 "objecttype should have the following three attributes: 1) submission_id; 2) "
@@ -11057,11 +11174,11 @@ msgstr ""
 " objecttype moet de volgende attributen bevatten: 1) submission_id; 2) type "
 "(het type van de 'ProductAanvraag'); 3) data (ingezonden formuliergegevens)"
 
-#: openforms/registrations/contrib/objects_api/config.py:156
+#: openforms/registrations/contrib/objects_api/config.py:150
 msgid "Update existing object"
 msgstr "Bestaand object bijwerken"
 
-#: openforms/registrations/contrib/objects_api/config.py:158
+#: openforms/registrations/contrib/objects_api/config.py:152
 msgid ""
 "Indicates whether the existing object should be updated (if it exists), "
 "instead of creating a new one."
@@ -11069,11 +11186,11 @@ msgstr ""
 "Bepaalt of een bestaand object (wanneer dit al bestaat) moet bijgewerkt "
 "worden in plaats van een nieuw object aan te maken."
 
-#: openforms/registrations/contrib/objects_api/config.py:171
+#: openforms/registrations/contrib/objects_api/config.py:165
 msgid "Upload submission CSV"
 msgstr "CSV bestand inzending uploaden"
 
-#: openforms/registrations/contrib/objects_api/config.py:173
+#: openforms/registrations/contrib/objects_api/config.py:167
 msgid ""
 "Indicates whether or not the submission CSV should be uploaded as a Document"
 " in Documenten API and attached to the ProductAanvraag."
@@ -11081,11 +11198,11 @@ msgstr ""
 "Geeft aan of de inzendingsgegevens als CSV in de Documenten API moet "
 "geüpload worden en toegevoegd aan de ProductAanvraag."
 
-#: openforms/registrations/contrib/objects_api/config.py:181
+#: openforms/registrations/contrib/objects_api/config.py:175
 msgid "RSIN of organization, which creates the INFORMATIEOBJECT."
 msgstr "RSIN van de organisatie die het INFORMATIEOBJECT aanmaakt."
 
-#: openforms/registrations/contrib/objects_api/config.py:193
+#: openforms/registrations/contrib/objects_api/config.py:187
 msgid ""
 "Description of the document type in the Catalogi API to be used for the "
 "submission report PDF. The appropriate version will automatically be "
@@ -11097,7 +11214,7 @@ msgstr ""
 "basis van de inzendingsdatum en geldigheidsdatums van de "
 "documenttypeversies."
 
-#: openforms/registrations/contrib/objects_api/config.py:206
+#: openforms/registrations/contrib/objects_api/config.py:200
 msgid ""
 "Description of the document type in the Catalogi API to be used for the "
 "submission report CSV. The appropriate version will automatically be "
@@ -11109,7 +11226,7 @@ msgstr ""
 "basis van de inzendingsdatum en geldigheidsdatums van de "
 "documenttypeversies."
 
-#: openforms/registrations/contrib/objects_api/config.py:219
+#: openforms/registrations/contrib/objects_api/config.py:213
 msgid ""
 "Description of the document type in the Catalogi API to be used for the "
 "submission attachments. The appropriate version will automatically be "
@@ -11120,80 +11237,52 @@ msgstr ""
 "inzendingsbijlagen. De juiste versie wordt automatisch geselecteerd op basis"
 " van de inzendingsdatum en geldigheidsdatums van de documenttypeversies."
 
-#: openforms/registrations/contrib/objects_api/config.py:228
-msgid "submission report PDF informatieobjecttype"
-msgstr "inzendings PDF document informatieobjecttype"
-
-#: openforms/registrations/contrib/objects_api/config.py:230
-msgid ""
-"URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used "
-"for the submission report PDF."
-msgstr ""
-"URL naar het INFORMATIEOBJECTTYPE in een Catalogi API dat wordt gebruikt "
-"voor het PDF-document."
-
-#: openforms/registrations/contrib/objects_api/config.py:239
-msgid ""
-"URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used "
-"for the submission report CSV."
-msgstr ""
-"URL naar het INFORMATIEOBJECTTYPE in een Catalogi API dat wordt gebruikt "
-"voor het CSV-document."
-
-#: openforms/registrations/contrib/objects_api/config.py:248
-msgid ""
-"URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used "
-"for the submission attachments."
-msgstr ""
-"URL naar het INFORMATIEOBJECTTYPE in een Catalogi API dat wordt gebruikt "
-"voor de bijlagen."
-
-#: openforms/registrations/contrib/objects_api/config.py:258
+#: openforms/registrations/contrib/objects_api/config.py:223
 #: openforms/registrations/contrib/stuf_zds/options.py:135
-#: openforms/registrations/contrib/zgw_apis/options.py:310
-#| msgid "File size"
+#: openforms/registrations/contrib/zgw_apis/options.py:289
 msgid "Files"
 msgstr "Bestanden"
 
-#: openforms/registrations/contrib/objects_api/config.py:261
+#: openforms/registrations/contrib/objects_api/config.py:226
 #: openforms/registrations/contrib/stuf_zds/options.py:138
-#: openforms/registrations/contrib/zgw_apis/options.py:313
+#: openforms/registrations/contrib/zgw_apis/options.py:292
 msgid ""
 "List of file upload options for file components. Each entry contains the key"
 " of the file component in the form, which may be a child in an edit grid. "
 "Any specified option overrides the equivalent option on the backend level. "
 "If unspecified, the backend configuration is used."
 msgstr ""
-"Lijst van instellingen voor bestandsupload-componenten. Elk item bevat de sleutel "
-"van het bestandsupload-component in het formulier, wat een item binnen een "
-"herhalende groep kan zijn. De opgegeven instellingen overschrijven de "
-"standaardinstellingen. Indien niet gespecifieerd, worden de backend-instellingen gebruikt.."
+"Lijst van instellingen voor bestandsupload-componenten. Elk item bevat de "
+"sleutel van het bestandsupload-component in het formulier, wat een item "
+"binnen een herhalende groep kan zijn. De opgegeven instellingen "
+"overschrijven de standaardinstellingen. Indien niet gespecifieerd, worden de"
+" backend-instellingen gebruikt.."
 
-#: openforms/registrations/contrib/objects_api/config.py:271
+#: openforms/registrations/contrib/objects_api/config.py:236
 msgid "productaanvraag type"
 msgstr "productaanvraag type"
 
-#: openforms/registrations/contrib/objects_api/config.py:272
+#: openforms/registrations/contrib/objects_api/config.py:237
 msgid "The type of ProductAanvraag."
 msgstr "Het type van de ProductAanvraag."
 
-#: openforms/registrations/contrib/objects_api/config.py:277
+#: openforms/registrations/contrib/objects_api/config.py:242
 msgid "JSON content field"
 msgstr "JSON-inhoud sjabloon"
 
-#: openforms/registrations/contrib/objects_api/config.py:279
-#: openforms/registrations/contrib/zgw_apis/options.py:289
+#: openforms/registrations/contrib/objects_api/config.py:244
+#: openforms/registrations/contrib/zgw_apis/options.py:268
 msgid "JSON template for the body of the request sent to the Objects API."
 msgstr ""
 "JSON-sjabloon voor de inhoud van het verzoek wat naar de Objecten API "
 "gestuurd wordt."
 
-#: openforms/registrations/contrib/objects_api/config.py:290
+#: openforms/registrations/contrib/objects_api/config.py:255
 #: openforms/registrations/contrib/objects_api/models.py:49
 msgid "payment status update JSON template"
 msgstr "JSON-sjabloon voor de betaalstatus-update"
 
-#: openforms/registrations/contrib/objects_api/config.py:292
+#: openforms/registrations/contrib/objects_api/config.py:257
 #: openforms/registrations/contrib/objects_api/models.py:58
 msgid ""
 "This template is evaluated with the submission data and the resulting JSON "
@@ -11203,11 +11292,11 @@ msgstr ""
 "resulterende JSON wordt vervolgens naar de Objecten API gestuurd met een "
 "PATCH call om de betalingsvelden bij te werken."
 
-#: openforms/registrations/contrib/objects_api/config.py:313
+#: openforms/registrations/contrib/objects_api/config.py:278
 msgid "geometry variable"
 msgstr "Geometrievariabele"
 
-#: openforms/registrations/contrib/objects_api/config.py:315
+#: openforms/registrations/contrib/objects_api/config.py:280
 msgid ""
 "The 'dotted' path to a form variable key that should be mapped to the "
 "`record.geometry` attribute."
@@ -11215,11 +11304,11 @@ msgstr ""
 "De sleutel van de formuliervariabele die aan het geometrieveld "
 "'record.geometry' gekoppeld wordt."
 
-#: openforms/registrations/contrib/objects_api/config.py:322
+#: openforms/registrations/contrib/objects_api/config.py:287
 msgid "transform to list"
 msgstr "Verander naar lijst"
 
-#: openforms/registrations/contrib/objects_api/config.py:326
+#: openforms/registrations/contrib/objects_api/config.py:291
 msgid ""
 "The components which need special handling concerning the shape of the data "
 "and need to be transformed to a list."
@@ -11227,28 +11316,41 @@ msgstr ""
 "De componenten die bijzondere afhandeling vereisen omtrend de structuur van "
 "de gegevens en veranderd moeten worden naar een lijst."
 
-#: openforms/registrations/contrib/objects_api/config.py:365
+#: openforms/registrations/contrib/objects_api/config.py:324
 #, python-brace-format
 msgid "{field_name} shouldn't be provided when version is 1"
 msgstr "{field_name} is niet van toepassing in v1"
 
-#: openforms/registrations/contrib/objects_api/config.py:376
+#: openforms/registrations/contrib/objects_api/config.py:335
 #, python-brace-format
 msgid "{field_name} shouldn't be provided when version is 2"
 msgstr "{field_name} is niet van toepassing in v2"
 
-#: openforms/registrations/contrib/objects_api/config.py:383
+#: openforms/registrations/contrib/objects_api/config.py:342
 #, python-brace-format
 msgid "Unknown version: {version}"
 msgstr "Onbekende versie: {version}"
 
-#: openforms/registrations/contrib/objects_api/config.py:390
+#: openforms/registrations/contrib/objects_api/config.py:349
 msgid "This field is required if \"Update existing object\" is checked"
 msgstr ""
 "Dit veld is verplicht wanneer \"Bestaand object bijwerken\" ingeschakeld is."
 
-#: openforms/registrations/contrib/objects_api/config.py:444
-#: openforms/registrations/contrib/zgw_apis/options.py:534
+#: openforms/registrations/contrib/objects_api/config.py:401
+#, fuzzy
+#| msgid ""
+#| "To look up document types by their description, a catalogue reference is "
+#| "required. Either specify one on the API group or in the plugin options."
+msgid ""
+"To look up document types by their description, a catalogue reference is "
+"required."
+msgstr ""
+"Om documenttypen te vinden op basis van hun omschrijving moet er een "
+"catalogus ingesteld zijn. Je kan de catalogus instellen in de API-groep of "
+"in de registratie-opties onder \"Documenttypen\"."
+
+#: openforms/registrations/contrib/objects_api/config.py:419
+#: openforms/registrations/contrib/zgw_apis/options.py:477
 msgid ""
 "The specified catalogue does not exist. Maybe you made a typo in the domain "
 "or RSIN?"
@@ -11256,37 +11358,18 @@ msgstr ""
 "De opgegeven catalogus bestaat niet. Controleer of je een typfout hebt in "
 "het domein of het RSIN."
 
-#: openforms/registrations/contrib/objects_api/config.py:473
-msgid ""
-"To look up document types by their description, a catalogue reference is "
-"required. Either specify one on the API group or in the plugin options."
-msgstr ""
-"Om documenttypen te vinden op basis van hun omschrijving moet er een "
-"catalogus ingesteld zijn. Je kan de catalogus instellen in de API-groep of "
-"in de registratie-opties onder \"Documenttypen\"."
-
-#: openforms/registrations/contrib/objects_api/config.py:486
-#: openforms/registrations/contrib/objects_api/config.py:553
+#: openforms/registrations/contrib/objects_api/config.py:435
+#: openforms/registrations/contrib/objects_api/config.py:447
 #, python-brace-format
 msgid "No document type with description '{description}' found."
 msgstr "Kon documenttype met omschrijving '{description}' niet vinden."
 
-#: openforms/registrations/contrib/objects_api/config.py:510
-#, python-brace-format
-msgid "The provided {field} does not exist in the Catalogi API."
-msgstr "Het opgegeven {field} bestaat niet in de ingestelde Catalogi API."
-
-#: openforms/registrations/contrib/objects_api/config.py:512
-#, python-brace-format
-msgid "The provided {field} does not exist in the selected catalogue."
-msgstr "Het opgegeven {field} bestaat niet in de geselecteerde catalogus."
-
-#: openforms/registrations/contrib/objects_api/config.py:579
+#: openforms/registrations/contrib/objects_api/config.py:477
 msgid "The provided objecttype does not exist in the Objecttypes API."
 msgstr ""
 "Het opgegeven objecttype is niet gevonden in de ingestelde Objecttypen API."
 
-#: openforms/registrations/contrib/objects_api/config.py:596
+#: openforms/registrations/contrib/objects_api/config.py:494
 msgid "The provided objecttype version does not exist in the Objecttypes API."
 msgstr ""
 "De opgegeven objecttypeversie is niet gevonden in de ingestelde Objecttypen "
@@ -11309,7 +11392,7 @@ msgid "JSON content template"
 msgstr "JSON-inhoud sjabloon"
 
 #: openforms/registrations/contrib/objects_api/models.py:45
-#: openforms/registrations/contrib/zgw_apis/models.py:133
+#: openforms/registrations/contrib/zgw_apis/models.py:135
 msgid ""
 "This template is evaluated with the submission data and the resulting JSON "
 "is sent to the objects API."
@@ -11329,7 +11412,7 @@ msgstr "Objecten API configuratie"
 #: openforms/submissions/models/submission_files.py:57
 #: openforms/submissions/models/submission_files.py:148
 #: openforms/submissions/models/submission_report.py:30
-#: openforms/submissions/models/submission_value_variable.py:441
+#: openforms/submissions/models/submission_value_variable.py:448
 msgid "submission"
 msgstr "inzending"
 
@@ -11459,7 +11542,7 @@ msgstr ""
 "enkele waarde, waarbij meerdere waarden door kommas worden gescheiden."
 
 #: openforms/registrations/contrib/stuf_zds/options.py:64
-#: openforms/registrations/contrib/zgw_apis/options.py:97
+#: openforms/registrations/contrib/zgw_apis/options.py:96
 msgid ""
 "Optional custom title for the document. By default, the attachment file name"
 " is used."
@@ -11628,12 +11711,10 @@ msgstr ""
 "{exception}"
 
 #: openforms/registrations/contrib/zgw_apis/constants.py:6
-#| msgid "document_url"
 msgid "JSON document"
 msgstr "JSON-document"
 
 #: openforms/registrations/contrib/zgw_apis/constants.py:7
-#| msgid "document_url"
 msgid "PDF document"
 msgstr "PDF-document"
 
@@ -11645,15 +11726,15 @@ msgstr "Een herkenbare naam voor deze groep ZGW API's."
 msgid "Zaken API"
 msgstr "Zaken API"
 
-#: openforms/registrations/contrib/zgw_apis/models.py:90
+#: openforms/registrations/contrib/zgw_apis/models.py:92
 msgid "Default RSIN of organization, which creates the ZAAK"
 msgstr "Standaard RSIN van de organisatie, die de ZAAK aanmaakt"
 
-#: openforms/registrations/contrib/zgw_apis/models.py:93
+#: openforms/registrations/contrib/zgw_apis/models.py:95
 msgid "vertrouwelijkheidaanduiding zaak"
 msgstr "vertrouwelijkheidaanduiding zaak"
 
-#: openforms/registrations/contrib/zgw_apis/models.py:98
+#: openforms/registrations/contrib/zgw_apis/models.py:100
 msgid ""
 "Indication of the level to which extend the ZAAK is meant to be public. Can "
 "be overridden in the Registration tab of a given form."
@@ -11662,11 +11743,11 @@ msgstr ""
 "openbaarheid bestemd is. Dit kan per formulier in de registratieconfiguratie"
 " overschreven worden."
 
-#: openforms/registrations/contrib/zgw_apis/models.py:103
+#: openforms/registrations/contrib/zgw_apis/models.py:105
 msgid "vertrouwelijkheidaanduiding document"
 msgstr "vertrouwelijkheidaanduiding document"
 
-#: openforms/registrations/contrib/zgw_apis/models.py:108
+#: openforms/registrations/contrib/zgw_apis/models.py:110
 msgid ""
 "Indication of the level to which extend the document associated with the "
 "ZAAK is meant to be public. Can be overridden in the file upload component "
@@ -11676,11 +11757,11 @@ msgstr ""
 "bestemd is. Dit wordt toegepast op de zaakdocumenten die aangemaakt worden. "
 "Dit kan per formulier in de registratieconfiguratie overschreven worden."
 
-#: openforms/registrations/contrib/zgw_apis/models.py:114
+#: openforms/registrations/contrib/zgw_apis/models.py:116
 msgid "auteur"
 msgstr "auteur"
 
-#: openforms/registrations/contrib/zgw_apis/models.py:116
+#: openforms/registrations/contrib/zgw_apis/models.py:118
 msgid ""
 "The value of the `author` field for documents that will be created in "
 "Documenten API."
@@ -11688,15 +11769,15 @@ msgstr ""
 "De waarde van het `auteur` veld voor documenten die worden aangemaakt in de "
 "Documenten API."
 
-#: openforms/registrations/contrib/zgw_apis/models.py:124
+#: openforms/registrations/contrib/zgw_apis/models.py:126
 msgid "objects API - JSON content template"
 msgstr "objecten API - JSON-inhoud sjabloon"
 
-#: openforms/registrations/contrib/zgw_apis/models.py:139
+#: openforms/registrations/contrib/zgw_apis/models.py:141
 msgid "Use generated zaaknummer"
 msgstr "Gebruik gegenereerd zaaknummer"
 
-#: openforms/registrations/contrib/zgw_apis/models.py:142
+#: openforms/registrations/contrib/zgw_apis/models.py:144
 msgid ""
 "Indicates whether the zaaknummer is used as public reference. When "
 "unchecked, then the public reference is generated by Open Forms."
@@ -11704,38 +11785,38 @@ msgstr ""
 "Geeft aan of het zaaknummer wordt gebruikt als openbare referentie. Als dit "
 "uitgeschakeld is, dan genereert Open Formulieren de  publieke referentie."
 
-#: openforms/registrations/contrib/zgw_apis/models.py:148
-#: openforms/registrations/contrib/zgw_apis/options.py:110
+#: openforms/registrations/contrib/zgw_apis/models.py:150
+#: openforms/registrations/contrib/zgw_apis/options.py:109
 msgid "ZGW API set"
 msgstr "ZGW API-groep"
 
-#: openforms/registrations/contrib/zgw_apis/models.py:149
+#: openforms/registrations/contrib/zgw_apis/models.py:151
 msgid "ZGW API sets"
 msgstr "ZGW API-groepen"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:38
+#: openforms/registrations/contrib/zgw_apis/options.py:37
 msgid "Component key"
 msgstr "Componentsleutel"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:39
+#: openforms/registrations/contrib/zgw_apis/options.py:38
 msgid "Key of the form variable to take the value from."
 msgstr "Sleutel van de formuliervariabele om de waarde uit te halen."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:42
+#: openforms/registrations/contrib/zgw_apis/options.py:41
 msgid "Property"
 msgstr "Eigenschap"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:45
+#: openforms/registrations/contrib/zgw_apis/options.py:44
 msgid ""
 "Name of the property on the case type to which the variable will be mapped."
 msgstr ""
 "Naam van de eigenschap op het zaaktype waar de variabele op gemapped wordt."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:109
+#: openforms/registrations/contrib/zgw_apis/options.py:108
 msgid "Which ZGW API set to use."
 msgstr "De gewenste ZGW API-groep."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:119
+#: openforms/registrations/contrib/zgw_apis/options.py:115
 msgid ""
 "The catalogue in the catalogi API from the selected API group. This "
 "overrides the catalogue specified in the API group, if it's set. Case and "
@@ -11745,11 +11826,11 @@ msgstr ""
 "overschrijft de catalogus die in de API-groep ingesteld is. De beschikbare "
 "zaak- en documenttypen worden uit deze catalogus opgevraagd."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:126
+#: openforms/registrations/contrib/zgw_apis/options.py:122
 msgid "Case type identification"
 msgstr "Zaaktype-identificatie"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:128
+#: openforms/registrations/contrib/zgw_apis/options.py:124
 msgid ""
 "The case type will be retrieved in the specified catalogue. The version will"
 " automatically be selected based on the submission completion timestamp. "
@@ -11760,7 +11841,7 @@ msgstr ""
 "inzendingsdatum. Als je een waarde voor dit veld opgeeft, dan moet ook een "
 "catalogus ingesteld zijn."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:139
+#: openforms/registrations/contrib/zgw_apis/options.py:134
 msgid ""
 "The document type will be retrieved in the specified catalogue. The version "
 "will automatically be selected based on the submission completion timestamp."
@@ -11773,11 +11854,11 @@ msgstr ""
 "het zaaktype via haar identificatie opgeven. Enkel documenttypen die bij het"
 " zaaktype horen zijn geldig."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:149
+#: openforms/registrations/contrib/zgw_apis/options.py:143
 msgid "Product url"
 msgstr "Product-URL"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:151
+#: openforms/registrations/contrib/zgw_apis/options.py:145
 msgid ""
 "The product url will be retrieved from the specified case type and the "
 "version that is active at that moment. "
@@ -11785,29 +11866,19 @@ msgstr ""
 "De product-URL wordt opgehaald uit het opgegeven zaaktype en de versie die "
 "op dat moment geldig is."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:161
-#| msgid "Summary page"
+#: openforms/registrations/contrib/zgw_apis/options.py:154
 msgid "Summary documents"
 msgstr "Samenvattingsdocumenten"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:162
+#: openforms/registrations/contrib/zgw_apis/options.py:155
 msgid "Which summary documents to include during registration."
-msgstr ""
-"Welke samenvattingsdocumenten aan de zaak worden toegevoegd."
+msgstr "Welke samenvattingsdocumenten aan de zaak worden toegevoegd."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:168
-msgid "URL of the ZAAKTYPE in the Catalogi API"
-msgstr "URL van het ZAAKTYPE in de Catalogi API"
-
-#: openforms/registrations/contrib/zgw_apis/options.py:174
-msgid "URL of the INFORMATIEOBJECTTYPE in the Catalogi API"
-msgstr "URL van het INFORMATIEOBJECTTYPE in de Catalogi API"
-
-#: openforms/registrations/contrib/zgw_apis/options.py:182
+#: openforms/registrations/contrib/zgw_apis/options.py:161
 msgid "RSIN of organization, which creates the ZAAK"
 msgstr "RSIN van de organisatie, die de ZAAK aanmaakt"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:190
+#: openforms/registrations/contrib/zgw_apis/options.py:169
 msgid ""
 "Indication of the level to which extend the dossier of the ZAAK is meant to "
 "be public."
@@ -11815,7 +11886,7 @@ msgstr ""
 "Aanduiding van de mate waarin het zaakdossier van de ZAAK voor de "
 "openbaarheid bestemd is."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:196
+#: openforms/registrations/contrib/zgw_apis/options.py:175
 msgid ""
 "Description (omschrijving) of the ROLTYPE to use for employees filling in a "
 "form for a citizen/company."
@@ -11823,7 +11894,7 @@ msgstr ""
 "Omschrijving van het ROLTYPE om de medewerker te registreren die het "
 "formulier invult voor de klant (burger/bedrijf)."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:205
+#: openforms/registrations/contrib/zgw_apis/options.py:184
 msgid ""
 "Description (omschrijving) of the ROLTYPE to use for citizens filling in a "
 "form with partners."
@@ -11831,12 +11902,12 @@ msgstr ""
 "Omschrijving van het ROLTYPE te gebruiken voor inwoners voor het invullen "
 "van een formulier met partners."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:213
+#: openforms/registrations/contrib/zgw_apis/options.py:192
 msgid ""
 "Description (omschrijving) that will be used in the partners registration."
 msgstr "De omschrijving welke gebruikt wordt voor partner registraties."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:221
+#: openforms/registrations/contrib/zgw_apis/options.py:200
 msgid ""
 "Description (omschrijving) of the ROLTYPE to use for citizens filling in a "
 "form with children."
@@ -11844,16 +11915,16 @@ msgstr ""
 "Omschrijving van het ROLTYPE te gebruiken voor inwoners voor het invullen "
 "van een formulier met kinderen."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:229
+#: openforms/registrations/contrib/zgw_apis/options.py:208
 msgid ""
 "Description (omschrijving) that will be used in the children registration."
 msgstr "De omschrijving welke gebruikt wordt voor kind registraties."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:233
+#: openforms/registrations/contrib/zgw_apis/options.py:212
 msgid "Omschrijving"
 msgstr "Omschrijving"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:237
+#: openforms/registrations/contrib/zgw_apis/options.py:216
 msgid ""
 "Description (omschrijving) of the case. You can use the expressions like '{{"
 " form_name }}' or other variables here. The resolved string is limited to 80"
@@ -11863,11 +11934,11 @@ msgstr ""
 "andere variabelen gebruiken. De resulterende tekst is beperkt tot 80 "
 "karakters. Standaard wordt de formuliernaam gebruikt."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:246
+#: openforms/registrations/contrib/zgw_apis/options.py:225
 msgid "Toelichting"
 msgstr "Toelichting"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:250
+#: openforms/registrations/contrib/zgw_apis/options.py:229
 msgid ""
 "Explanation (toelichting) of the case. You can use the expressions like '{{ "
 "form_name }}' or other variables here."
@@ -11875,19 +11946,19 @@ msgstr ""
 "Toelichting van de zaak. Je kan hier expressies zoals '{{ form_name }}' of "
 "andere variabelen gebruiken."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:264
+#: openforms/registrations/contrib/zgw_apis/options.py:243
 msgid "Which Objects API set to use."
 msgstr "De gewenste Objecten API-groep."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:265
+#: openforms/registrations/contrib/zgw_apis/options.py:244
 msgid "Objects API set"
 msgstr "Objecten API-groep"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:270
+#: openforms/registrations/contrib/zgw_apis/options.py:249
 msgid "objects API - objecttype"
 msgstr "objecten API - objecttype"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:272
+#: openforms/registrations/contrib/zgw_apis/options.py:251
 msgid ""
 "URL that points to the ProductAanvraag objecttype in the Objecttypes API. "
 "The objecttype should have the following three attributes: 1) submission_id;"
@@ -11897,36 +11968,28 @@ msgstr ""
 " objecttype moet de volgende attributen bevatten: 1) submission_id; 2) type "
 "(het type van de 'ProductAanvraag'); 3) data (ingezonden formuliergegevens)"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:282
+#: openforms/registrations/contrib/zgw_apis/options.py:261
 msgid "objects API - objecttype version"
 msgstr "objecten API - objecttypeversie"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:283
+#: openforms/registrations/contrib/zgw_apis/options.py:262
 msgid "Version of the objecttype in the Objecttypes API"
 msgstr "Versie van het objecttype in de Objecttypen API"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:287
+#: openforms/registrations/contrib/zgw_apis/options.py:266
 msgid "objects API - JSON content field"
 msgstr "objecten API - JSON-inhoud veld"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:303
+#: openforms/registrations/contrib/zgw_apis/options.py:282
 msgid "Variable-to-property mappings"
 msgstr "Variabele-naar-eigenschapkoppelingen"
 
-#: openforms/registrations/contrib/zgw_apis/options.py:362
-msgid "You must specify a case type."
-msgstr "Je moet een zaaktype instellen."
-
-#: openforms/registrations/contrib/zgw_apis/options.py:373
-msgid "You must specify a document type"
-msgstr "Je moet een documenttype instellen."
-
-#: openforms/registrations/contrib/zgw_apis/options.py:457
+#: openforms/registrations/contrib/zgw_apis/options.py:409
 msgid "Objects API group must be specified if an objecttype is specified."
 msgstr ""
 "Je moet een Objecten-API-groep selecteren als je een objecttype opgeeft."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:471
+#: openforms/registrations/contrib/zgw_apis/options.py:423
 msgid ""
 "The specified objecttype is not present in the selected Objecttypes API (the"
 " URL does not start with the API root of the Objecttypes API)."
@@ -11934,11 +11997,20 @@ msgstr ""
 "Het gekozen objecttype bestaat niet binnen de gekozen Objecttypen-API (de "
 "URL begint niet met de basis-URL van de Objecttypen-API-service)."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:504
+#: openforms/registrations/contrib/zgw_apis/options.py:451
+#, fuzzy
+#| msgid ""
+#| "You must specify a catalogue when passing a case type identification."
+msgid "You must specify a catalogue (got empty domain and RSIN)."
+msgstr ""
+"Je moet een catalogus aanduiden wanneer je het zaaktype via de identificatie"
+" opgeeft."
+
+#: openforms/registrations/contrib/zgw_apis/options.py:461
 msgid "The provided zaaktype does not exist in the specified Catalogi API."
 msgstr "Het opgegeven zaaktype bestaat niet in de ingestelde Catalogi API."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:509
+#: openforms/registrations/contrib/zgw_apis/options.py:466
 msgid ""
 "The provided informatieobjecttype does not exist in the selected case type "
 "or Catalogi API."
@@ -11946,30 +12018,24 @@ msgstr ""
 "Het opgegeven informatieobjecttype bestaat niet in het geselecteerde "
 "zaaktype of in de ingestelde Catalogi API."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:521
-msgid "You must specify a catalogue when passing a case type identification."
-msgstr ""
-"Je moet een catalogus aanduiden wanneer je het zaaktype via de identificatie"
-" opgeeft."
-
-#: openforms/registrations/contrib/zgw_apis/options.py:661
+#: openforms/registrations/contrib/zgw_apis/options.py:576
 #, python-brace-format
 msgid "Could not find a property with the name '{name}' in the case type"
 msgstr ""
 "Kon geen eigenschap met de naam '{name}' vinden binnen het ingestelde "
 "zaaktype."
 
-#: openforms/registrations/contrib/zgw_apis/options.py:733
+#: openforms/registrations/contrib/zgw_apis/options.py:629
 msgid ""
 "Could not find a roltype with this description related to the zaaktype."
 msgstr ""
 "Kon geen roltype vinden met deze omschrijving binnen het opgegeven zaaktype."
 
-#: openforms/registrations/contrib/zgw_apis/plugin.py:212
+#: openforms/registrations/contrib/zgw_apis/plugin.py:211
 msgid "ZGW API's"
 msgstr "ZGW API's"
 
-#: openforms/registrations/contrib/zgw_apis/plugin.py:613
+#: openforms/registrations/contrib/zgw_apis/plugin.py:593
 msgid "Employee who registered the case on behalf of the customer."
 msgstr "Medewerker die de zaak registreerde voor de klant."
 
@@ -12194,11 +12260,11 @@ msgstr "Anoniem"
 msgid "Whether the submission was started anonymously or not."
 msgstr "Geeft aan of de inzending zonder inloggen gestart is."
 
-#: openforms/submissions/api/serializers.py:248
+#: openforms/submissions/api/serializers.py:251
 msgid "JSON Logic Trigger"
 msgstr "Trigger voor JSON-logica"
 
-#: openforms/submissions/api/serializers.py:250
+#: openforms/submissions/api/serializers.py:253
 msgid ""
 "The trigger expression to determine if the actions should execute. Will be "
 "(partially) evaluated based on available data."
@@ -12207,15 +12273,15 @@ msgstr ""
 "uitgevoerd. Deze wordt (gedeeltelijk) geëvalueerd op basis van de "
 "beschikbare gegevens."
 
-#: openforms/submissions/api/serializers.py:308
+#: openforms/submissions/api/serializers.py:307
 msgid "Default configuration"
 msgstr "Standaardconfiguratie"
 
-#: openforms/submissions/api/serializers.py:309
+#: openforms/submissions/api/serializers.py:308
 msgid "Default form configuration of the corresponding form step."
 msgstr "Standaardconfiguratie van de corresponderende formulierstap."
 
-#: openforms/submissions/api/serializers.py:316
+#: openforms/submissions/api/serializers.py:315
 msgid ""
 "Form configuration of the corresponding form step, (possibly) mutated by "
 "form logic."
@@ -12223,23 +12289,23 @@ msgstr ""
 "De formulierconfiguratie van de betreffende formulierstap, (eventueel) "
 "gewijzigd door de formulierlogica."
 
-#: openforms/submissions/api/serializers.py:322
+#: openforms/submissions/api/serializers.py:321
 msgid "data"
 msgstr "gegevens"
 
-#: openforms/submissions/api/serializers.py:329
+#: openforms/submissions/api/serializers.py:328
 msgid "Require backend logic evaluation"
 msgstr "Evaluatie van backend-logica vereist"
 
-#: openforms/submissions/api/serializers.py:330
+#: openforms/submissions/api/serializers.py:329
 msgid "Indicates whether the backend is required to execute form logic."
 msgstr "Geeft aan of de backend nodig is om de formulierlogica uit te voeren."
 
-#: openforms/submissions/api/serializers.py:336
+#: openforms/submissions/api/serializers.py:335
 msgid "Logic rules"
 msgstr "Logicaregels"
 
-#: openforms/submissions/api/serializers.py:338
+#: openforms/submissions/api/serializers.py:337
 msgid ""
 "Logic rules of the corresponding form step. The JSON logic triggers are "
 "partially evaluated with data from user-defined variables, and variables of "
@@ -12252,7 +12318,7 @@ msgstr ""
 "dan de huidige. Dit veld blijft leeg als de backend nodig is om de "
 "formulierlogica te evalueren."
 
-#: openforms/submissions/api/serializers.py:351
+#: openforms/submissions/api/serializers.py:350
 msgid ""
 "Flag for indicating if a submission step is coming from a suspended form or "
 "a regular submitted form step."
@@ -12260,11 +12326,11 @@ msgstr ""
 "Vlag die aangeeft of een inzendingsstap afkomstig is van een onderbroken "
 "inzending of een standaard ingezonden stap."
 
-#: openforms/submissions/api/serializers.py:509
+#: openforms/submissions/api/serializers.py:508
 msgid "form data"
 msgstr "Formuliergegevens"
 
-#: openforms/submissions/api/serializers.py:512
+#: openforms/submissions/api/serializers.py:511
 msgid ""
 "The Form.io submission data object. This will be merged with the full form "
 "submission data, including data from other steps, to evaluate the configured"
@@ -12274,21 +12340,21 @@ msgstr ""
 "inzendingsgegevens, inclusief de gegevens van de andere stappen, om de "
 "geconfigureerde formulier logica uit te voeren."
 
-#: openforms/submissions/api/serializers.py:523
+#: openforms/submissions/api/serializers.py:522
 msgid "Contact email address"
 msgstr "Contact e-mailadres"
 
-#: openforms/submissions/api/serializers.py:525
+#: openforms/submissions/api/serializers.py:524
 msgid "The email address where the 'magic' resume link should be sent to"
 msgstr ""
 "Het e-mailadres waar de 'magische' vervolg link naar toe gestuurd moet "
 "worden"
 
-#: openforms/submissions/api/serializers.py:619
+#: openforms/submissions/api/serializers.py:618
 msgid "background processing status"
 msgstr "achtergrondproces status"
 
-#: openforms/submissions/api/serializers.py:623
+#: openforms/submissions/api/serializers.py:622
 msgid ""
 "The async task state, managed by the async task queue. Once the status is "
 "`done`, check the `result` field for the outcome."
@@ -12296,11 +12362,11 @@ msgstr ""
 "De asynchrone taakstatus, beheerd door de asynchrone taakwachtrij. Zodra de "
 "status 'klaar' is, controleert u het veld 'resultaat' voor de uitkomst."
 
-#: openforms/submissions/api/serializers.py:628
+#: openforms/submissions/api/serializers.py:627
 msgid "background processing result"
 msgstr "achtergrondproces resultaat"
 
-#: openforms/submissions/api/serializers.py:633
+#: openforms/submissions/api/serializers.py:632
 msgid ""
 "The result from the background processing. This field only has a value if "
 "the processing has completed (both successfully or with errors)."
@@ -12308,15 +12374,15 @@ msgstr ""
 "Het resultaat van de achtergrondverwerking. Dit veld heeft alleen een waarde"
 " als de verwerking is voltooid (zowel met succes als met fouten)."
 
-#: openforms/submissions/api/serializers.py:640
+#: openforms/submissions/api/serializers.py:639
 msgid "Error information"
 msgstr "Fout informatie"
 
-#: openforms/submissions/api/serializers.py:644
+#: openforms/submissions/api/serializers.py:643
 msgid "Error feedback in case the processing did not complete successfully."
 msgstr "Foutfeedback in het geval de verwerking niet succesvol is voltooid."
 
-#: openforms/submissions/api/serializers.py:655
+#: openforms/submissions/api/serializers.py:654
 msgid ""
 "The public registration reference, sourced from the registration backend or "
 "otherwise uniquely generated in case the backend could not provide it."
@@ -12325,29 +12391,29 @@ msgstr ""
 "anderszins uniek gegenereerd voor het geval de backend deze niet kan "
 "verstrekken."
 
-#: openforms/submissions/api/serializers.py:661
+#: openforms/submissions/api/serializers.py:660
 msgid "Confirmation page title"
 msgstr "Bevestigingspaginatitel"
 
-#: openforms/submissions/api/serializers.py:663
+#: openforms/submissions/api/serializers.py:662
 msgid "Title of the confirmation page."
 msgstr "Titel op de bevestigingspagina"
 
-#: openforms/submissions/api/serializers.py:667
+#: openforms/submissions/api/serializers.py:666
 msgid "Confirmation page content"
 msgstr "Bevestigingspagina tekst"
 
-#: openforms/submissions/api/serializers.py:669
+#: openforms/submissions/api/serializers.py:668
 msgid "Body text of the confirmation page. May contain HTML!"
 msgstr ""
 "Inhoud van de bevestigingspagina. Hierin mogen HTML-karakers worden "
 "opgenomen."
 
-#: openforms/submissions/api/serializers.py:673
+#: openforms/submissions/api/serializers.py:672
 msgid "Report download URL"
 msgstr "Document download URL"
 
-#: openforms/submissions/api/serializers.py:677
+#: openforms/submissions/api/serializers.py:676
 msgid ""
 "Download URL for the generated PDF report. Note that this contain a "
 "timestamped token generated by the backend."
@@ -12355,11 +12421,11 @@ msgstr ""
 "Download-URL voor het gegenereerde PDF document. Let op: Deze URL bevat een "
 "tijdgebaseerd token dat door de backend wordt gegenereerd."
 
-#: openforms/submissions/api/serializers.py:682
+#: openforms/submissions/api/serializers.py:681
 msgid "Payment URL"
 msgstr "Betaalpagina URL"
 
-#: openforms/submissions/api/serializers.py:686
+#: openforms/submissions/api/serializers.py:685
 msgid ""
 "URL to retrieve the payment information. Note that this (will) contain(s) a "
 "timestamped token generated by the backend."
@@ -12367,69 +12433,69 @@ msgstr ""
 "URL om de betalingsinformatie op te halen. Let op: Deze URL bevat een "
 "tijdgebaseerd token dat door de backend wordt gegenereerd."
 
-#: openforms/submissions/api/serializers.py:715
+#: openforms/submissions/api/serializers.py:714
 msgid "is co-signed?"
 msgstr "Is mede-ondertekend?"
 
-#: openforms/submissions/api/serializers.py:716
+#: openforms/submissions/api/serializers.py:715
 msgid "Indicator whether the submission has been co-signed or not."
 msgstr "Geeft aan of de inzending is mede-ondertekend."
 
-#: openforms/submissions/api/serializers.py:719
+#: openforms/submissions/api/serializers.py:718
 msgid "Co-signer display"
 msgstr "Mede-ondertekenaar weergave"
 
-#: openforms/submissions/api/serializers.py:720
+#: openforms/submissions/api/serializers.py:719
 msgid "Co-signer representation string for the UI."
 msgstr "Mede-ondertekenaar weergave in de UI."
 
-#: openforms/submissions/api/serializers.py:737
+#: openforms/submissions/api/serializers.py:736
 msgid "Display name of the component."
 msgstr "Weergavenaam van de component"
 
-#: openforms/submissions/api/serializers.py:741
+#: openforms/submissions/api/serializers.py:740
 msgid "Raw value of the component."
 msgstr "JSON-waarde van de component"
 
-#: openforms/submissions/api/serializers.py:745
+#: openforms/submissions/api/serializers.py:744
 msgid "Configuration of the component."
 msgstr "Componentconfiguratie"
 
-#: openforms/submissions/api/serializers.py:752
+#: openforms/submissions/api/serializers.py:751
 msgid "Slug of the form definition used in the form step."
 msgstr "Slug van de formulierdefinitie horend bij de stap."
 
-#: openforms/submissions/api/serializers.py:756
+#: openforms/submissions/api/serializers.py:755
 msgid "Name of the form definition used in the form step."
 msgstr "Naam van de formulierdefinitie horend bij de stap."
 
-#: openforms/submissions/api/serializers.py:765
+#: openforms/submissions/api/serializers.py:764
 #: openforms/submissions/models/submission.py:261
 msgid "privacy policy accepted"
 msgstr "Privacybeleid geaccepteerd"
 
-#: openforms/submissions/api/serializers.py:766
+#: openforms/submissions/api/serializers.py:765
 msgid "Whether the co-signer has accepted the privacy policy"
 msgstr ""
 "Indicator of de mede-ondertekenaar het privacybeleid geaccepteerd heeft."
 
-#: openforms/submissions/api/serializers.py:769
+#: openforms/submissions/api/serializers.py:768
 #: openforms/submissions/models/submission.py:271
 msgid "statement of truth accepted"
 msgstr "verklaring van waarheid geaccepteerd"
 
-#: openforms/submissions/api/serializers.py:771
+#: openforms/submissions/api/serializers.py:770
 msgid ""
 "Whether the co-signer has declared the form to be filled out truthfully."
 msgstr ""
 "Indicator of de mede-ondertekenaar het formulier naar waarheid ingevuld "
 "heeft."
 
-#: openforms/submissions/api/serializers.py:786
+#: openforms/submissions/api/serializers.py:785
 msgid "download report url"
 msgstr "Download-URL PDF"
 
-#: openforms/submissions/api/serializers.py:788
+#: openforms/submissions/api/serializers.py:787
 msgid ""
 "The URL where the submission report can be downloaded. Note that this "
 "contain a timestamped token generated by the backend."
@@ -12437,19 +12503,19 @@ msgstr ""
 "Download-URL voor het gegenereerde PDF document. Let op: deze URL bevat een "
 "tijdgebaseerd token dat door de backend wordt gegenereerd."
 
-#: openforms/submissions/api/serializers.py:848
+#: openforms/submissions/api/serializers.py:847
 #, python-brace-format
 msgid "The key '{key}' does not point to an email component in the form."
 msgstr ""
 "De sleutel '{key}' hoort niet bij een e-mailcomponent in het formulier."
 
-#: openforms/submissions/api/serializers.py:863
+#: openforms/submissions/api/serializers.py:862
 #: openforms/submissions/models/cosign.py:31
 #: openforms/submissions/models/email_verification.py:62
 msgid "verification code"
 msgstr "bevestigingscode"
 
-#: openforms/submissions/api/serializers.py:881
+#: openforms/submissions/api/serializers.py:880
 msgid "The verification code does not match."
 msgstr "De bevestigingscode komt niet overeen."
 
@@ -13359,85 +13425,85 @@ msgstr "formulierstap (historisch)"
 msgid "Submission step"
 msgstr "Inzendingsstap"
 
-#: openforms/submissions/models/submission_value_variable.py:442
+#: openforms/submissions/models/submission_value_variable.py:449
 msgid "The submission to which this variable value is related"
 msgstr "Inzending waar deze variabelewaarde bij hoort"
 
-#: openforms/submissions/models/submission_value_variable.py:448
+#: openforms/submissions/models/submission_value_variable.py:455
 msgid "Key of the variable"
 msgstr "Sleutel van de variabele"
 
-#: openforms/submissions/models/submission_value_variable.py:452
+#: openforms/submissions/models/submission_value_variable.py:459
 msgid "The value of the variable"
 msgstr "Waarde van de variabele"
 
-#: openforms/submissions/models/submission_value_variable.py:459
+#: openforms/submissions/models/submission_value_variable.py:466
 msgid "Where variable value came from"
 msgstr "Bron van de waarde"
 
-#: openforms/submissions/models/submission_value_variable.py:464
+#: openforms/submissions/models/submission_value_variable.py:471
 msgid "created at"
 msgstr "aangemaakt op"
 
-#: openforms/submissions/models/submission_value_variable.py:465
+#: openforms/submissions/models/submission_value_variable.py:472
 msgid "The date/time at which the value of this variable was created"
 msgstr "De timestamp waarop de waarde van deze variabele aangemaakt werd"
 
-#: openforms/submissions/models/submission_value_variable.py:469
+#: openforms/submissions/models/submission_value_variable.py:476
 msgid "modified at"
 msgstr "gewijzigd op"
 
-#: openforms/submissions/models/submission_value_variable.py:470
+#: openforms/submissions/models/submission_value_variable.py:477
 msgid "The date/time at which the value of this variable was last set"
 msgstr "Timestamp wanneer de waarde laatst gezet is"
 
-#: openforms/submissions/models/submission_value_variable.py:476
+#: openforms/submissions/models/submission_value_variable.py:483
 msgid "is initially prefilled"
 msgstr "gevuld vanuit prefill-gegevens"
 
-#: openforms/submissions/models/submission_value_variable.py:477
+#: openforms/submissions/models/submission_value_variable.py:484
 msgid "Can this variable be prefilled at the beginning of a submission?"
 msgstr ""
 "Is de waarde bij het starten van de inzending door een prefill-plugin "
 "gevuld?"
 
-#: openforms/submissions/models/submission_value_variable.py:483
+#: openforms/submissions/models/submission_value_variable.py:490
 msgid "Form.io component configuration"
 msgstr "Form.io component configuratie"
 
-#: openforms/submissions/models/submission_value_variable.py:484
+#: openforms/submissions/models/submission_value_variable.py:491
 msgid "The component configuration as Form.io JSON schema"
 msgstr "De formulierdefinitie als Form.io JSON schema"
 
-#: openforms/submissions/models/submission_value_variable.py:505
+#: openforms/submissions/models/submission_value_variable.py:512
 msgid "pre-registration status"
 msgstr "pre-registratiestatus"
 
-#: openforms/submissions/models/submission_value_variable.py:507
+#: openforms/submissions/models/submission_value_variable.py:514
 msgid ""
 "Indication whether the pre-registration hook in the component plugin was "
 "successful."
 msgstr "Indicatie of de pre-registratiestap van de component succesvol was."
 
-#: openforms/submissions/models/submission_value_variable.py:514
+#: openforms/submissions/models/submission_value_variable.py:521
 msgid "pre-registration result"
 msgstr "pre-registratieresultaat"
 
-#: openforms/submissions/models/submission_value_variable.py:518
+#: openforms/submissions/models/submission_value_variable.py:525
 msgid "Contains data returned by the pre-registration hook of the component."
 msgstr ""
 "Bevat de gegevens zoals teruggegeven door de pre-registratie van de "
 "component."
 
-#: openforms/submissions/models/submission_value_variable.py:527
+#: openforms/submissions/models/submission_value_variable.py:535
 msgid "Submission value variable"
 msgstr "Inzendingswaarde"
 
-#: openforms/submissions/models/submission_value_variable.py:528
+#: openforms/submissions/models/submission_value_variable.py:536
 msgid "Submission values variables"
 msgstr "Inzendingswaarden"
 
-#: openforms/submissions/models/submission_value_variable.py:545
+#: openforms/submissions/models/submission_value_variable.py:553
 #, python-brace-format
 msgid "Submission value variable {key}"
 msgstr "Inzendingswaarde {key}"
@@ -13603,11 +13669,6 @@ msgstr "Wachtwoord wijzigen"
 #: openforms/templates/admin/base_site.html:50
 msgid "Account security"
 msgstr "Accountbeveiliging"
-
-#: openforms/templates/admin/base_site.html:71
-#, python-format
-msgid "version %(version)s"
-msgstr "versie %(version)s"
 
 #: openforms/templates/cookie_consent/_cookie_group.html:19
 msgid "Accepted"
@@ -13780,6 +13841,7 @@ msgid "Get customized (compiled) translations"
 msgstr "Krijg aangepaste (gecompileerde) vertalingen"
 
 #: openforms/translations/api/views.py:99
+#, python-brace-format
 msgid ""
 "Retrieve the new customized (compiled) translations after changes have been "
 "applied. This is done based on the language code in the path. In case no "
@@ -14270,7 +14332,7 @@ msgstr ""
 msgid "International phone number"
 msgstr "Internationaal telefoonnummer"
 
-#: openforms/validations/validators/formats.py:72 openforms/conf/base.py:61
+#: openforms/validations/validators/formats.py:72 openforms/conf/base.py:62
 msgid "Dutch"
 msgstr "Nederlands"
 
@@ -14458,29 +14520,35 @@ msgstr ""
 msgid "service fetch configurations"
 msgstr "Servicebevragingconfiguraties"
 
-#: openforms/variables/static_variables/static_variables.py:16
+#: openforms/variables/static_variables/static_variables.py:25
 msgid "Now"
 msgstr "Nu"
 
-#: openforms/variables/static_variables/static_variables.py:33
+#: openforms/variables/static_variables/static_variables.py:42
 msgid "Today"
 msgstr "Vandaag"
 
-#: openforms/variables/static_variables/static_variables.py:46
+#: openforms/variables/static_variables/static_variables.py:55
 msgid "Current year"
 msgstr "Huidig jaar"
 
-#: openforms/variables/static_variables/static_variables.py:59
+#: openforms/variables/static_variables/static_variables.py:68
 msgid "Environment"
 msgstr "Omgeving"
 
-#: openforms/variables/static_variables/static_variables.py:71
+#: openforms/variables/static_variables/static_variables.py:80
 msgid "Form name"
 msgstr "Formuliernaam"
 
-#: openforms/variables/static_variables/static_variables.py:83
+#: openforms/variables/static_variables/static_variables.py:92
 msgid "Form ID"
 msgstr "Formulier-ID"
+
+#: openforms/variables/static_variables/static_variables.py:104
+#, fuzzy
+#| msgid "Form variable"
+msgid "Form Url"
+msgstr "Formuliervariabele"
 
 #: openforms/variables/validators.py:66
 msgid "Header should have the form {\"X-my-header\": \"My header value\"}"
@@ -15133,9 +15201,76 @@ msgid "Without any binding addresses, no Suwinet service can be used."
 msgstr ""
 "Zonder enig \"binding address\" kan er geen Suwinet service gebruikt worden."
 
-#: openforms/conf/base.py:63
+#: openforms/conf/base.py:64
 msgid "English"
 msgstr "Engels"
+
+#, python-format
+#~ msgid "version %(version)s"
+#~ msgstr "versie %(version)s"
+
+#~ msgid ""
+#~ "\n"
+#~ "            Once your request has been processed, you will be sent an email (at the address configured in your admin\n"
+#~ "            profile) containing a link where you can download a zip file with all the exported forms.\n"
+#~ "            "
+#~ msgstr ""
+#~ "\n"
+#~ "Zodra uw verzoek verwerkt is, ontvangt u een e-mail met een link naar het ZIP-bestand dat alle geëxporteerde formulieren bevat."
+
+#~ msgid ""
+#~ "The catalogue in the catalogi API from the selected API group. This "
+#~ "overrides the catalogue specified in the API group, if it's set. When "
+#~ "specified, the document types specified on the API group are ignored."
+#~ msgstr ""
+#~ "De catalogus in de Catalogi API uit de geselecteerde API-groep. Deze waarde "
+#~ "overschrijft de catalogus die in de API-groep ingesteld is. Als je de "
+#~ "catalogus hier instelt, dan worden eventuele ingestelde documenttypen in de "
+#~ "API-groep genegeerd."
+
+#~ msgid "submission report PDF informatieobjecttype"
+#~ msgstr "inzendings PDF document informatieobjecttype"
+
+#~ msgid ""
+#~ "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used "
+#~ "for the submission report PDF."
+#~ msgstr ""
+#~ "URL naar het INFORMATIEOBJECTTYPE in een Catalogi API dat wordt gebruikt "
+#~ "voor het PDF-document."
+
+#~ msgid ""
+#~ "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used "
+#~ "for the submission report CSV."
+#~ msgstr ""
+#~ "URL naar het INFORMATIEOBJECTTYPE in een Catalogi API dat wordt gebruikt "
+#~ "voor het CSV-document."
+
+#~ msgid ""
+#~ "URL that points to the INFORMATIEOBJECTTYPE in the Catalogi API to be used "
+#~ "for the submission attachments."
+#~ msgstr ""
+#~ "URL naar het INFORMATIEOBJECTTYPE in een Catalogi API dat wordt gebruikt "
+#~ "voor de bijlagen."
+
+#, python-brace-format
+#~ msgid "The provided {field} does not exist in the Catalogi API."
+#~ msgstr "Het opgegeven {field} bestaat niet in de ingestelde Catalogi API."
+
+#, python-brace-format
+#~ msgid "The provided {field} does not exist in the selected catalogue."
+#~ msgstr "Het opgegeven {field} bestaat niet in de geselecteerde catalogus."
+
+#~ msgid "URL of the ZAAKTYPE in the Catalogi API"
+#~ msgstr "URL van het ZAAKTYPE in de Catalogi API"
+
+#~ msgid "URL of the INFORMATIEOBJECTTYPE in the Catalogi API"
+#~ msgstr "URL van het INFORMATIEOBJECTTYPE in de Catalogi API"
+
+#~ msgid "You must specify a case type."
+#~ msgstr "Je moet een zaaktype instellen."
+
+#~ msgid "You must specify a document type"
+#~ msgstr "Je moet een documenttype instellen."
 
 #~ msgid "Catalogue"
 #~ msgstr "Catalogus"
@@ -15146,8 +15281,8 @@ msgstr "Engels"
 #~ "validated against the catalogue."
 #~ msgstr ""
 #~ "Selecteer de catalogus (uit de ingestelde Catalogi API-service) waar de "
-#~ "documenttypen gedefinieerd zijn. Wanneer documenttypen ingesteld zijn, "
-#~ "dan worden deze tegen de catalogus gevalideerd."
+#~ "documenttypen gedefinieerd zijn. Wanneer documenttypen ingesteld zijn, dan "
+#~ "worden deze tegen de catalogus gevalideerd."
 
 #~ msgid "Default values (deprecated)"
 #~ msgstr "Standaardwaarden (verouderd)"
@@ -15178,14 +15313,14 @@ msgstr "Engels"
 #~ "Please verify the selected forms have the ogone-legacy payment backend "
 #~ "configured."
 #~ msgstr ""
-#~ "Een of meerdere formulieren konden niet gemigreerd worden naar de "
-#~ "Worldline betalingsprovider. Controleer dat de geselecteerde formulieren "
-#~ "de Ogone Backend geconfigueerd hebben."
+#~ "Een of meerdere formulieren konden niet gemigreerd worden naar de Worldline "
+#~ "betalingsprovider. Controleer dat de geselecteerde formulieren de Ogone "
+#~ "Backend geconfigueerd hebben."
 
 #, python-brace-format
 #~ msgid ""
-#~ "The following forms reference a merchant that is non-existent: {form_ids}"
-#~ "Please select a new merchant for these forms."
+#~ "The following forms reference a merchant that is non-existent: "
+#~ "{form_ids}Please select a new merchant for these forms."
 #~ msgstr ""
 #~ "De volgende formulieren refereren naar een merchant die niet bestaat: "
 #~ "{form_ids}. Selecteer een nieuwe merchant voor deze formulieren."
@@ -15223,17 +15358,15 @@ msgstr "Engels"
 
 #~ msgid ""
 #~ "API Key created for the specified PSPID. This value will be used when "
-#~ "upgrading to a Open Forms version supporting the Worldline payment "
-#~ "provider."
+#~ "upgrading to a Open Forms version supporting the Worldline payment provider."
 #~ msgstr ""
-#~ "API Key aangemaakt voor de specifieke PSPID. Deze waarde zal gebruikt "
-#~ "worden tijdens het upgraden naar een Open Forms versie die de nieuwe "
-#~ "Worldline betalingsprovider ondersteunt."
+#~ "API Key aangemaakt voor de specifieke PSPID. Deze waarde zal gebruikt worden"
+#~ " tijdens het upgraden naar een Open Forms versie die de nieuwe Worldline "
+#~ "betalingsprovider ondersteunt."
 
 #~ msgid ""
 #~ "API Secret created for the specified PSPID. This value will be used when "
-#~ "upgrading to a Open Forms version supporting the Worldline payment "
-#~ "provider."
+#~ "upgrading to a Open Forms version supporting the Worldline payment provider."
 #~ msgstr ""
 #~ "API Secret aangemaakt voor de specifieke PSPID. Deze waarde zal gebruikt "
 #~ "worden tijdens het upgraden naar een Open Forms versie die de nieuwe "
@@ -15250,15 +15383,15 @@ msgstr "Engels"
 
 #~ msgid ""
 #~ "Optional custom template for the title displayed on the payment page. You "
-#~ "can include all form variables (using their keys) and the "
-#~ "'public_reference' variable (using expression '{{ public_reference }}'). "
-#~ "If unspecified, a default description is used."
+#~ "can include all form variables (using their keys) and the 'public_reference'"
+#~ " variable (using expression '{{ public_reference }}'). If unspecified, a "
+#~ "default description is used."
 #~ msgstr ""
 #~ "Sjabloon voor de titel die op de betaalpagina getoond wordt. Je kan alle "
-#~ "formuliervariabelen gebruiken (gebruik de variabelesleutel als naam) en "
-#~ "de 'public_reference' sjabloonvariabele (gebruik de expressie "
-#~ "'{{ public_reference }}'). Indien geen sjabloon opgegeven is, dan wordt "
-#~ "een standaardomschrijving gebruikt."
+#~ "formuliervariabelen gebruiken (gebruik de variabelesleutel als naam) en de "
+#~ "'public_reference' sjabloonvariabele (gebruik de expressie '{{ "
+#~ "public_reference }}'). Indien geen sjabloon opgegeven is, dan wordt een "
+#~ "standaardomschrijving gebruikt."
 
 #~ msgid "COM template"
 #~ msgstr "COM-sjabloon"
@@ -15266,20 +15399,20 @@ msgstr "Engels"
 #~ msgid ""
 #~ "Optional custom template for the description, included in the payment "
 #~ "overviews for the backoffice. Use this to link the payment back to a "
-#~ "particular process or form. You can include all form variables (using "
-#~ "their keys) and the 'public_reference' variable (using expression "
-#~ "'{{ public_reference }}'). If unspecified, a default description is used. "
-#~ "Note that the length of the result is capped to 100 characters and only "
-#~ "alpha-numeric characters are allowed."
+#~ "particular process or form. You can include all form variables (using their "
+#~ "keys) and the 'public_reference' variable (using expression '{{ "
+#~ "public_reference }}'). If unspecified, a default description is used. Note "
+#~ "that the length of the result is capped to 100 characters and only alpha-"
+#~ "numeric characters are allowed."
 #~ msgstr ""
-#~ "Sjabloon voor de omschrijving van de betaling in de afschriften die je "
-#~ "bij Ogone kan ophalen. Gebruik dit om betalingen aan processen/afdelingen "
-#~ "te koppelen. Je kan alle formuliervariabelen gebruiken (gebruik de "
+#~ "Sjabloon voor de omschrijving van de betaling in de afschriften die je bij "
+#~ "Ogone kan ophalen. Gebruik dit om betalingen aan processen/afdelingen te "
+#~ "koppelen. Je kan alle formuliervariabelen gebruiken (gebruik de "
 #~ "variabelesleutel als naam) en de 'public_reference' sjabloonvariabele "
 #~ "(gebruik de expressie '{{ public_reference }}'). Indien geen sjabloon "
-#~ "opgegeven is, dan wordt een standaardomschrijving gebruikt. Merk op dat "
-#~ "het resultaat op 100 karakters afgekapt wordt en enkel alfanumerieke "
-#~ "tekens toegestaan zijn."
+#~ "opgegeven is, dan wordt een standaardomschrijving gebruikt. Merk op dat het "
+#~ "resultaat op 100 karakters afgekapt wordt en enkel alfanumerieke tekens "
+#~ "toegestaan zijn."
 
 #~ msgid "Ogone legacy"
 #~ msgstr "Ogone legacy"
@@ -15292,8 +15425,8 @@ msgstr "Engels"
 #~ "zaak- en documenttypen gedefinieerd zijn."
 
 #~ msgid ""
-#~ "You must create a valid ZGW API Group config (with the necessary "
-#~ "services) before importing."
+#~ "You must create a valid ZGW API Group config (with the necessary services) "
+#~ "before importing."
 #~ msgstr ""
 #~ "Je moet eerst een werkende ZGW API-groep aanmaken voor dit formulier "
 #~ "geïmporteerd kan worden."

--- a/src/openforms/forms/admin/form.py
+++ b/src/openforms/forms/admin/form.py
@@ -1,3 +1,5 @@
+import json
+
 from django.contrib import admin, messages
 from django.contrib.admin.templatetags.admin_list import result_headers
 from django.db.models import BooleanField, Case, Count, F, Value, When
@@ -12,6 +14,7 @@ from ordered_model.admin import OrderedInlineModelAdminMixin, OrderedTabularInli
 
 from openforms.api.utils import underscore_to_camel
 from openforms.emails.models import ConfirmationEmailTemplate
+from openforms.import_export.typing import FormExportOptions
 from openforms.registrations.admin import RegistrationBackendFieldMixin
 from openforms.typing import StrOrPromise
 from openforms.utils.expressions import FirstNotBlank
@@ -299,6 +302,8 @@ class FormAdmin(
                 reverse("admin:forms_form_change", args=(copied_form.pk,))
             )
         if "_export" in request.POST:
+            export_options = json.loads(request.POST.get("export_options", "{}"))
+
             # Clear messages
             storage = messages.get_messages(request)
             for _msg in storage:
@@ -306,7 +311,21 @@ class FormAdmin(
 
             response = HttpResponse(content_type="application/zip")
             response["Content-Disposition"] = f"attachment;filename={obj.slug}.zip"
-            export_form(obj.pk, response=response)
+            export_form(
+                obj.pk,
+                response=response,
+                export_options=FormExportOptions(
+                    **{
+                        field_name: export_options[field_name]
+                        for field_name in (
+                            "remove_sensitive_content",
+                            "form_configuration",
+                            "additional_form_configuration",
+                        )
+                        if field_name in export_options
+                    },
+                ),
+            )
 
             response["Content-Length"] = len(response.content)
 

--- a/src/openforms/forms/admin/tasks.py
+++ b/src/openforms/forms/admin/tasks.py
@@ -17,6 +17,7 @@ from rest_framework.exceptions import ValidationError
 from openforms.accounts.models import User
 from openforms.celery import app
 from openforms.emails.utils import send_mail_html
+from openforms.import_export.typing import FormExportOptions
 from openforms.logging import audit_logger
 from openforms.utils.urls import build_absolute_uri
 
@@ -28,7 +29,9 @@ logger = structlog.stdlib.get_logger(__name__)
 
 
 @app.task(ignore_result=True)
-def process_forms_export(forms_uuids: list, user_id: int) -> None:
+def process_forms_export(
+    forms_uuids: list, user_id: int, export_options: FormExportOptions
+) -> None:
     forms = Form.objects.filter(uuid__in=forms_uuids)
 
     user = User.objects.get(id=user_id)
@@ -41,6 +44,7 @@ def process_forms_export(forms_uuids: list, user_id: int) -> None:
                 export_form(
                     form_id=form.pk,
                     archive_name=Path(temp_dir, f"form_{form.slug}.zip"),
+                    export_options=export_options,
                 )
             )
 

--- a/src/openforms/forms/admin/tasks.py
+++ b/src/openforms/forms/admin/tasks.py
@@ -17,7 +17,7 @@ from rest_framework.exceptions import ValidationError
 from openforms.accounts.models import User
 from openforms.celery import app
 from openforms.emails.utils import send_mail_html
-from openforms.import_export.typing import FormExportOptions
+from openforms.import_export.typing import FormExportOptions, FormImportOptions
 from openforms.logging import audit_logger
 from openforms.utils.urls import build_absolute_uri
 
@@ -79,7 +79,9 @@ def process_forms_export(
 
 
 @app.task(ignore_result=True)
-def process_forms_import(import_file: str, user_id: int) -> None:
+def process_forms_import(
+    import_file: str, user_id: int, import_options: FormImportOptions = None
+) -> None:
     failed_files: list[tuple[str, object]] = []
     # This deletes the temp dir once the context manager is exited
     with tempfile.TemporaryDirectory() as temp_dir:
@@ -88,7 +90,8 @@ def process_forms_import(import_file: str, user_id: int) -> None:
                 try:
                     # This normalises the path before extracting the files (to avoid writing outside the temp_dir)
                     import_form(
-                        zip_file.extract(member=zipped_form_file, path=temp_dir)
+                        zip_file.extract(member=zipped_form_file, path=temp_dir),
+                        import_options=import_options,
                     )
                 except ValidationError as exc:
                     filename = Path(zipped_form_file.filename).name

--- a/src/openforms/forms/admin/views.py
+++ b/src/openforms/forms/admin/views.py
@@ -22,6 +22,12 @@ from import_export.formats.base_formats import XLSX
 from privates.storages import private_media_storage
 from rest_framework.exceptions import ValidationError
 
+from openforms.import_export.typing import (
+    EXPORT_FORM_CONFIGURATION_CHOICES,
+    AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
+    FormExportOptions,
+)
 from openforms.logging import audit_logger
 
 from ..forms import ExportStatisticsForm
@@ -33,6 +39,37 @@ from .tasks import process_forms_export, process_forms_import
 
 class ExportFormsForm(forms.Form):
     forms_uuids = SimpleArrayField(forms.UUIDField(), widget=forms.HiddenInput)
+    remove_sensitive_content = forms.BooleanField(
+        label=_("Anonymize form configuration"),
+        required=False,
+        initial=True,
+        help_text=_(
+            "Whether sensative form configuration should be anonymized during exporting."
+        ),
+    )
+    form_configuration = forms.MultipleChoiceField(
+        label=_("Form configuration"),
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        initial=[
+            FormConfigurationOptions.registration_backends,
+            FormConfigurationOptions.prefill,
+            FormConfigurationOptions.payment_backend,
+        ],
+        choices=EXPORT_FORM_CONFIGURATION_CHOICES,
+        help_text=_(
+            "Which form configuration should be included in the export file content."
+        ),
+    )
+    additional_form_configuration = forms.MultipleChoiceField(
+        label=_("Additional form configuration"),
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        choices=AdditionalFormConfigurationOptions.choices,
+        help_text=_(
+            "Which additional form configuration should be included in the export file content."
+        ),
+    )
 
     def clean_forms_uuids(self):
         if not Form.objects.filter(uuid__in=self.cleaned_data["forms_uuids"]).exists():
@@ -55,6 +92,17 @@ class ExportFormsView(ExportImportPermissionMixin, SuccessMessageMixin, FormView
         process_forms_export.delay(
             forms_uuids=form.cleaned_data["forms_uuids"],
             user_id=self.request.user.id,
+            export_options=FormExportOptions(
+                **{
+                    field_name: form.cleaned_data[field_name]
+                    for field_name in (
+                        "remove_sensitive_content",
+                        "form_configuration",
+                        "additional_form_configuration",
+                    )
+                    if field_name in form.cleaned_data
+                },
+            ),
         )
         return super().form_valid(form)
 

--- a/src/openforms/forms/admin/views.py
+++ b/src/openforms/forms/admin/views.py
@@ -27,6 +27,7 @@ from openforms.import_export.typing import (
     AdditionalFormConfigurationOptions,
     FormConfigurationOptions,
     FormExportOptions,
+    FormImportOptions,
 )
 from openforms.logging import audit_logger
 
@@ -137,9 +138,25 @@ class ImportFormsView(ExportImportPermissionMixin, SuccessMessageMixin, FormView
         import_file = form.cleaned_data["file"]
         is_bulk_import = self.get_is_bulk_import(import_file)
 
+        import_options = FormImportOptions(
+            **{
+                field_name: form.cleaned_data[field_name]
+                for field_name in (
+                    "form_configuration",
+                    "reusable_form_definitions",
+                    "links_to_unknown_domains",
+                    "additional_form_configuration",
+                )
+                if field_name in form.cleaned_data
+            }
+        )
+
         if not is_bulk_import:
             try:
-                import_form(import_file)
+                import_form(
+                    import_file,
+                    import_options=import_options,
+                )
             except ValidationError as exc:
                 messages.error(
                     self.request,
@@ -147,7 +164,7 @@ class ImportFormsView(ExportImportPermissionMixin, SuccessMessageMixin, FormView
                 )
                 return super().form_invalid(form)
         else:
-            self._bulk_import_forms(import_file)
+            self._bulk_import_forms(import_file, import_options)
 
         return super().form_valid(form)
 
@@ -161,11 +178,11 @@ class ImportFormsView(ExportImportPermissionMixin, SuccessMessageMixin, FormView
             "The bulk import is being processed! The imported forms will soon be available."
         )
 
-    def _bulk_import_forms(self, import_file):
+    def _bulk_import_forms(self, import_file, import_options: FormImportOptions):
         name = f"imports/import_forms_{uuid4()}.zip"
         filename = private_media_storage.save(name, import_file)
 
-        process_forms_import.delay(filename, self.request.user.id)
+        process_forms_import.delay(filename, self.request.user.id, import_options)
 
 
 @method_decorator(staff_member_required, name="dispatch")

--- a/src/openforms/forms/api/serializers/__init__.py
+++ b/src/openforms/forms/api/serializers/__init__.py
@@ -1,4 +1,4 @@
-from .form import FormExportSerializer, FormImportSerializer, FormSerializer
+from .form import FormImportSerializer, FormSerializer
 from .form_admin_message import FormAdminMessageSerializer
 from .form_definition import FormDefinitionDetailSerializer, FormDefinitionSerializer
 from .form_step import FormStepLiteralsSerializer, FormStepSerializer
@@ -11,7 +11,6 @@ __all__ = [
     "LogicComponentActionSerializer",
     "FormLogicSerializer",
     "FormSerializer",
-    "FormExportSerializer",
     "FormImportSerializer",
     "FormDefinitionSerializer",
     "FormDefinitionDetailSerializer",

--- a/src/openforms/forms/api/serializers/form.py
+++ b/src/openforms/forms/api/serializers/form.py
@@ -26,6 +26,10 @@ from openforms.contrib.objects_api.models import ObjectsAPIGroupConfig
 from openforms.emails.api.serializers import ConfirmationEmailTemplateSerializer
 from openforms.emails.models import ConfirmationEmailTemplate
 from openforms.formio.typing import Component
+from openforms.import_export.typing import (
+    EXPORT_FORM_CONFIGURATION_CHOICES,
+    AdditionalFormConfigurationOptions,
+)
 from openforms.payments.api.fields import PaymentOptionsReadOnlyField
 from openforms.payments.registry import register as payment_register
 from openforms.plugins.constants import UNIQUE_ID_MAX_LENGTH
@@ -653,6 +657,29 @@ FormSerializer.__doc__ = FormSerializer.__doc__.format(
         [f"`{field}`" for field in FormSerializer._get_admin_field_names()]
     )
 )
+
+
+class FormAPIExportRequestSerializer(serializers.Serializer):
+    remove_sensitive_content = serializers.BooleanField(
+        required=False,
+        help_text=_(
+            "Whether sensative form configuration should be anonymized during exporting."
+        ),
+    )
+    form_configuration = serializers.MultipleChoiceField(
+        required=False,
+        choices=EXPORT_FORM_CONFIGURATION_CHOICES,
+        help_text=_(
+            "Which form configuration should be included in the export file content."
+        ),
+    )
+    additional_form_configuration = serializers.MultipleChoiceField(
+        required=False,
+        choices=AdditionalFormConfigurationOptions.choices,
+        help_text=_(
+            "Which additional form configuration should be included in the export file content."
+        ),
+    )
 
 
 class FormImportSerializer(serializers.Serializer):

--- a/src/openforms/forms/api/serializers/form.py
+++ b/src/openforms/forms/api/serializers/form.py
@@ -655,17 +655,6 @@ FormSerializer.__doc__ = FormSerializer.__doc__.format(
 )
 
 
-class FormExportSerializer(FormSerializer):
-    def get_fields(self):
-        fields = super().get_fields()
-        # for export we want to use the list of plugin-id's instead of detailed info objects
-        if "login_options" in fields:
-            del fields["login_options"]
-        if "payment_options" in fields:
-            del fields["payment_options"]
-        return fields
-
-
 class FormImportSerializer(serializers.Serializer):
     file = serializers.FileField(
         help_text=_("The file that contains the form, form definitions and form steps.")

--- a/src/openforms/forms/api/serializers/form.py
+++ b/src/openforms/forms/api/serializers/form.py
@@ -701,10 +701,8 @@ class FormImportSerializer(serializers.Serializer):
         choices=ReusableFormDefinitionsOptions.choices,
         help_text=_(
             "Whether to reuse existing form definitions or create new ones for each "
-            "form definition in the import file. "
-            "To determine whether a form definition is a duplicate, the title and "
-            "configuration are compared. If no comparable form definition exists, a new "
-            "form definition is created regardless of the choice."
+            "form definition in the import file. If no similar form definition exists, "
+            "a new form definition is created."
         ),
     )
     links_to_unknown_domains = serializers.ChoiceField(

--- a/src/openforms/forms/api/serializers/form.py
+++ b/src/openforms/forms/api/serializers/form.py
@@ -29,6 +29,9 @@ from openforms.formio.typing import Component
 from openforms.import_export.typing import (
     EXPORT_FORM_CONFIGURATION_CHOICES,
     AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
+    LinksToUnknownDomainsOptions,
+    ReusableFormDefinitionsOptions,
 )
 from openforms.payments.api.fields import PaymentOptionsReadOnlyField
 from openforms.payments.registry import register as payment_register
@@ -685,6 +688,39 @@ class FormAPIExportRequestSerializer(serializers.Serializer):
 class FormImportSerializer(serializers.Serializer):
     file = serializers.FileField(
         help_text=_("The file that contains the form, form definitions and form steps.")
+    )
+    form_configuration = serializers.MultipleChoiceField(
+        choices=FormConfigurationOptions.choices,
+        help_text=_(
+            "Which form configuration should be included in the export file content."
+        ),
+        required=False,
+    )
+    reusable_form_definitions = serializers.ChoiceField(
+        required=False,
+        choices=ReusableFormDefinitionsOptions.choices,
+        help_text=_(
+            "Whether to reuse existing form definitions or create new ones for each "
+            "form definition in the import file. "
+            "To determine whether a form definition is a duplicate, the title and "
+            "configuration are compared. If no comparable form definition exists, a new "
+            "form definition is created regardless of the choice."
+        ),
+    )
+    links_to_unknown_domains = serializers.ChoiceField(
+        required=False,
+        help_text=_(
+            "What to do with links in email templates to domains that are not accepted "
+            "in the global configuration."
+        ),
+        choices=LinksToUnknownDomainsOptions.choices,
+    )
+    additional_form_configuration = serializers.MultipleChoiceField(
+        required=False,
+        choices=AdditionalFormConfigurationOptions.choices,
+        help_text=_(
+            "Which additional form configuration should be included in the export file content."
+        ),
     )
 
 

--- a/src/openforms/forms/api/serializers/form_definition.py
+++ b/src/openforms/forms/api/serializers/form_definition.py
@@ -66,6 +66,7 @@ class FormDefinitionConfigurationSerializer(serializers.Serializer):
 class FormDefinitionSerializer(
     PublicFieldsSerializerMixin, serializers.HyperlinkedModelSerializer
 ):
+    is_exporting: bool = False
     translations = ModelTranslationsSerializer()
     configuration = FormDefinitionConfigurationSerializer(
         label=_("Form.io configuration"),
@@ -121,9 +122,7 @@ class FormDefinitionSerializer(
         #    for the dynamic formio configuration in the context of a submission.
         # 2. The serializers/API endpoints of :module:`openforms.forms.api` for
         #    'standalone' use/introspection.
-        is_export = self.context.get("is_export", False)
-
-        if not is_export:
+        if not self.is_exporting:
             rewrite_formio_components_for_request(
                 instance.configuration_wrapper,
                 request=self.context["request"],

--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -21,6 +21,7 @@ from rest_framework.response import Response
 
 from openforms.api.pagination import PageNumberPagination
 from openforms.api.serializers import ExceptionSerializer, ValidationErrorSerializer
+from openforms.import_export.typing import FormExportOptions
 from openforms.translations.utils import set_language_cookie
 from openforms.utils.patches.rest_framework_nested.viewsets import NestedViewSetMixin
 from openforms.utils.urls import is_admin_request, reverse_plus
@@ -61,6 +62,7 @@ from .serializers import (
     FormVersionSerializer,
 )
 from .serializers.form import (
+    FormAPIExportRequestSerializer,
     FormImportResponseSerializer,
     FormJsonSchemaOptionsSerializer,
 )
@@ -422,7 +424,10 @@ class FormViewSet(viewsets.ModelViewSet):
         },
     )
     @action(
-        detail=True, methods=["post"], authentication_classes=(TokenAuthentication,)
+        detail=True,
+        methods=["post"],
+        authentication_classes=(TokenAuthentication,),
+        serializer_class=FormAPIExportRequestSerializer,
     )
     def export(self, request, *args, **kwargs):
         """
@@ -435,7 +440,24 @@ class FormViewSet(viewsets.ModelViewSet):
         response = HttpResponse(content_type="application/zip")
         response["Content-Disposition"] = f"attachment;filename={instance.slug}.zip"
 
-        export_form(instance.id, response=response)
+        serializer = self.serializer_class(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        export_form(
+            instance.id,
+            response=response,
+            export_options=FormExportOptions(
+                **{
+                    field_name: serializer.validated_data[field_name]
+                    for field_name in (
+                        "remove_sensitive_content",
+                        "form_configuration",
+                        "additional_form_configuration",
+                    )
+                    if field_name in serializer.validated_data
+                },
+            ),
+        )
 
         response["Content-Length"] = len(response.content)
         return response

--- a/src/openforms/forms/api/viewsets.py
+++ b/src/openforms/forms/api/viewsets.py
@@ -21,7 +21,7 @@ from rest_framework.response import Response
 
 from openforms.api.pagination import PageNumberPagination
 from openforms.api.serializers import ExceptionSerializer, ValidationErrorSerializer
-from openforms.import_export.typing import FormExportOptions
+from openforms.import_export.typing import FormExportOptions, FormImportOptions
 from openforms.translations.utils import set_language_cookie
 from openforms.utils.patches.rest_framework_nested.viewsets import NestedViewSetMixin
 from openforms.utils.urls import is_admin_request, reverse_plus
@@ -776,7 +776,10 @@ class FormVersionViewSet(NestedViewSetMixin, ListModelMixin, viewsets.GenericVie
 
 class FormsImportAPIView(views.APIView):
     serializer_class = FormImportSerializer
-    parser_classes = (parsers.FileUploadParser,)
+    parser_classes = (
+        parsers.MultiPartParser,
+        parsers.FormParser,
+    )
     authentication_classes = [TokenAuthentication]
     permission_classes = [FormAPIPermissions]
 
@@ -792,8 +795,24 @@ class FormsImportAPIView(views.APIView):
         """
         serializer = self.serializer_class(data=request.data)
         serializer.is_valid(raise_exception=True)
+        print(request.data)
+        print(serializer.validated_data)
 
-        form_instance = import_form(serializer.validated_data["file"])
+        form_instance = import_form(
+            serializer.validated_data["file"],
+            import_options=FormImportOptions(
+                **{
+                    field_name: serializer.validated_data[field_name]
+                    for field_name in (
+                        "form_configuration",
+                        "reusable_form_definitions",
+                        "links_to_unknown_domains",
+                        "additional_form_configuration",
+                    )
+                    if field_name in serializer.validated_data
+                }
+            ),
+        )
         assert form_instance
 
         response_serializer = FormImportResponseSerializer(instance=form_instance)

--- a/src/openforms/forms/forms/form.py
+++ b/src/openforms/forms/forms/form.py
@@ -1,10 +1,66 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
 
+from openforms.import_export.typing import (
+    AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
+    LinksToUnknownDomainsOptions,
+    ReusableFormDefinitionsOptions,
+)
+
 
 class FormImportForm(forms.Form):
     file = forms.FileField(
         label=_("file"),
         required=True,
         help_text=_("Upload your exported ZIP-file."),
+    )
+    form_configuration = forms.MultipleChoiceField(
+        label=_("Form configuration"),
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        initial=[
+            FormConfigurationOptions.registration_backends,
+            FormConfigurationOptions.prefill,
+            FormConfigurationOptions.payment_backend,
+            FormConfigurationOptions.auth_backends,
+        ],
+        choices=FormConfigurationOptions.choices,
+        help_text=_(
+            "Which form configuration should be included in the export file content."
+        ),
+    )
+    reusable_form_definition = forms.ChoiceField(
+        label=_("Reusable form definition"),
+        required=False,
+        widget=forms.RadioSelect,
+        help_text=_(
+            "Whether to reuse existing form definitions or create new ones for each "
+            "form definition in the import file. "
+            "To determine whether a form definition is a duplicate, the title and "
+            "configuration are compared. If no comparable form definition exists, a new "
+            "form definition is created regardless of the choice."
+        ),
+        initial=ReusableFormDefinitionsOptions.create_new,
+        choices=ReusableFormDefinitionsOptions.choices,
+    )
+    links_to_unknown_domains = forms.ChoiceField(
+        label=_("Links to unknown domains in email templates"),
+        required=False,
+        widget=forms.RadioSelect,
+        help_text=_(
+            "What to do with links in email templates to domains that are not accepted "
+            "in the global configuration."
+        ),
+        initial=LinksToUnknownDomainsOptions.ignore,
+        choices=LinksToUnknownDomainsOptions.choices,
+    )
+    additional_form_configuration = forms.MultipleChoiceField(
+        label=_("Additional form configuration"),
+        required=False,
+        widget=forms.CheckboxSelectMultiple,
+        choices=AdditionalFormConfigurationOptions.choices,
+        help_text=_(
+            "Which additional form configuration should be included in the export file content."
+        ),
     )

--- a/src/openforms/forms/forms/form.py
+++ b/src/openforms/forms/forms/form.py
@@ -36,10 +36,8 @@ class FormImportForm(forms.Form):
         widget=forms.RadioSelect,
         help_text=_(
             "Whether to reuse existing form definitions or create new ones for each "
-            "form definition in the import file. "
-            "To determine whether a form definition is a duplicate, the title and "
-            "configuration are compared. If no comparable form definition exists, a new "
-            "form definition is created regardless of the choice."
+            "form definition in the import file. If no similar form definition exists, "
+            "a new form definition is created."
         ),
         initial=ReusableFormDefinitionsOptions.create_new,
         choices=ReusableFormDefinitionsOptions.choices,

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -6,7 +6,7 @@ from contextlib import suppress
 from copy import deepcopy
 from functools import cached_property
 from itertools import chain
-from typing import TYPE_CHECKING, ClassVar, Literal
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 from uuid import UUID
 
 from django.conf import settings
@@ -676,6 +676,37 @@ class Form(models.Model):
         for form_step in self.formstep_set.select_related("form_definition"):
             yield from form_step.iter_components(recursive=recursive)
 
+    @staticmethod
+    def __delete_current_form_configuration(current_form: Form):
+        from . import FormDefinition, FormLogic, FormStep, FormVariable
+
+        form_steps = FormStep.objects.filter(form=current_form)
+        # delete single-use form definitions, they're orphan nodes when deleting the steps
+        fd_ids = list(
+            FormDefinition.objects.filter(
+                is_reusable=False, formstep__in=form_steps
+            ).values_list("id", flat=True)
+        )
+        form_steps.delete()
+        FormDefinition.objects.filter(id__in=fd_ids).delete()
+        FormLogic.objects.filter(form=current_form).delete()
+        FormVariable.objects.filter(form=current_form).delete()
+
+    @staticmethod
+    def __after_restore_corrections(
+        restored: Form, restore_version_data: dict[str, Any]
+    ):
+        import json
+
+        form_data = json.loads(restore_version_data["forms"])[0]
+
+        # The FormImportSerializer sets the 'active' state to False by default. We should
+        # restore it to the state it had before.
+        if (previous_active := form_data.get("active")) is not None:
+            restored.active = previous_active
+
+        restored.save()
+
     @transaction.atomic
     def restore_old_version(
         self, form_version_uuid: str, user: User | None = None
@@ -698,7 +729,13 @@ class Form(models.Model):
         form_version = form_versions_mapping[form_version_uuid]
         old_version_data = form_version.export_blob
 
-        import_form_data(old_version_data, form_version.form)
+        # when restoring a previous version, delete the current form configuration,
+        # it will be replaced with the import data.
+        self.__delete_current_form_configuration(form_version.form)
+
+        restored_form = import_form_data(old_version_data, form_version.form)
+
+        self.__after_restore_corrections(restored_form, old_version_data)
 
         # now create a new FormVersion for this restore as well, tracking those nuances
         # in the description.

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -32,6 +32,13 @@ from openforms.config.models import GlobalConfiguration
 from openforms.data_removal.constants import RemovalMethods
 from openforms.formio.typing import Component
 from openforms.formio.validators import variable_key_validator
+from openforms.import_export.typing import (
+    AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
+    FormImportOptions,
+    LinksToUnknownDomainsOptions,
+    ReusableFormDefinitionsOptions,
+)
 from openforms.payments.fields import PaymentBackendChoiceField
 from openforms.payments.registry import register as payment_register
 from openforms.plugins.constants import UNIQUE_ID_MAX_LENGTH
@@ -733,7 +740,28 @@ class Form(models.Model):
         # it will be replaced with the import data.
         self.__delete_current_form_configuration(form_version.form)
 
-        restored_form = import_form_data(old_version_data, form_version.form)
+        restored_form = import_form_data(
+            old_version_data,
+            form_version.form,
+            import_options=FormImportOptions(
+                form_configuration=[
+                    FormConfigurationOptions.registration_backends,
+                    FormConfigurationOptions.prefill,
+                    FormConfigurationOptions.payment_backend,
+                    FormConfigurationOptions.auth_backends,
+                ],
+                additional_form_configuration=[
+                    AdditionalFormConfigurationOptions.product,
+                    AdditionalFormConfigurationOptions.theme,
+                    AdditionalFormConfigurationOptions.category,
+                    AdditionalFormConfigurationOptions.wms_tile_layers,
+                    AdditionalFormConfigurationOptions.wmts_tile_layers,
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                ],
+                reusable_form_definitions=ReusableFormDefinitionsOptions.reuse_existing,
+                links_to_unknown_domains=LinksToUnknownDomainsOptions.remove,
+            ),
+        )
 
         self.__after_restore_corrections(restored_form, old_version_data)
 

--- a/src/openforms/forms/models/form_version.py
+++ b/src/openforms/forms/models/form_version.py
@@ -8,6 +8,11 @@ from django.utils.formats import localize
 from django.utils.timezone import localtime
 from django.utils.translation import gettext_lazy as _
 
+from ...import_export.typing import (
+    AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
+    FormExportOptions,
+)
 from .form import Form
 
 User = get_user_model()
@@ -23,7 +28,25 @@ class FormVersionManager(models.Manager):
         # circular dependencies
         from ..utils import form_to_json
 
-        form_json = form_to_json(form.id)
+        form_json = form_to_json(
+            form.id,
+            export_options=FormExportOptions(
+                form_configuration=[
+                    FormConfigurationOptions.registration_backends,
+                    FormConfigurationOptions.prefill,
+                    FormConfigurationOptions.payment_backend,
+                ],
+                additional_form_configuration=[
+                    AdditionalFormConfigurationOptions.product,
+                    AdditionalFormConfigurationOptions.theme,
+                    AdditionalFormConfigurationOptions.category,
+                    AdditionalFormConfigurationOptions.wms_tile_layers,
+                    AdditionalFormConfigurationOptions.wmts_tile_layers,
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                ],
+                remove_sensitive_content=False,
+            ),
+        )
         if not description:
             version_number = self.filter(form=form).count() + 1
             description = _("Version {number}").format(number=version_number)

--- a/src/openforms/forms/templates/admin/forms/form/export.html
+++ b/src/openforms/forms/templates/admin/forms/form/export.html
@@ -56,7 +56,16 @@
                             {{ field.errors }}
                             <div class="flex-container {% if field.field.widget.input_type == 'checkbox' and field|length == 1 %}checkbox-row{% endif %} {% if field.errors %}errors{% endif %}">
                                 {{ field.label_tag }}
-                                {{ field }}
+
+                                {% if field|length == 1 %}
+                                    {{ field }}
+                                {% else %}
+                                    <ul {% if field.id_for_label %} id="{{ field.id_for_label }}"{% endif %}>
+                                        {% for subfield in field %}
+                                            <li>{{ subfield }}</li>
+                                        {% endfor %}
+                                    </ul>
+                                {% endif %}
                             </div>
 
                             {% if field.help_text %}

--- a/src/openforms/forms/templates/admin/forms/form/export.html
+++ b/src/openforms/forms/templates/admin/forms/form/export.html
@@ -2,6 +2,7 @@
 {% load static i18n django_admin_index %}
 
 {% block extrastyle %}{{ block.super }}
+<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
 <link rel="stylesheet" href="{% static "admin/css/admin-index.css" %}">
 {% endblock %}
 
@@ -20,25 +21,55 @@
 {% block content %}
     <h1>{% trans 'Export forms' %}</h1>
     <div id="content-main">
-        <div>
-            {% blocktranslate %}
-            Once your request has been processed, you will be sent an email (at the address configured in your admin
-            profile) containing a link where you can download a zip file with all the exported forms.
-            {% endblocktranslate %}
-            <br/><br/>
-        </div>
         <form action="{% url 'admin:forms_export' %}" method="post">
+            {% csrf_token %}
+
+            {% for hidden in form.hidden_fields %}
+                {{ hidden }}
+            {% endfor %}
+
             <div>
                 <fieldset class="module aligned">
-                    {% csrf_token %}
+                    <div class="description">
+                        {% blocktrans trimmed %}
+                            <p>
+                                Here you can control how the previously selected forms will be
+                                exported. Using these options, sensitive information can be
+                                anonymized, certain form configuration can be left out, and
+                                additional information can be included.
+                            </p>
+                            <p>
+                                These export options will be used for each form that will be exported.
+                            </p>
+                            <p>
+                                After you've clicked the "Export" button, the forms will be
+                                exported in the background. <br/>
+                                Once your request has been processed, you will be sent an email
+                                (at the address configured in your admin profile) containing a link
+                                where you can download a zip file with all the exported forms.
+                            </p>
+                        {% endblocktrans %}
+                    </div>
 
-                    {% for hidden in form.hidden_fields %}
-                        {{ hidden }}
+                    {% for field in form.visible_fields %}
+                        <div class="form-row {% if field.errors %} errors{% endif %}">
+                            {{ field.errors }}
+                            <div class="flex-container {% if field.field.widget.input_type == 'checkbox' and field|length == 1 %}checkbox-row{% endif %} {% if field.errors %}errors{% endif %}">
+                                {{ field.label_tag }}
+                                {{ field }}
+                            </div>
+
+                            {% if field.help_text %}
+                                <div class="help" {% if field.id_for_label %} id="{{ field.id_for_label }}_helptext"{% endif %}>
+                                    <div>{{ field.help_text|safe }}</div>
+                                </div>
+                            {% endif %}
+                        </div>
                     {% endfor %}
                 </fieldset>
 
                 <div class="submit-row">
-                    <input type="submit" value="{% trans 'Export' %}">
+                    <input type="submit" class="default" value="{% trans 'Export' %}">
                 </div>
             </div>
         </form>

--- a/src/openforms/forms/templates/admin/forms/form/import_form.html
+++ b/src/openforms/forms/templates/admin/forms/form/import_form.html
@@ -2,6 +2,7 @@
 {% load static i18n django_admin_index %}
 
 {% block extrastyle %}{{ block.super }}
+<link rel="stylesheet" href="{% static "admin/css/forms.css" %}">
 <link rel="stylesheet" href="{% static "admin/css/admin-index.css" %}">{% endblock %}
 
 {% block nav-global %}{% include "django_admin_index/includes/app_list.html" %}{% endblock nav-global %}
@@ -23,9 +24,30 @@
             <div>
                 <fieldset class="module aligned ">
                     {% csrf_token %}
-                    {% for field in form %}
-                        {{ field.label.capitalize }}: {{ field }}<br/>
-                        {{ field.help_text }}<br/><br/>
+
+                    {% for field in form.visible_fields %}
+                        <div class="form-row {% if field.errors %} errors{% endif %}">
+                            {{ field.errors }}
+                            <div class="flex-container {% if field.field.widget.input_type == 'checkbox' and field|length == 1 %}checkbox-row{% endif %} {% if field.errors %}errors{% endif %}">
+                                {{ field.label_tag }}
+
+                                {% if field|length == 1 %}
+                                    {{ field }}
+                                {% else %}
+                                    <ul {% if field.id_for_label %} id="{{ field.id_for_label }}"{% endif %}>
+                                        {% for subfield in field %}
+                                            <li>{{ subfield }}</li>
+                                        {% endfor %}
+                                    </ul>
+                                {% endif %}
+                            </div>
+
+                            {% if field.help_text %}
+                                <div class="help" {% if field.id_for_label %} id="{{ field.id_for_label }}_helptext"{% endif %}>
+                                    <div>{{ field.help_text|safe }}</div>
+                                </div>
+                            {% endif %}
+                        </div>
                     {% endfor %}
                 </fieldset>
 

--- a/src/openforms/forms/tests/admin/test_form.py
+++ b/src/openforms/forms/tests/admin/test_form.py
@@ -14,10 +14,31 @@ from django_webtest import WebTest
 from maykin_2fa.test import disable_admin_mfa
 
 from openforms.accounts.tests.factories import SuperUserFactory, UserFactory
+from openforms.authentication.constants import AuthAttribute
 from openforms.authentication.contrib.digid.constants import DIGID_DEFAULT_LOA
+from openforms.authentication.tests.factories import AttributeGroupFactory
 from openforms.config.models import GlobalConfiguration, RichTextColor
+from openforms.config.tests.factories import (
+    MapTileLayerFactory,
+    MapWMSTileLayerFactory,
+    ThemeFactory,
+)
+from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
 from openforms.emails.tests.factories import ConfirmationEmailTemplateFactory
-from openforms.forms.tests.factories import FormLogicFactory
+from openforms.forms.tests.factories import (
+    CategoryFactory,
+    FormLogicFactory,
+    FormVariableFactory,
+)
+from openforms.import_export.typing import (
+    AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
+)
+from openforms.payments.contrib.worldline.tests.factories import (
+    WorldlineMerchantFactory,
+)
+from openforms.prefill.constants import IdentifierRoles
+from openforms.products.tests.factories import ProductFactory
 from openforms.utils.admin import SubmitActions
 
 from ...admin.form import FormAdmin
@@ -83,6 +104,763 @@ class FormAdminImportExportTests(WebTest):
 
         form_steps = json.loads(zf.read("formSteps.json"))
         self.assertEqual(len(form_steps), 0)
+
+    def test_form_admin_export_remove_all_sensitive_data(self):
+        self.client.force_login(self.user)
+
+        form = FormFactory.create(
+            internal_remarks="Some internal remark that should be removed",
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["submission@company.com"],
+                "to_emails_from_variable": "variable_with_sensitive_data",
+                "payment_emails": ["payment@company.com"],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            user_defined=True,
+            key="variable_with_sensitive_data",
+            initial_value="personal@company.com",
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "variable_with_sensitive_data",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        admin_url = reverse("admin:forms_form_change", args=(form.pk,))
+
+        response = self.client.post(
+            admin_url,
+            data={
+                "_export": "Export",
+                "export_options": json.dumps(
+                    {
+                        "remove_sensitive_content": True,
+                        "form_configuration": [
+                            FormConfigurationOptions.registration_backends,
+                        ],
+                    }
+                ),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "application/zip")
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        form_logic = json.loads(zf.read("formLogic.json"))
+        form_variables = json.loads(zf.read("formVariables.json"))
+
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(len(form_logic), 1)
+        self.assertEqual(len(form_variables), 2)
+
+        # Internal remarks should be removed
+        self.assertEqual(forms[0]["internal_remarks"], "")
+
+        # E-mail addresses assigned in the registration backend should be cleared
+        # The variable assigned in the registration backend should be kept
+        self.assertEqual(len(forms[0]["registration_backends"]), 1)
+        registration_backend = forms[0]["registration_backends"][0]
+
+        self.assertEqual(registration_backend["options"]["to_emails"], [])
+        self.assertEqual(
+            registration_backend["options"]["to_emails_from_variable"],
+            "variable_with_sensitive_data",
+        )
+        self.assertEqual(
+            registration_backend["options"]["payment_emails"],
+            [],
+        )
+
+        # The initial data of the user-defined variable used by the e-mail
+        # registration backend should be cleared
+        sensitive_variable = next(
+            variable
+            for variable in form_variables
+            if variable["key"] == "variable_with_sensitive_data"
+        )
+        self.assertEqual(sensitive_variable["initial_value"], "")
+
+        # The logic rule that assigns the value of the sensitive user-defined
+        # variable is cleared
+        self.assertEqual(len(form_logic[0]["actions"]), 1)
+        self.assertEqual(
+            form_logic[0]["actions"][0]["variable"], "variable_with_sensitive_data"
+        )
+        self.assertEqual(
+            form_logic[0]["actions"][0]["action"],
+            {"type": "variable", "value": ""},
+        )
+
+    def test_form_admin_export_keep_all_sensitive_data(self):
+        self.client.force_login(self.user)
+
+        form = FormFactory.create(
+            internal_remarks="Some internal remark that should be kept",
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["submission@company.com"],
+                "to_emails_from_variable": "variable_with_sensitive_data",
+                "payment_emails": ["payment@company.com"],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            user_defined=True,
+            key="variable_with_sensitive_data",
+            initial_value="personal@company.com",
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "variable_with_sensitive_data",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        admin_url = reverse("admin:forms_form_change", args=(form.pk,))
+
+        response = self.client.post(
+            admin_url,
+            data={
+                "_export": "Export",
+                "export_options": json.dumps(
+                    {
+                        "remove_sensitive_content": False,
+                        "form_configuration": [
+                            FormConfigurationOptions.registration_backends,
+                        ],
+                    }
+                ),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "application/zip")
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        form_logic = json.loads(zf.read("formLogic.json"))
+        form_variables = json.loads(zf.read("formVariables.json"))
+
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(len(form_logic), 1)
+        self.assertEqual(len(form_variables), 2)
+
+        # Internal remarks should be left untouched
+        self.assertEqual(
+            forms[0]["internal_remarks"], "Some internal remark that should be kept"
+        )
+
+        # E-mail addresses and variable assigned in the registration backend should be
+        # kept.
+        self.assertEqual(len(forms[0]["registration_backends"]), 1)
+        registration_backend = forms[0]["registration_backends"][0]
+
+        self.assertEqual(
+            registration_backend["options"]["to_emails"], ["submission@company.com"]
+        )
+        self.assertEqual(
+            registration_backend["options"]["to_emails_from_variable"],
+            "variable_with_sensitive_data",
+        )
+        self.assertEqual(
+            registration_backend["options"]["payment_emails"],
+            ["payment@company.com"],
+        )
+
+        # The initial data of the user-defined variable used by the e-mail
+        # registration backend should be kept
+        sensitive_variable = next(
+            variable
+            for variable in form_variables
+            if variable["key"] == "variable_with_sensitive_data"
+        )
+        self.assertEqual(sensitive_variable["initial_value"], "personal@company.com")
+
+        # The logic rule that assigns the value of the sensitive user-defined
+        # variable is kept
+        self.assertEqual(len(form_logic[0]["actions"]), 1)
+        self.assertEqual(
+            form_logic[0]["actions"][0]["variable"], "variable_with_sensitive_data"
+        )
+        self.assertEqual(
+            form_logic[0]["actions"][0]["action"],
+            {"type": "variable", "value": "internal@company.com"},
+        )
+
+    def test_form_admin_export_include_all_form_configuration(self):
+        self.client.force_login(self.user)
+
+        product = ProductFactory.create()
+        merchant = WorldlineMerchantFactory.create()
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            identifier="test-objects-api-group"
+        )
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            authentication_backend="digid",
+            payment_backend="worldline",
+            payment_backend_options={"merchant": merchant.pspid},
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["abc@xyz.com"],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "prefill": {
+                            "plugin": "demo",
+                            "attribute": "random_number",
+                            "identifier_role": IdentifierRoles.authorizee,
+                        },
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_demo_prefill",
+            user_defined=True,
+            prefill_plugin="demo",
+            prefill_attribute="random_string",
+            prefill_identifier_role=IdentifierRoles.authorizee,
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_objects_api_prefill",
+            user_defined=True,
+            prefill_plugin="objects_api",
+            prefill_options={
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        admin_url = reverse("admin:forms_form_change", args=(form.pk,))
+
+        response = self.client.post(
+            admin_url,
+            data={
+                "_export": "Export",
+                "export_options": json.dumps(
+                    {
+                        # Keep sensitive data to keep the email registration config complete
+                        "remove_sensitive_content": False,
+                        "form_configuration": [
+                            FormConfigurationOptions.registration_backends,
+                            FormConfigurationOptions.prefill,
+                            FormConfigurationOptions.payment_backend,
+                        ],
+                    }
+                ),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "application/zip")
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        self.assertEqual(len(forms), 1)
+
+        # Registration backend should be in exportdata
+        self.assertEqual(len(forms[0]["registration_backends"]), 1)
+        registration_backend = forms[0]["registration_backends"][0]
+        self.assertEqual(registration_backend["backend"], "email")
+        self.assertEqual(registration_backend["options"]["to_emails"], ["abc@xyz.com"])
+
+        # Payment backend should be in exportdata
+        self.assertEqual(forms[0]["payment_backend"], "worldline")
+        self.assertEqual(
+            forms[0]["payment_backend_options"], {"merchant": merchant.pspid}
+        )
+
+        form_variables = json.loads(zf.read("formVariables.json"))
+        form_definitions = json.loads(zf.read("formDefinitions.json"))
+
+        self.assertEqual(len(form_variables), 2)
+        self.assertEqual(len(form_definitions), 1)
+
+        # Both variables should have their prefill data
+        self.assertEqual(form_variables[0]["prefill_plugin"], "demo")
+        self.assertEqual(form_variables[0]["prefill_attribute"], "random_string")
+        self.assertEqual(form_variables[0]["prefill_identifier_role"], "authorizee")
+
+        self.assertEqual(form_variables[1]["prefill_plugin"], "objects_api")
+        self.assertEqual(
+            form_variables[1]["prefill_options"],
+            {
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        # The component prefill data should be kept
+        self.assertEqual(len(form_definitions[0]["configuration"]["components"]), 1)
+        component_definition = form_definitions[0]["configuration"]["components"][0]
+        self.assertEqual(component_definition["prefill"]["plugin"], "demo")
+        self.assertEqual(component_definition["prefill"]["attribute"], "random_number")
+        self.assertEqual(
+            component_definition["prefill"]["identifier_role"], "authorizee"
+        )
+
+    def test_form_admin_export_exclude_all_form_configuration(self):
+        self.client.force_login(self.user)
+
+        product = ProductFactory.create()
+        merchant = WorldlineMerchantFactory.create()
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            identifier="test-objects-api-group"
+        )
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            authentication_backend="digid",
+            payment_backend="worldline",
+            payment_backend_options={"merchant": merchant.pspid},
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["abc@xyz.com"],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "prefill": {
+                            "plugin": "demo",
+                            "attribute": "random_number",
+                            "identifier_role": "authorised_person",
+                        },
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_demo_prefill",
+            user_defined=True,
+            prefill_plugin="demo",
+            prefill_attribute="random_string",
+            prefill_identifier_role="authorised_person",
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_objects_api_prefill",
+            user_defined=True,
+            prefill_plugin="objects_api",
+            prefill_options={
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        admin_url = reverse("admin:forms_form_change", args=(form.pk,))
+
+        response = self.client.post(
+            admin_url,
+            data={
+                "_export": "Export",
+                "export_options": json.dumps(
+                    {
+                        "form_configuration": [],
+                    }
+                ),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "application/zip")
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        self.assertEqual(len(forms), 1)
+
+        # Registration backend should not be in exportdata
+        self.assertEqual(forms[0]["registration_backends"], [])
+
+        # Payment backend should not be in exportdata
+        self.assertEqual(forms[0]["payment_backend"], "")
+        self.assertEqual(forms[0]["payment_backend_options"], {})
+
+        form_variables = json.loads(zf.read("formVariables.json"))
+        form_definitions = json.loads(zf.read("formDefinitions.json"))
+
+        self.assertEqual(len(form_variables), 2)
+        self.assertEqual(len(form_definitions), 1)
+
+        # Both variables should have empty prefill data
+        self.assertEqual(form_variables[0]["prefill_plugin"], "")
+        self.assertEqual(form_variables[0]["prefill_attribute"], "")
+        self.assertEqual(form_variables[0]["prefill_identifier_role"], "main")
+        self.assertEqual(form_variables[0]["prefill_options"], {})
+
+        self.assertEqual(form_variables[1]["prefill_plugin"], "")
+        self.assertEqual(form_variables[1]["prefill_attribute"], "")
+        self.assertEqual(form_variables[1]["prefill_identifier_role"], "main")
+        self.assertEqual(form_variables[1]["prefill_options"], {})
+
+        # The component prefill data should be cleared
+        self.assertEqual(len(form_definitions[0]["configuration"]["components"]), 1)
+        component_definition = form_definitions[0]["configuration"]["components"][0]
+        self.assertEqual(component_definition["prefill"]["plugin"], "")
+        self.assertEqual(component_definition["prefill"]["attribute"], "")
+        self.assertEqual(component_definition["prefill"]["identifier_role"], "main")
+
+    def test_form_admin_export_including_all_additional_form_configuration(self):
+        self.client.force_login(self.user)
+
+        product = ProductFactory.create()
+        theme = ThemeFactory.create(design_token_values={"key": "token"})
+        category = CategoryFactory.create()
+
+        wmts_tile_layer = MapTileLayerFactory.create()
+        wms_tile_layer = MapWMSTileLayerFactory.create()
+
+        yivi_attribute_group = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+
+        # Define form with all additional form configuration
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            theme=theme,
+            category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [yivi_attribute_group.uuid],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmts_tile_layer.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wms_tile_layer.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        admin_url = reverse("admin:forms_form_change", args=(form.pk,))
+
+        response = self.client.post(
+            admin_url,
+            data={
+                "_export": "Export",
+                "export_options": json.dumps(
+                    {
+                        "additional_form_configuration": [
+                            AdditionalFormConfigurationOptions.product,
+                            AdditionalFormConfigurationOptions.theme,
+                            AdditionalFormConfigurationOptions.category,
+                            AdditionalFormConfigurationOptions.wms_tile_layers,
+                            AdditionalFormConfigurationOptions.wmts_tile_layers,
+                            AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                        ]
+                    }
+                ),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "application/zip")
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                "product.json",
+                "theme.json",
+                "category.json",
+                "wmsTileLayers.json",
+                "wmtsTileLayers.json",
+                "yiviAttributeGroups.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        exported_product = json.loads(zf.read("product.json"))
+        self.assertEqual(len(exported_product), 1)
+        self.assertEqual(
+            exported_product,
+            [
+                {
+                    "uuid": str(product.uuid),
+                    "name": product.name,
+                    "price": str(product.price).replace(".", ","),
+                    "information": product.information,
+                }
+            ],
+        )
+
+        exported_theme = json.loads(zf.read("theme.json"))
+        self.assertEqual(len(exported_theme), 1)
+        self.assertEqual(
+            exported_theme,
+            [
+                {
+                    "uuid": str(theme.uuid),
+                    "name": theme.name,
+                    "organization_name": theme.organization_name,
+                    "main_website": theme.main_website,
+                    "favicon": str(theme.favicon),
+                    "email_logo": str(theme.email_logo),
+                    "classname": theme.classname,
+                    "stylesheet": theme.stylesheet,
+                    "stylesheet_file": str(theme.stylesheet_file),
+                    # Simple stringify results in the wrong quotes being used, so we
+                    # have to json.dump the design_token_values
+                    "design_token_values": json.dumps(theme.design_token_values),
+                }
+            ],
+        )
+
+        exported_category = json.loads(zf.read("category.json"))
+        self.assertEqual(len(exported_category), 1)
+        self.assertEqual(
+            exported_category,
+            [
+                {
+                    "uuid": str(category.uuid),
+                    "name": category.name,
+                }
+            ],
+        )
+
+        exported_wms_tile_layers = json.loads(zf.read("wmsTileLayers.json"))
+        self.assertEqual(len(exported_wms_tile_layers), 1)
+        self.assertEqual(
+            exported_wms_tile_layers,
+            [
+                {
+                    "uuid": str(wms_tile_layer.uuid),
+                    "name": wms_tile_layer.name,
+                    "url": wms_tile_layer.url,
+                },
+            ],
+        )
+
+        exported_wmts_tile_layers = json.loads(zf.read("wmtsTileLayers.json"))
+        self.assertEqual(len(exported_wmts_tile_layers), 1)
+        self.assertEqual(
+            exported_wmts_tile_layers,
+            [
+                {
+                    "identifier": wmts_tile_layer.identifier,
+                    "label": wmts_tile_layer.label,
+                    "url": wmts_tile_layer.url,
+                },
+            ],
+        )
+
+        exported_yivi_attribute_groups = json.loads(zf.read("yiviAttributeGroups.json"))
+        self.assertEqual(len(exported_yivi_attribute_groups), 1)
+        self.assertEqual(
+            exported_yivi_attribute_groups,
+            [
+                {
+                    "uuid": str(yivi_attribute_group.uuid),
+                    "name": yivi_attribute_group.name,
+                    "description": yivi_attribute_group.description,
+                    "attributes": ",".join(yivi_attribute_group.attributes),
+                },
+            ],
+        )
+
+    def test_form_admin_export_excluding_all_additional_form_configuration(self):
+        self.client.force_login(self.user)
+
+        product = ProductFactory.create()
+        theme = ThemeFactory.create(design_token_values={"key": "token"})
+        category = CategoryFactory.create()
+
+        wmts_tile_layer = MapTileLayerFactory.create()
+        wms_tile_layer = MapWMSTileLayerFactory.create()
+
+        yivi_attribute_group = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+
+        # Define form with all additional form configuration
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            theme=theme,
+            category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [yivi_attribute_group.uuid],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmts_tile_layer.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wms_tile_layer.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        admin_url = reverse("admin:forms_form_change", args=(form.pk,))
+
+        response = self.client.post(
+            admin_url,
+            data={
+                "_export": "Export",
+                "export_options": json.dumps({"additional_form_configuration": []}),
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response["content-type"], "application/zip")
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        exported_forms = json.loads(zf.read("forms.json"))
+        self.assertEqual(len(exported_forms), 1)
+
+        # The references on the form are also removed
+        self.assertEqual(exported_forms[0]["product"], None)
+        self.assertEqual(exported_forms[0]["theme"], None)
+        self.assertEqual(exported_forms[0]["category"], None)
 
     @override_settings(LANGUAGE_CODE="en")
     def test_form_admin_import_button(self):

--- a/src/openforms/forms/tests/admin/test_form.py
+++ b/src/openforms/forms/tests/admin/test_form.py
@@ -732,6 +732,8 @@ class FormAdminImportExportTests(WebTest):
                 {
                     "uuid": str(category.uuid),
                     "name": category.name,
+                    "path": category.path,
+                    "depth": str(category.depth),
                 }
             ],
         )

--- a/src/openforms/forms/tests/admin/test_tasks.py
+++ b/src/openforms/forms/tests/admin/test_tasks.py
@@ -12,6 +12,7 @@ from privates.test import temp_private_root
 from rest_framework.exceptions import ValidationError
 
 from openforms.accounts.tests.factories import SuperUserFactory
+from openforms.import_export.typing import FormExportOptions
 from openforms.logging.models import TimelineLogProxy
 from openforms.utils.urls import build_absolute_uri
 
@@ -31,6 +32,7 @@ class ExportFormsTaskTests(TestCase):
         process_forms_export(
             forms_uuids=[form1.uuid, form2.uuid],
             user_id=user.id,
+            export_options=FormExportOptions(),
         )
 
         # Test that the forms export model was created with the right data
@@ -81,6 +83,7 @@ class ImportFormsTaskTests(TestCase):
         process_forms_export(
             forms_uuids=[form1.uuid, form2.uuid],
             user_id=user.id,
+            export_options=FormExportOptions(),
         )
 
         cls.form_export = FormsExport.objects.get()

--- a/src/openforms/forms/tests/admin/test_views.py
+++ b/src/openforms/forms/tests/admin/test_views.py
@@ -92,7 +92,19 @@ class TestExportFormsView(WebTest):
         self.assertRedirects(
             submission_response, reverse("admin:forms_form_changelist")
         )
-        m.assert_called_with(forms_uuids=[form.uuid], user_id=user.id)
+        m.assert_called_with(
+            forms_uuids=[form.uuid],
+            user_id=user.id,
+            export_options=FormExportOptions(
+                remove_sensitive_content=True,
+                form_configuration=[
+                    "registrationBackends",
+                    "prefill",
+                    "paymentBackend",
+                ],
+                additional_form_configuration=[],
+            ),
+        )
 
         submission_response = submission_response.follow()
         messages = list(submission_response.context.get("messages"))

--- a/src/openforms/forms/tests/admin/test_views.py
+++ b/src/openforms/forms/tests/admin/test_views.py
@@ -19,6 +19,7 @@ from openforms.accounts.tests.factories import (
 from openforms.forms.admin.tasks import process_forms_export
 from openforms.forms.models.form import FormsExport
 from openforms.forms.tests.factories import FormFactory
+from openforms.import_export.typing import FormExportOptions
 from openforms.utils.urls import build_absolute_uri
 
 
@@ -225,6 +226,7 @@ class TestImportView(WebTest):
         process_forms_export(
             forms_uuids=[form1.uuid, form2.uuid],
             user_id=user.id,
+            export_options=FormExportOptions(),
         )
 
         form_export = FormsExport.objects.get()

--- a/src/openforms/forms/tests/factories.py
+++ b/src/openforms/forms/tests/factories.py
@@ -4,6 +4,11 @@ import factory.fuzzy
 
 from openforms.authentication.registry import register as authentication_registry
 from openforms.forms.constants import LogicActionTypes
+from openforms.import_export.typing import (
+    AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
+    FormExportOptions,
+)
 from openforms.products.tests.factories import ProductFactory
 from openforms.registrations.registry import register as registration_registry
 from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
@@ -246,7 +251,25 @@ class FormVersionFactory(factory.django.DjangoModelFactory):
 
     @factory.post_generation
     def post(obj, create, extracted, **kwargs):
-        json_form = form_to_json(obj.form.id)
+        json_form = form_to_json(
+            obj.form.id,
+            export_options=FormExportOptions(
+                form_configuration=[
+                    FormConfigurationOptions.registration_backends,
+                    FormConfigurationOptions.prefill,
+                    FormConfigurationOptions.payment_backend,
+                ],
+                additional_form_configuration=[
+                    AdditionalFormConfigurationOptions.product,
+                    AdditionalFormConfigurationOptions.theme,
+                    AdditionalFormConfigurationOptions.category,
+                    AdditionalFormConfigurationOptions.wms_tile_layers,
+                    AdditionalFormConfigurationOptions.wmts_tile_layers,
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                ],
+                remove_sensitive_content=False,
+            ),
+        )
         obj.export_blob = json_form
         obj.save()
 

--- a/src/openforms/forms/tests/test_api_import_export.py
+++ b/src/openforms/forms/tests/test_api_import_export.py
@@ -13,14 +13,33 @@ from rest_framework.test import APITestCase
 
 from openforms.accounts.tests.factories import TokenFactory, UserFactory
 from openforms.appointments.models import AppointmentsConfig
+from openforms.authentication.constants import AuthAttribute
+from openforms.authentication.tests.factories import AttributeGroupFactory
+from openforms.config.tests.factories import (
+    MapTileLayerFactory,
+    MapWMSTileLayerFactory,
+    ThemeFactory,
+)
+from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
+from openforms.import_export.typing import (
+    AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
+)
+from openforms.payments.contrib.worldline.tests.factories import (
+    WorldlineMerchantFactory,
+)
+from openforms.prefill.constants import IdentifierRoles
+from openforms.products.tests.factories import ProductFactory
 from openforms.variables.constants import FormVariableSources
 
 from ...emails.tests.factories import ConfirmationEmailTemplateFactory
 from ..constants import EXPORT_META_KEY, FormTypeChoices
 from ..models import Form, FormDefinition, FormStep
 from .factories import (
+    CategoryFactory,
     FormDefinitionFactory,
     FormFactory,
+    FormLogicFactory,
     FormRegistrationBackendFactory,
     FormStepFactory,
     FormVariableFactory,
@@ -133,6 +152,747 @@ class ImportExportAPITests(APITestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_form_export_remove_all_sensitive_data(self):
+        self.user.user_permissions.add(Permission.objects.get(codename="change_form"))
+        self.user.is_staff = True
+        self.user.save()
+
+        form = FormFactory.create(
+            internal_remarks="Some internal remark that should be removed",
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["submission@company.com"],
+                "to_emails_from_variable": "variable_with_sensitive_data",
+                "payment_emails": ["payment@company.com"],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            user_defined=True,
+            key="variable_with_sensitive_data",
+            initial_value="personal@company.com",
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "variable_with_sensitive_data",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        url = reverse("api:form-export", args=(form.uuid,))
+        response = self.client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            data={
+                "remove_sensitive_content": True,
+                "form_configuration": [
+                    FormConfigurationOptions.registration_backends,
+                ],
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        form_logic = json.loads(zf.read("formLogic.json"))
+        form_variables = json.loads(zf.read("formVariables.json"))
+
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(len(form_logic), 1)
+        self.assertEqual(len(form_variables), 2)
+
+        # Internal remarks should be removed
+        self.assertEqual(forms[0]["internal_remarks"], "")
+
+        # E-mail addresses assigned in the registration backend should be cleared
+        # The variable assigned in the registration backend should be kept
+        self.assertEqual(len(forms[0]["registration_backends"]), 1)
+        registration_backend = forms[0]["registration_backends"][0]
+
+        self.assertEqual(registration_backend["options"]["to_emails"], [])
+        self.assertEqual(
+            registration_backend["options"]["to_emails_from_variable"],
+            "variable_with_sensitive_data",
+        )
+        self.assertEqual(
+            registration_backend["options"]["payment_emails"],
+            [],
+        )
+
+        # The initial data of the user-defined variable used by the e-mail
+        # registration backend should be cleared
+        sensitive_variable = next(
+            variable
+            for variable in form_variables
+            if variable["key"] == "variable_with_sensitive_data"
+        )
+        self.assertEqual(sensitive_variable["initial_value"], "")
+
+        # The logic rule that assigns the value of the sensitive user-defined
+        # variable is cleared
+        self.assertEqual(len(form_logic[0]["actions"]), 1)
+        self.assertEqual(
+            form_logic[0]["actions"][0]["variable"], "variable_with_sensitive_data"
+        )
+        self.assertEqual(
+            form_logic[0]["actions"][0]["action"],
+            {"type": "variable", "value": ""},
+        )
+
+    def test_form_export_keep_all_sensitive_data(self):
+        self.user.user_permissions.add(Permission.objects.get(codename="change_form"))
+        self.user.is_staff = True
+        self.user.save()
+
+        form = FormFactory.create(
+            internal_remarks="Some internal remark that should be kept",
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["submission@company.com"],
+                "to_emails_from_variable": "variable_with_sensitive_data",
+                "payment_emails": ["payment@company.com"],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            user_defined=True,
+            key="variable_with_sensitive_data",
+            initial_value="personal@company.com",
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "variable_with_sensitive_data",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        url = reverse("api:form-export", args=(form.uuid,))
+        response = self.client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            data={
+                "remove_sensitive_content": False,
+                "form_configuration": [
+                    FormConfigurationOptions.registration_backends,
+                ],
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        form_logic = json.loads(zf.read("formLogic.json"))
+        form_variables = json.loads(zf.read("formVariables.json"))
+
+        self.assertEqual(len(forms), 1)
+        self.assertEqual(len(form_logic), 1)
+        self.assertEqual(len(form_variables), 2)
+
+        # Internal remarks should be left untouched
+        self.assertEqual(
+            forms[0]["internal_remarks"], "Some internal remark that should be kept"
+        )
+
+        # E-mail addresses and variable assigned in the registration backend should be
+        # kept.
+        self.assertEqual(len(forms[0]["registration_backends"]), 1)
+        registration_backend = forms[0]["registration_backends"][0]
+
+        self.assertEqual(
+            registration_backend["options"]["to_emails"], ["submission@company.com"]
+        )
+        self.assertEqual(
+            registration_backend["options"]["to_emails_from_variable"],
+            "variable_with_sensitive_data",
+        )
+        self.assertEqual(
+            registration_backend["options"]["payment_emails"],
+            ["payment@company.com"],
+        )
+
+        # The initial data of the user-defined variable used by the e-mail
+        # registration backend should be kept
+        sensitive_variable = next(
+            variable
+            for variable in form_variables
+            if variable["key"] == "variable_with_sensitive_data"
+        )
+        self.assertEqual(sensitive_variable["initial_value"], "personal@company.com")
+
+        # The logic rule that assigns the value of the sensitive user-defined
+        # variable is kept
+        self.assertEqual(len(form_logic[0]["actions"]), 1)
+        self.assertEqual(
+            form_logic[0]["actions"][0]["variable"], "variable_with_sensitive_data"
+        )
+        self.assertEqual(
+            form_logic[0]["actions"][0]["action"],
+            {"type": "variable", "value": "internal@company.com"},
+        )
+
+    def test_form_export_include_all_form_configuration(self):
+        self.user.user_permissions.add(Permission.objects.get(codename="change_form"))
+        self.user.is_staff = True
+        self.user.save()
+
+        product = ProductFactory.create()
+        merchant = WorldlineMerchantFactory.create()
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            identifier="test-objects-api-group"
+        )
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            authentication_backend="digid",
+            payment_backend="worldline",
+            payment_backend_options={"merchant": merchant.pspid},
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["abc@xyz.com"],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "prefill": {
+                            "plugin": "demo",
+                            "attribute": "random_number",
+                            "identifier_role": IdentifierRoles.authorizee,
+                        },
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_demo_prefill",
+            user_defined=True,
+            prefill_plugin="demo",
+            prefill_attribute="random_string",
+            prefill_identifier_role=IdentifierRoles.authorizee,
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_objects_api_prefill",
+            user_defined=True,
+            prefill_plugin="objects_api",
+            prefill_options={
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        url = reverse("api:form-export", args=(form.uuid,))
+        response = self.client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            data={
+                # Keep sensitive data to keep the email registration config complete
+                "remove_sensitive_content": False,
+                "form_configuration": [
+                    FormConfigurationOptions.registration_backends,
+                    FormConfigurationOptions.prefill,
+                    FormConfigurationOptions.payment_backend,
+                ],
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        self.assertEqual(len(forms), 1)
+
+        # Registration backend should be in exportdata
+        self.assertEqual(len(forms[0]["registration_backends"]), 1)
+        registration_backend = forms[0]["registration_backends"][0]
+        self.assertEqual(registration_backend["backend"], "email")
+        self.assertEqual(registration_backend["options"]["to_emails"], ["abc@xyz.com"])
+
+        # Payment backend should be in exportdata
+        self.assertEqual(forms[0]["payment_backend"], "worldline")
+        self.assertEqual(
+            forms[0]["payment_backend_options"], {"merchant": merchant.pspid}
+        )
+
+        form_variables = json.loads(zf.read("formVariables.json"))
+        form_definitions = json.loads(zf.read("formDefinitions.json"))
+
+        self.assertEqual(len(form_variables), 2)
+        self.assertEqual(len(form_definitions), 1)
+
+        # Both variables should have their prefill data
+        self.assertEqual(form_variables[0]["prefill_plugin"], "demo")
+        self.assertEqual(form_variables[0]["prefill_attribute"], "random_string")
+        self.assertEqual(form_variables[0]["prefill_identifier_role"], "authorizee")
+
+        self.assertEqual(form_variables[1]["prefill_plugin"], "objects_api")
+        self.assertEqual(
+            form_variables[1]["prefill_options"],
+            {
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        # The component prefill data should be kept
+        self.assertEqual(len(form_definitions[0]["configuration"]["components"]), 1)
+        component_definition = form_definitions[0]["configuration"]["components"][0]
+        self.assertEqual(component_definition["prefill"]["plugin"], "demo")
+        self.assertEqual(component_definition["prefill"]["attribute"], "random_number")
+        self.assertEqual(
+            component_definition["prefill"]["identifier_role"], "authorizee"
+        )
+
+    def test_form_export_exclude_all_form_configuration(self):
+        self.user.user_permissions.add(Permission.objects.get(codename="change_form"))
+        self.user.is_staff = True
+        self.user.save()
+
+        product = ProductFactory.create()
+        merchant = WorldlineMerchantFactory.create()
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            identifier="test-objects-api-group"
+        )
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            authentication_backend="digid",
+            payment_backend="worldline",
+            payment_backend_options={"merchant": merchant.pspid},
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["abc@xyz.com"],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "prefill": {
+                            "plugin": "demo",
+                            "attribute": "random_number",
+                            "identifier_role": "authorised_person",
+                        },
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_demo_prefill",
+            user_defined=True,
+            prefill_plugin="demo",
+            prefill_attribute="random_string",
+            prefill_identifier_role="authorised_person",
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_objects_api_prefill",
+            user_defined=True,
+            prefill_plugin="objects_api",
+            prefill_options={
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        url = reverse("api:form-export", args=(form.uuid,))
+        response = self.client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            data={
+                "form_configuration": [],
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        forms = json.loads(zf.read("forms.json"))
+        self.assertEqual(len(forms), 1)
+
+        # Registration backend should not be in exportdata
+        self.assertEqual(forms[0]["registration_backends"], [])
+
+        # Payment backend should not be in exportdata
+        self.assertEqual(forms[0]["payment_backend"], "")
+        self.assertEqual(forms[0]["payment_backend_options"], {})
+
+        form_variables = json.loads(zf.read("formVariables.json"))
+        form_definitions = json.loads(zf.read("formDefinitions.json"))
+
+        self.assertEqual(len(form_variables), 2)
+        self.assertEqual(len(form_definitions), 1)
+
+        # Both variables should have empty prefill data
+        self.assertEqual(form_variables[0]["prefill_plugin"], "")
+        self.assertEqual(form_variables[0]["prefill_attribute"], "")
+        self.assertEqual(form_variables[0]["prefill_identifier_role"], "main")
+        self.assertEqual(form_variables[0]["prefill_options"], {})
+
+        self.assertEqual(form_variables[1]["prefill_plugin"], "")
+        self.assertEqual(form_variables[1]["prefill_attribute"], "")
+        self.assertEqual(form_variables[1]["prefill_identifier_role"], "main")
+        self.assertEqual(form_variables[1]["prefill_options"], {})
+
+        # The component prefill data should be cleared
+        self.assertEqual(len(form_definitions[0]["configuration"]["components"]), 1)
+        component_definition = form_definitions[0]["configuration"]["components"][0]
+        self.assertEqual(component_definition["prefill"]["plugin"], "")
+        self.assertEqual(component_definition["prefill"]["attribute"], "")
+        self.assertEqual(component_definition["prefill"]["identifier_role"], "main")
+
+    def test_form_export_including_all_additional_form_configuration(self):
+        self.user.user_permissions.add(Permission.objects.get(codename="change_form"))
+        self.user.is_staff = True
+        self.user.save()
+
+        product = ProductFactory.create()
+        theme = ThemeFactory.create(design_token_values={"key": "token"})
+        category = CategoryFactory.create()
+
+        wmts_tile_layer = MapTileLayerFactory.create()
+        wms_tile_layer = MapWMSTileLayerFactory.create()
+
+        yivi_attribute_group = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+
+        # Define form with all additional form configuration
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            theme=theme,
+            category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [yivi_attribute_group.uuid],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmts_tile_layer.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wms_tile_layer.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        url = reverse("api:form-export", args=(form.uuid,))
+        response = self.client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            data={
+                "additional_form_configuration": [
+                    AdditionalFormConfigurationOptions.product,
+                    AdditionalFormConfigurationOptions.theme,
+                    AdditionalFormConfigurationOptions.category,
+                    AdditionalFormConfigurationOptions.wms_tile_layers,
+                    AdditionalFormConfigurationOptions.wmts_tile_layers,
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                ]
+            },
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                "product.json",
+                "theme.json",
+                "category.json",
+                "wmsTileLayers.json",
+                "wmtsTileLayers.json",
+                "yiviAttributeGroups.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        exported_product = json.loads(zf.read("product.json"))
+        self.assertEqual(len(exported_product), 1)
+        self.assertEqual(
+            exported_product,
+            [
+                {
+                    "uuid": str(product.uuid),
+                    "name": product.name,
+                    "price": str(product.price).replace(".", ","),
+                    "information": product.information,
+                }
+            ],
+        )
+
+        exported_theme = json.loads(zf.read("theme.json"))
+        self.assertEqual(len(exported_theme), 1)
+        self.assertEqual(
+            exported_theme,
+            [
+                {
+                    "uuid": str(theme.uuid),
+                    "name": theme.name,
+                    "organization_name": theme.organization_name,
+                    "main_website": theme.main_website,
+                    "favicon": str(theme.favicon),
+                    "email_logo": str(theme.email_logo),
+                    "classname": theme.classname,
+                    "stylesheet": theme.stylesheet,
+                    "stylesheet_file": str(theme.stylesheet_file),
+                    # Simple stringify results in the wrong quotes being used, so we
+                    # have to json.dump the design_token_values
+                    "design_token_values": json.dumps(theme.design_token_values),
+                }
+            ],
+        )
+
+        exported_category = json.loads(zf.read("category.json"))
+        self.assertEqual(len(exported_category), 1)
+        self.assertEqual(
+            exported_category,
+            [
+                {
+                    "uuid": str(category.uuid),
+                    "name": category.name,
+                }
+            ],
+        )
+
+        exported_wms_tile_layers = json.loads(zf.read("wmsTileLayers.json"))
+        self.assertEqual(len(exported_wms_tile_layers), 1)
+        self.assertEqual(
+            exported_wms_tile_layers,
+            [
+                {
+                    "uuid": str(wms_tile_layer.uuid),
+                    "name": wms_tile_layer.name,
+                    "url": wms_tile_layer.url,
+                },
+            ],
+        )
+
+        exported_wmts_tile_layers = json.loads(zf.read("wmtsTileLayers.json"))
+        self.assertEqual(len(exported_wmts_tile_layers), 1)
+        self.assertEqual(
+            exported_wmts_tile_layers,
+            [
+                {
+                    "identifier": wmts_tile_layer.identifier,
+                    "label": wmts_tile_layer.label,
+                    "url": wmts_tile_layer.url,
+                },
+            ],
+        )
+
+        exported_yivi_attribute_groups = json.loads(zf.read("yiviAttributeGroups.json"))
+        self.assertEqual(len(exported_yivi_attribute_groups), 1)
+        self.assertEqual(
+            exported_yivi_attribute_groups,
+            [
+                {
+                    "uuid": str(yivi_attribute_group.uuid),
+                    "name": yivi_attribute_group.name,
+                    "description": yivi_attribute_group.description,
+                    "attributes": ",".join(yivi_attribute_group.attributes),
+                },
+            ],
+        )
+
+    def test_form_export_excluding_all_additional_form_configuration(self):
+        self.user.user_permissions.add(Permission.objects.get(codename="change_form"))
+        self.user.is_staff = True
+        self.user.save()
+
+        product = ProductFactory.create()
+        theme = ThemeFactory.create(design_token_values={"key": "token"})
+        category = CategoryFactory.create()
+
+        wmts_tile_layer = MapTileLayerFactory.create()
+        wms_tile_layer = MapWMSTileLayerFactory.create()
+
+        yivi_attribute_group = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+
+        # Define form with all additional form configuration
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            theme=theme,
+            category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [yivi_attribute_group.uuid],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmts_tile_layer.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wms_tile_layer.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        url = reverse("api:form-export", args=(form.uuid,))
+        response = self.client.post(
+            url,
+            format="json",
+            HTTP_AUTHORIZATION=f"Token {self.token.key}",
+            data={"additional_form_configuration": []},
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        zf = ZipFile(BytesIO(response.content))
+        self.assertEqual(
+            zf.namelist(),
+            [
+                "forms.json",
+                "formSteps.json",
+                "formDefinitions.json",
+                "formLogic.json",
+                "formVariables.json",
+                f"{EXPORT_META_KEY}.json",
+            ],
+        )
+
+        exported_forms = json.loads(zf.read("forms.json"))
+        self.assertEqual(len(exported_forms), 1)
+
+        # The references on the form are also removed
+        self.assertEqual(exported_forms[0]["product"], None)
+        self.assertEqual(exported_forms[0]["theme"], None)
+        self.assertEqual(exported_forms[0]["category"], None)
 
     def test_form_import(self):
         # export, delete, import roundtrip

--- a/src/openforms/forms/tests/test_api_import_export.py
+++ b/src/openforms/forms/tests/test_api_import_export.py
@@ -765,6 +765,8 @@ class ImportExportAPITests(APITestCase):
                 {
                     "uuid": str(category.uuid),
                     "name": category.name,
+                    "path": category.path,
+                    "depth": str(category.depth),
                 }
             ],
         )

--- a/src/openforms/forms/tests/test_api_import_export.py
+++ b/src/openforms/forms/tests/test_api_import_export.py
@@ -24,6 +24,7 @@ from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigF
 from openforms.import_export.typing import (
     AdditionalFormConfigurationOptions,
     FormConfigurationOptions,
+    ReusableFormDefinitionsOptions,
 )
 from openforms.payments.contrib.worldline.tests.factories import (
     WorldlineMerchantFactory,
@@ -1087,7 +1088,10 @@ class ImportExportAPITests(APITestCase):
         url = reverse("api:forms-import")
         response = self.client.post(
             url,
-            {"file": f},
+            {
+                "file": f,
+                "reusable_form_definitions": ReusableFormDefinitionsOptions.reuse_existing,
+            },
             format="multipart",
             HTTP_AUTHORIZATION=f"Token {self.token.key}",
             HTTP_CONTENT_DISPOSITION="attachment;filename=file.zip",

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -16,13 +16,22 @@ from rest_framework.exceptions import ValidationError
 
 from openforms.config.constants import UploadFileType
 from openforms.config.models import GlobalConfiguration
-from openforms.config.tests.factories import ThemeFactory
+from openforms.config.tests.factories import (
+    MapTileLayerFactory,
+    MapWMSTileLayerFactory,
+    ThemeFactory,
+)
 from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
 from openforms.emails.models import ConfirmationEmailTemplate
 from openforms.emails.tests.factories import ConfirmationEmailTemplateFactory
+from openforms.import_export.typing import (
+    AdditionalFormConfigurationOptions,
+    FormExportOptions,
+)
 from openforms.payments.contrib.worldline.tests.factories import (
     WorldlineMerchantFactory,
 )
+from openforms.prefill.constants import IdentifierRoles
 from openforms.products.tests.factories import ProductFactory
 from openforms.registrations.contrib.objects_api.config import (
     ObjectsAPIOptionsSerializer,
@@ -56,6 +65,7 @@ from openforms.utils.tests.vcr import OFVCRMixin
 from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
 
+from ...authentication.constants import AuthAttribute
 from ...authentication.tests.factories import AttributeGroupFactory
 from ..constants import EXPORT_META_KEY
 from ..disable_next_import_conversion import add_form_step_uuid_to_disable_next_actions
@@ -242,6 +252,683 @@ class ImportExportTests(TempdirMixin, TestCase):
             self.assertEqual(
                 form_definitions[0]["configuration"],
                 form_definition.configuration,
+            )
+
+    def test_export_without_anonymize_option_keeps_all_sensitive_data(self):
+        # Setting up a form with sensitive data in:
+        # - form internal remarks
+        # - user defined variable initial value
+        # - user defined variable in logic rule
+        # - e-mail address in e-mail registration to_emails
+        # - e-mail address in e-mail registration payment_emails
+        form = FormFactory.create(
+            internal_remarks="Some internal remark that should be kept",
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["submission@company.com"],
+                "to_emails_from_variable": "variable_with_sensitive_data",
+                "payment_emails": ["payment@company.com"],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            user_defined=True,
+            key="variable_with_sensitive_data",
+            initial_value="personal@company.com",
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "variable_with_sensitive_data",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=["registrationBackends"],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+            form_logic = json.loads(f.read("formLogic.json"))
+            form_variables = json.loads(f.read("formVariables.json"))
+
+            self.assertEqual(len(forms), 1)
+            self.assertEqual(len(form_logic), 1)
+            self.assertEqual(len(form_variables), 2)
+
+            # Internal remarks should be kept
+            self.assertEqual(
+                forms[0]["internal_remarks"], "Some internal remark that should be kept"
+            )
+
+            # E-mail addresses and variable assigned to registration backend should be
+            # kept
+            self.assertEqual(len(forms[0]["registration_backends"]), 1)
+            registration_backend = forms[0]["registration_backends"][0]
+            self.assertEqual(
+                registration_backend["options"]["to_emails"], ["submission@company.com"]
+            )
+            self.assertEqual(
+                registration_backend["options"]["to_emails_from_variable"],
+                "variable_with_sensitive_data",
+            )
+            self.assertEqual(
+                registration_backend["options"]["payment_emails"],
+                ["payment@company.com"],
+            )
+
+            # The initial data of the user-defined variable used by the e-mail
+            # registration backend should be kept
+            sensitive_variable = next(
+                variable
+                for variable in form_variables
+                if variable["key"] == "variable_with_sensitive_data"
+            )
+            self.assertEqual(
+                sensitive_variable["initial_value"], "personal@company.com"
+            )
+
+            # The logic rule that assigns the value of the sensitive user-defined
+            # variable is kept
+            self.assertEqual(len(form_logic[0]["actions"]), 1)
+            self.assertEqual(
+                form_logic[0]["actions"][0]["variable"], "variable_with_sensitive_data"
+            )
+            self.assertEqual(
+                form_logic[0]["actions"][0]["action"],
+                {"type": "variable", "value": "internal@company.com"},
+            )
+
+    def test_export_with_anonymize_option_removes_all_sensitive_data(self):
+        # Setting up a form with sensitive data in:
+        # - form internal remarks
+        # - user defined variable initial value
+        # - user defined variable in logic rule
+        # - e-mail address in e-mail registration to_emails
+        # - e-mail address in e-mail registration payment_emails
+        form = FormFactory.create(
+            internal_remarks="Some internal remark that should be removed",
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["submission@company.com"],
+                "to_emails_from_variable": "variable_with_sensitive_data",
+                "payment_emails": ["payment@company.com"],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            user_defined=True,
+            key="variable_with_sensitive_data",
+            initial_value="personal@company.com",
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "variable_with_sensitive_data",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=True,
+                form_configuration=["registrationBackends"],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+            form_logic = json.loads(f.read("formLogic.json"))
+            form_variables = json.loads(f.read("formVariables.json"))
+
+            self.assertEqual(len(forms), 1)
+            self.assertEqual(len(form_logic), 1)
+            self.assertEqual(len(form_variables), 2)
+
+            # Internal remarks should be removed
+            self.assertEqual(forms[0]["internal_remarks"], "")
+
+            # E-mail addresses assigned in the registration backend should be cleared
+            # The variable assigned in the registration backend should be kept
+            self.assertEqual(len(forms[0]["registration_backends"]), 1)
+            registration_backend = forms[0]["registration_backends"][0]
+
+            self.assertEqual(registration_backend["options"]["to_emails"], [])
+            self.assertEqual(
+                registration_backend["options"]["to_emails_from_variable"],
+                "variable_with_sensitive_data",
+            )
+            self.assertEqual(
+                registration_backend["options"]["payment_emails"],
+                [],
+            )
+
+            # The initial data of the user-defined variable used by the e-mail
+            # registration backend should be cleared
+            sensitive_variable = next(
+                variable
+                for variable in form_variables
+                if variable["key"] == "variable_with_sensitive_data"
+            )
+            self.assertEqual(sensitive_variable["initial_value"], "")
+
+            # The logic rule that assigns the value of the sensitive user-defined
+            # variable is cleared
+            self.assertEqual(len(form_logic[0]["actions"]), 1)
+            self.assertEqual(
+                form_logic[0]["actions"][0]["variable"], "variable_with_sensitive_data"
+            )
+            self.assertEqual(
+                form_logic[0]["actions"][0]["action"],
+                {"type": "variable", "value": ""},
+            )
+
+    def test_export_with_anonymize_option_anonymizes_component_variable(self):
+        # Setting up a form with sensitive data in:
+        # - component variable initial value
+        # - component variable in logic rule
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            registration_backend="email",
+            registration_backend_options={"to_emails_from_variable": "textfield"},
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "defaultValue": "personal@me.com",
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "textfield",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=True,
+                form_configuration=["registrationBackends"],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+            form_logic = json.loads(f.read("formLogic.json"))
+            form_variables = json.loads(f.read("formVariables.json"))
+            form_definitions = json.loads(f.read("formDefinitions.json"))
+
+            self.assertEqual(len(forms), 1)
+            self.assertEqual(len(form_logic), 1)
+            self.assertEqual(len(form_variables), 1)
+            self.assertEqual(len(form_definitions), 1)
+
+            self.assertEqual(len(forms[0]["registration_backends"]), 1)
+            registration_backend = forms[0]["registration_backends"][0]
+
+            self.assertEqual(
+                registration_backend["options"]["to_emails_from_variable"],
+                "textfield",
+            )
+
+            # The logic rule that assigns the value of the component variable is cleared
+            self.assertEqual(len(form_logic[0]["actions"]), 1)
+            self.assertEqual(form_logic[0]["actions"][0]["variable"], "textfield")
+            self.assertEqual(
+                form_logic[0]["actions"][0]["action"],
+                {"type": "variable", "value": ""},
+            )
+
+            # The default value of the component variable used in the e-mail registration
+            # is cleared
+            self.assertEqual(len(form_definitions[0]["configuration"]["components"]), 1)
+            component_definition = form_definitions[0]["configuration"]["components"][0]
+            self.assertEqual(component_definition["defaultValue"], "")
+
+    def test_export_with_exclude_registration_backends_option(self):
+        form = FormFactory.create(
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["abc@xyz.com"],
+            },
+        )
+
+        # The export is made without registrationBackends in the form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                form_configuration=["prefill", "paymentBackend"],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+
+            self.assertEqual(len(forms), 1)
+            # Registration backends should not be in exportdata
+            self.assertEqual(len(forms[0]["registration_backends"]), 0)
+
+    def test_export_with_exclude_prefill_option(self):
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            identifier="test-objects-api-group"
+        )
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "prefill": {
+                            "plugin": "demo",
+                            "attribute": "random_number",
+                            "identifier_role": IdentifierRoles.authorizee,
+                        },
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_demo_prefill",
+            user_defined=True,
+            prefill_plugin="demo",
+            prefill_attribute="random_string",
+            prefill_identifier_role=IdentifierRoles.authorizee,
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_objects_api_prefill",
+            user_defined=True,
+            prefill_plugin="objects_api",
+            prefill_options={
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=True,
+                form_configuration=["registrationBackends"],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+            form_variables = json.loads(f.read("formVariables.json"))
+            form_definitions = json.loads(f.read("formDefinitions.json"))
+
+            self.assertEqual(len(forms), 1)
+            self.assertEqual(len(form_variables), 2)
+            self.assertEqual(len(form_definitions), 1)
+
+            # Both variables should have empty prefill data
+            self.assertEqual(form_variables[0]["prefill_plugin"], "")
+            self.assertEqual(form_variables[0]["prefill_attribute"], "")
+            self.assertEqual(form_variables[0]["prefill_identifier_role"], "main")
+            self.assertEqual(form_variables[0]["prefill_options"], {})
+
+            self.assertEqual(form_variables[1]["prefill_plugin"], "")
+            self.assertEqual(form_variables[1]["prefill_attribute"], "")
+            self.assertEqual(form_variables[1]["prefill_identifier_role"], "main")
+            self.assertEqual(form_variables[1]["prefill_options"], {})
+
+            # The component prefill data should be cleared
+            self.assertEqual(len(form_definitions[0]["configuration"]["components"]), 1)
+            component_definition = form_definitions[0]["configuration"]["components"][0]
+            self.assertEqual(component_definition["prefill"]["plugin"], "")
+            self.assertEqual(component_definition["prefill"]["attribute"], "")
+            self.assertEqual(component_definition["prefill"]["identifier_role"], "main")
+
+    def test_export_with_exclude_payment_backend(self):
+        product = ProductFactory.create()
+        merchant = WorldlineMerchantFactory.create()
+        form = FormFactory.create(
+            product=product,
+            authentication_backend="digid",
+            payment_backend="worldline",
+            payment_backend_options={"merchant": merchant.pspid},
+        )
+
+        # The export is made without paymentBackend in the form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                form_configuration=["prefill", "registrationBackends"],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+
+            self.assertEqual(len(forms), 1)
+            # Payment backend should not be in exportdata
+            self.assertEqual(forms[0]["payment_backend"], "")
+            self.assertEqual(forms[0]["payment_backend_options"], {})
+
+    def test_export_with_all_additional_form_configuration_excluded(self):
+        product = ProductFactory.create()
+        theme = ThemeFactory.create()
+        category = CategoryFactory.create()
+        form = FormFactory.create(
+            product=product,
+            theme=theme,
+            category=category,
+        )
+
+        # The export is made without any additional_form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                additional_form_configuration=[],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            # None of the additional form configuration files should be in the exportdata
+            self.assertEqual(
+                f.namelist(),
+                [
+                    "forms.json",
+                    "formSteps.json",
+                    "formDefinitions.json",
+                    "formLogic.json",
+                    "formVariables.json",
+                    f"{EXPORT_META_KEY}.json",
+                ],
+            )
+
+            forms = json.loads(f.read("forms.json"))
+
+            self.assertEqual(len(forms), 1)
+
+            # Assert product, theme, category are not in exportdata
+            self.assertEqual(forms[0]["product"], None)
+            self.assertEqual(forms[0]["theme"], None)
+            self.assertEqual(forms[0]["category"], None)
+
+    def test_export_with_all_additional_form_configuration_included(self):
+        product = ProductFactory.create()
+        theme = ThemeFactory.create(design_token_values={"key": "token"})
+        category = CategoryFactory.create()
+
+        wmtsMap1 = MapTileLayerFactory.create()
+        wmtsMap2 = MapTileLayerFactory.create()
+        wmsMap1 = MapWMSTileLayerFactory.create()
+        wmsMap2 = MapWMSTileLayerFactory.create()
+        wmsMap3 = MapWMSTileLayerFactory.create()
+
+        yiviAttributeGroup1 = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+        yiviAttributeGroup2 = AttributeGroupFactory.create(attributes=["email_address"])
+
+        # Define form with all additional form configuration
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            theme=theme,
+            category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [
+                    # The uuids of the `personal` and `mail` attributegroups
+                    yiviAttributeGroup1.uuid,
+                    yiviAttributeGroup2.uuid,
+                ],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map 1",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmtsMap1.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wmsMap1.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                    {
+                        "label": "Map 2",
+                        "key": "map2",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmtsMap2.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wmsMap2.uuid),
+                                "label": "height",
+                                "layers": ["EL.GridCoverage"],
+                            },
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wmsMap3.uuid),
+                                "label": "LGN",
+                                "layers": ["lgn-actueel"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        # The export is made with all additional_form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                additional_form_configuration=[
+                    AdditionalFormConfigurationOptions.product,
+                    AdditionalFormConfigurationOptions.theme,
+                    AdditionalFormConfigurationOptions.category,
+                    AdditionalFormConfigurationOptions.wms_tile_layers,
+                    AdditionalFormConfigurationOptions.wmts_tile_layers,
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                ],
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            # All of the additional form configuration files should be in the exportdata
+            self.assertEqual(
+                f.namelist(),
+                [
+                    "forms.json",
+                    "formSteps.json",
+                    "formDefinitions.json",
+                    "formLogic.json",
+                    "formVariables.json",
+                    "product.json",
+                    "theme.json",
+                    "category.json",
+                    "wmsTileLayers.json",
+                    "wmtsTileLayers.json",
+                    "yiviAttributeGroups.json",
+                    f"{EXPORT_META_KEY}.json",
+                ],
+            )
+
+            forms = json.loads(f.read("forms.json"))
+            product_export = json.loads(f.read("product.json"))
+            theme_export = json.loads(f.read("theme.json"))
+            category_export = json.loads(f.read("category.json"))
+            wms_tile_layers_export = json.loads(f.read("wmsTileLayers.json"))
+            wmts_tile_layers_export = json.loads(f.read("wmtsTileLayers.json"))
+            yivi_attribute_groups_export = json.loads(
+                f.read("yiviAttributeGroups.json")
+            )
+
+            self.assertEqual(len(forms), 1)
+
+            # Assert product, theme, category are in exportdata
+            self.assertIsNotNone(forms[0]["product"])
+            self.assertIsNotNone(forms[0]["theme"])
+            self.assertIsNotNone(forms[0]["category"])
+
+            # Validate the export file contents
+            self.assertEqual(
+                product_export,
+                [
+                    {
+                        "uuid": str(product.uuid),
+                        "name": product.name,
+                        "price": str(product.price).replace(".", ","),
+                        "information": product.information,
+                    }
+                ],
+            )
+            self.assertEqual(
+                theme_export,
+                [
+                    {
+                        "uuid": str(theme.uuid),
+                        "name": theme.name,
+                        "organization_name": theme.organization_name,
+                        "main_website": theme.main_website,
+                        "favicon": str(theme.favicon),
+                        "email_logo": str(theme.email_logo),
+                        "classname": theme.classname,
+                        "stylesheet": theme.stylesheet,
+                        "stylesheet_file": str(theme.stylesheet_file),
+                        # Simple stringify results in the wrong quotes being used, so we
+                        # have to json.dump the design_token_values
+                        "design_token_values": json.dumps(theme.design_token_values),
+                    }
+                ],
+            )
+            self.assertEqual(
+                category_export,
+                [
+                    {
+                        "uuid": str(category.uuid),
+                        "name": category.name,
+                    }
+                ],
+            )
+
+            self.assertEqual(len(wms_tile_layers_export), 3)
+            self.assertIn(
+                {
+                    "uuid": str(wmsMap1.uuid),
+                    "name": wmsMap1.name,
+                    "url": wmsMap1.url,
+                },
+                wms_tile_layers_export,
+            )
+            self.assertIn(
+                {
+                    "uuid": str(wmsMap2.uuid),
+                    "name": wmsMap2.name,
+                    "url": wmsMap2.url,
+                },
+                wms_tile_layers_export,
+            )
+            self.assertIn(
+                {
+                    "uuid": str(wmsMap3.uuid),
+                    "name": wmsMap3.name,
+                    "url": wmsMap3.url,
+                },
+                wms_tile_layers_export,
+            )
+
+            self.assertEqual(len(wmts_tile_layers_export), 2)
+            self.assertIn(
+                {
+                    "identifier": wmtsMap1.identifier,
+                    "label": wmtsMap1.label,
+                    "url": wmtsMap1.url,
+                },
+                wmts_tile_layers_export,
+            )
+            self.assertIn(
+                {
+                    "identifier": wmtsMap2.identifier,
+                    "label": wmtsMap2.label,
+                    "url": wmtsMap2.url,
+                },
+                wmts_tile_layers_export,
+            )
+
+            self.assertEqual(len(yivi_attribute_groups_export), 2)
+            self.assertIn(
+                {
+                    "uuid": str(yiviAttributeGroup1.uuid),
+                    "name": yiviAttributeGroup1.name,
+                    "description": yiviAttributeGroup1.description,
+                    "attributes": ",".join(yiviAttributeGroup1.attributes),
+                },
+                yivi_attribute_groups_export,
+            )
+            self.assertIn(
+                {
+                    "uuid": str(yiviAttributeGroup2.uuid),
+                    "name": yiviAttributeGroup2.name,
+                    "description": yiviAttributeGroup2.description,
+                    "attributes": ",".join(yiviAttributeGroup2.attributes),
+                },
+                yivi_attribute_groups_export,
             )
 
     def test_import(self):

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -729,10 +729,51 @@ class ImportExportTests(TempdirMixin, TestCase):
         product = ProductFactory.create()
         theme = ThemeFactory.create()
         category = CategoryFactory.create()
+
+        yiviAttributeGroup1 = AttributeGroupFactory.create()
+        yiviAttributeGroup2 = AttributeGroupFactory.create()
+
+        wmtsTileLayer = MapTileLayerFactory.create()
+        wmsTileLayer = MapWMSTileLayerFactory.create()
+
         form = FormFactory.create(
+            generate_minimal_setup=True,
             product=product,
             theme=theme,
             category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [
+                    yiviAttributeGroup1.uuid,
+                    yiviAttributeGroup2.uuid,
+                ],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmtsTileLayer.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wmsTileLayer.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                ],
+            },
         )
 
         # The export is made without any additional_form_configuration
@@ -759,6 +800,7 @@ class ImportExportTests(TempdirMixin, TestCase):
             )
 
             forms = json.loads(f.read("forms.json"))
+            formDefinitions = json.loads(f.read("formDefinitions.json"))
 
             self.assertEqual(len(forms), 1)
 
@@ -766,6 +808,44 @@ class ImportExportTests(TempdirMixin, TestCase):
             self.assertEqual(forms[0]["product"], None)
             self.assertEqual(forms[0]["theme"], None)
             self.assertEqual(forms[0]["category"], None)
+
+            # Assert Yivi authentication_backend is in exportdata, but without
+            # additional_attributes_groups
+            self.assertEqual(len(forms[0]["auth_backends"]), 1)
+            auth_backend = forms[0]["auth_backends"][0]
+            self.assertEqual(auth_backend["backend"], "yivi_oidc")
+            self.assertEqual(
+                auth_backend["options"]["additional_attributes_groups"], []
+            )
+            # Assert that the authentication_options on the actual form object are kept
+            self.assertIn(
+                str(yiviAttributeGroup1.uuid),
+                form.auth_backends.first().options["additional_attributes_groups"],
+            )
+            self.assertIn(
+                str(yiviAttributeGroup2.uuid),
+                form.auth_backends.first().options["additional_attributes_groups"],
+            )
+
+            # Assert that the WMS and WMTS tile layers are removed from the exportdata
+            self.assertEqual(len(formDefinitions), 1)
+            self.assertEqual(len(formDefinitions[0]["configuration"]["components"]), 1)
+            component_definition = formDefinitions[0]["configuration"]["components"][0]
+
+            self.assertEqual(component_definition["type"], "map")
+            self.assertEqual(component_definition["tileLayerIdentifier"], "")
+            self.assertEqual(len(component_definition["overlays"]), 1)
+            self.assertEqual(component_definition["overlays"][0]["uuid"], "")
+            self.assertEqual(component_definition["overlays"][0]["layers"], [])
+            # Assert that the actual form definition still contains the WMS and WMTS tile layers
+            fd = form.formstep_set.get().form_definition
+            self.assertEqual(
+                fd.configuration["components"][0]["tileLayerIdentifier"],
+                wmtsTileLayer.identifier,
+            )
+            overlay = fd.configuration["components"][0]["overlays"][0]
+            self.assertEqual(overlay["uuid"], str(wmsTileLayer.uuid))
+            self.assertEqual(overlay["layers"], ["pand", "verblijfsobject"])
 
     def test_export_with_all_additional_form_configuration_included(self):
         product = ProductFactory.create()
@@ -890,6 +970,7 @@ class ImportExportTests(TempdirMixin, TestCase):
             )
 
             forms = json.loads(f.read("forms.json"))
+            formDefinitions = json.loads(f.read("formDefinitions.json"))
             product_export = json.loads(f.read("product.json"))
             theme_export = json.loads(f.read("theme.json"))
             category_export = json.loads(f.read("category.json"))
@@ -905,6 +986,40 @@ class ImportExportTests(TempdirMixin, TestCase):
             self.assertIsNotNone(forms[0]["product"])
             self.assertIsNotNone(forms[0]["theme"])
             self.assertIsNotNone(forms[0]["category"])
+
+            # Assert Yivi authentication_backend is in exportdata with
+            # additional_attributes_groups
+            self.assertEqual(len(forms[0]["auth_backends"]), 1)
+            auth_backend = forms[0]["auth_backends"][0]
+            self.assertEqual(auth_backend["backend"], "yivi_oidc")
+            self.assertIn(
+                str(yiviAttributeGroup1.uuid),
+                auth_backend["options"]["additional_attributes_groups"],
+            )
+            self.assertIn(
+                str(yiviAttributeGroup2.uuid),
+                auth_backend["options"]["additional_attributes_groups"],
+            )
+
+            # Assert WMS and WMTS tile layers are in exportdata
+            self.assertEqual(len(formDefinitions), 1)
+            self.assertEqual(len(formDefinitions[0]["configuration"]["components"]), 2)
+            component1 = formDefinitions[0]["configuration"]["components"][0]
+            component2 = formDefinitions[0]["configuration"]["components"][1]
+
+            self.assertEqual(component1["tileLayerIdentifier"], wmtsMap1.identifier)
+            self.assertEqual(len(component1["overlays"]), 1)
+            self.assertEqual(component1["overlays"][0]["uuid"], str(wmsMap1.uuid))
+            self.assertEqual(
+                component1["overlays"][0]["layers"], ["pand", "verblijfsobject"]
+            )
+
+            self.assertEqual(component2["tileLayerIdentifier"], wmtsMap2.identifier)
+            self.assertEqual(len(component2["overlays"]), 2)
+            self.assertEqual(component2["overlays"][0]["uuid"], str(wmsMap2.uuid))
+            self.assertEqual(component2["overlays"][0]["layers"], ["EL.GridCoverage"])
+            self.assertEqual(component2["overlays"][1]["uuid"], str(wmsMap3.uuid))
+            self.assertEqual(component2["overlays"][1]["layers"], ["lgn-actueel"])
 
             # Validate the export file contents
             self.assertEqual(

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -1199,7 +1199,18 @@ class ImportExportTests(TempdirMixin, TestCase):
             form_logic.pk,
         )
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=[
+                    "registrationBackends",
+                    "prefill",
+                    "paymentBackend",
+                ],
+            ),
+        )
 
         # attempt to break ForeignKey constraint
         far_fetched.delete()
@@ -2757,7 +2768,14 @@ class ImportExportTests(TempdirMixin, TestCase):
             },
         )
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=["registrationBackends"],
+            ),
+        )
         import_form(import_file=self.filepath)
 
         updated_form = Form.objects.last()
@@ -2914,7 +2932,14 @@ class ImportExportTests(TempdirMixin, TestCase):
             is_advanced=True,
         )
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=["prefill"],
+            ),
+        )
 
         # Import form
         import_form(import_file=self.filepath)
@@ -3015,7 +3040,14 @@ class ExportObjectsAPITests(TempdirMixin, TestCase):
             },
         )
 
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=["registrationBackends"],
+            ),
+        )
 
         with zipfile.ZipFile(self.filepath, "r") as f:
             self.assertEqual(
@@ -3521,7 +3553,14 @@ class ImportObjectsAPITests(TempdirMixin, OFVCRMixin, TestCase):
                 "files": [],
             },
         )
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=["registrationBackends"],
+            ),
+        )
         form.delete()
 
         import_form(import_file=self.filepath)
@@ -3767,7 +3806,14 @@ class ImportZGWAPITests(TempdirMixin, OFVCRMixin, TestCase):
                 "files": [],
             },
         )
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=["registrationBackends"],
+            ),
+        )
         form.delete()
 
         import_form(import_file=self.filepath)
@@ -3894,7 +3940,14 @@ class ImportStUFZDSTests(TempdirMixin, TestCase):
                 "files": [],
             },
         )
-        export_form(form.pk, archive_name=self.filepath)
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=["registrationBackends"],
+            ),
+        )
         form.delete()
 
         import_form(import_file=self.filepath)

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -1071,6 +1071,8 @@ class ImportExportTests(TempdirMixin, TestCase):
                     {
                         "uuid": str(category.uuid),
                         "name": category.name,
+                        "path": category.path,
+                        "depth": str(category.depth),
                     }
                 ],
             )
@@ -1238,7 +1240,17 @@ class ImportExportTests(TempdirMixin, TestCase):
         form.slug = "modified"
         form.save()
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[
+                    FormConfigurationOptions.registration_backends,
+                    FormConfigurationOptions.prefill,
+                    FormConfigurationOptions.payment_backend,
+                    FormConfigurationOptions.auth_backends,
+                ]
+            ),
+        )
 
         forms = Form.objects.all()
         imported_form = forms.last()
@@ -2436,7 +2448,12 @@ class ImportExportTests(TempdirMixin, TestCase):
             for name, data in resources.items():
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.auth_backends]
+            ),
+        )
 
         imported_form = Form.objects.get(slug="test-form")
         authentication_backends = imported_form.auth_backends.all()
@@ -2508,7 +2525,12 @@ class ImportExportTests(TempdirMixin, TestCase):
             for name, data in resources.items():
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.auth_backends]
+            ),
+        )
 
         imported_form = Form.objects.get(slug="test-form")
         authentication_backends = imported_form.auth_backends.all()
@@ -2556,7 +2578,15 @@ class ImportExportTests(TempdirMixin, TestCase):
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
         with self.assertRaises(ValidationError) as exc:
-            import_form(import_file=self.filepath)
+            import_form(
+                import_file=self.filepath,
+                import_options=FormImportOptions(
+                    form_configuration=[FormConfigurationOptions.auth_backends],
+                    additional_form_configuration=[
+                        AdditionalFormConfigurationOptions.yivi_attribute_groups
+                    ],
+                ),
+            )
 
         error_detail = exc.exception.detail["auth_backends"][0]["backend"][0]
 
@@ -2587,7 +2617,12 @@ class ImportExportTests(TempdirMixin, TestCase):
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
         with self.assertRaises(ValidationError) as exc:
-            import_form(import_file=self.filepath)
+            import_form(
+                import_file=self.filepath,
+                import_options=FormImportOptions(
+                    form_configuration=[FormConfigurationOptions.auth_backends],
+                ),
+            )
 
         error_detail = exc.exception.detail["auth_backends"][0]["backend"][0]
 
@@ -2629,7 +2664,15 @@ class ImportExportTests(TempdirMixin, TestCase):
             for name, data in resources.items():
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.auth_backends],
+                additional_form_configuration=[
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups
+                ],
+            ),
+        )
 
         imported_form = Form.objects.get(slug="test-form")
         authentication_backends = imported_form.auth_backends.all()
@@ -2688,7 +2731,15 @@ class ImportExportTests(TempdirMixin, TestCase):
             for name, data in resources.items():
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.auth_backends],
+                additional_form_configuration=[
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups
+                ],
+            ),
+        )
 
         imported_form = Form.objects.get(slug="test-form")
         authentication_backends = imported_form.auth_backends.all()
@@ -2738,7 +2789,15 @@ class ImportExportTests(TempdirMixin, TestCase):
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
         with self.assertRaises(ValidationError) as exc:
-            import_form(import_file=self.filepath)
+            import_form(
+                import_file=self.filepath,
+                import_options=FormImportOptions(
+                    form_configuration=[FormConfigurationOptions.auth_backends],
+                    additional_form_configuration=[
+                        AdditionalFormConfigurationOptions.yivi_attribute_groups
+                    ],
+                ),
+            )
 
         error_detail = exc.exception.detail["auth_backends"][0]["options"][
             "additional_attributes_groups"
@@ -2789,7 +2848,12 @@ class ImportExportTests(TempdirMixin, TestCase):
                 form_configuration=["registrationBackends"],
             ),
         )
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.registration_backends],
+            ),
+        )
 
         updated_form = Form.objects.last()
         registration_backend = updated_form.registration_backends.get()
@@ -2955,7 +3019,12 @@ class ImportExportTests(TempdirMixin, TestCase):
         )
 
         # Import form
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.prefill],
+            ),
+        )
 
         imported_form = Form.objects.last()
         imported_steps = list(imported_form.formstep_set.all())
@@ -4332,7 +4401,12 @@ class ImportObjectsAPITests(TempdirMixin, OFVCRMixin, TestCase):
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
         with self.assertRaises(ValidationError) as exc:
-            import_form(import_file=self.filepath)
+            import_form(
+                import_file=self.filepath,
+                import_options=FormImportOptions(
+                    form_configuration=[FormConfigurationOptions.registration_backends]
+                ),
+            )
 
         error_detail = exc.exception.detail["registration_backends"][0]["options"][
             "objects_api_group"
@@ -4376,7 +4450,12 @@ class ImportObjectsAPITests(TempdirMixin, OFVCRMixin, TestCase):
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
         with self.assertRaises(ValidationError) as exc:
-            import_form(import_file=self.filepath)
+            import_form(
+                import_file=self.filepath,
+                import_options=FormImportOptions(
+                    form_configuration=[FormConfigurationOptions.registration_backends]
+                ),
+            )
 
         error_detail = exc.exception.detail["registration_backends"][0]["options"][
             "objecttype"
@@ -4423,7 +4502,12 @@ class ImportObjectsAPITests(TempdirMixin, OFVCRMixin, TestCase):
             for name, data in resources.items():
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.registration_backends]
+            ),
+        )
 
         registration_backend = FormRegistrationBackend.objects.get(key="test-backend")
         self.assertEqual(
@@ -4464,7 +4548,12 @@ class ImportObjectsAPITests(TempdirMixin, OFVCRMixin, TestCase):
             for name, data in resources.items():
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.registration_backends]
+            ),
+        )
 
         registration_backend = FormRegistrationBackend.objects.get(key="test-backend")
 
@@ -4521,7 +4610,12 @@ class ImportObjectsAPITests(TempdirMixin, OFVCRMixin, TestCase):
             for name, data in resources.items():
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.registration_backends]
+            ),
+        )
 
         registration_backend_v1 = FormRegistrationBackend.objects.get(
             key="test-backend-v1"
@@ -4576,7 +4670,12 @@ class ImportObjectsAPITests(TempdirMixin, OFVCRMixin, TestCase):
             for name, data in resources.items():
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.registration_backends]
+            ),
+        )
 
         registration_backend_valid_mapping = FormRegistrationBackend.objects.get(
             key="test-backend"
@@ -4625,7 +4724,12 @@ class ImportObjectsAPITests(TempdirMixin, OFVCRMixin, TestCase):
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
         with self.assertRaises(ValidationError) as exc:
-            import_form(import_file=self.filepath)
+            import_form(
+                import_file=self.filepath,
+                import_options=FormImportOptions(
+                    form_configuration=[FormConfigurationOptions.registration_backends]
+                ),
+            )
 
         error_detail = exc.exception.detail["registration_backends"][0]["options"][
             "variables_mapping"
@@ -4670,7 +4774,12 @@ class ImportObjectsAPITests(TempdirMixin, OFVCRMixin, TestCase):
             for name, data in resources.items():
                 zip_file.writestr(f"{name}.json", json.dumps(data))
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.registration_backends]
+            ),
+        )
 
         registration_backend = FormRegistrationBackend.objects.get(key="test-backend")
         self.assertEqual(
@@ -4785,7 +4894,12 @@ class ImportObjectsAPITests(TempdirMixin, OFVCRMixin, TestCase):
         )
         form.delete()
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.registration_backends]
+            ),
+        )
 
         backends: dict[str, FormRegistrationBackend] = {
             backend.key: backend for backend in FormRegistrationBackend.objects.all()
@@ -4876,7 +4990,12 @@ class ImportZGWAPITests(TempdirMixin, OFVCRMixin, TestCase):
             },
         )
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.registration_backends]
+            ),
+        )
 
         registration_backend = FormRegistrationBackend.objects.get(key="test-backend")
         self.assertEqual(
@@ -4908,7 +5027,14 @@ class ImportZGWAPITests(TempdirMixin, OFVCRMixin, TestCase):
             )
 
             with self.assertRaises(ValidationError) as exc:
-                import_form(import_file=self.filepath)
+                import_form(
+                    import_file=self.filepath,
+                    import_options=FormImportOptions(
+                        form_configuration=[
+                            FormConfigurationOptions.registration_backends
+                        ]
+                    ),
+                )
 
             error_detail = exc.exception.detail["registration_backends"][0]["options"][
                 "objects_api_group"
@@ -4937,7 +5063,12 @@ class ImportZGWAPITests(TempdirMixin, OFVCRMixin, TestCase):
                 },
             )
 
-            import_form(import_file=self.filepath)
+            import_form(
+                import_file=self.filepath,
+                import_options=FormImportOptions(
+                    form_configuration=[FormConfigurationOptions.registration_backends]
+                ),
+            )
 
             registration_backend = FormRegistrationBackend.objects.get(
                 key="test-backend"
@@ -5038,7 +5169,12 @@ class ImportZGWAPITests(TempdirMixin, OFVCRMixin, TestCase):
         )
         form.delete()
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.registration_backends]
+            ),
+        )
 
         backends: dict[str, FormRegistrationBackend] = {
             backend.key: backend for backend in FormRegistrationBackend.objects.all()
@@ -5172,7 +5308,12 @@ class ImportStUFZDSTests(TempdirMixin, TestCase):
         )
         form.delete()
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.registration_backends]
+            ),
+        )
 
         backends: dict[str, FormRegistrationBackend] = {
             backend.key: backend for backend in FormRegistrationBackend.objects.all()

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -4,18 +4,27 @@ import zipfile
 from pathlib import Path
 from shutil import rmtree
 from textwrap import dedent
-from unittest.mock import patch
-from uuid import UUID
+from unittest.mock import ANY, patch
+from uuid import UUID, uuid4
 
 from django.test import TestCase, override_settings, tag
 from django.utils import translation
+from django.utils.translation import gettext as _
 
 from digid_eherkenning.choices import AssuranceLevels, DigiDAssuranceLevels
 from freezegun import freeze_time
 from rest_framework.exceptions import ValidationError
 
+from openforms.authentication.constants import AuthAttribute
+from openforms.authentication.contrib.yivi_oidc.models import AttributeGroup
+from openforms.authentication.tests.factories import AttributeGroupFactory
 from openforms.config.constants import UploadFileType
-from openforms.config.models import GlobalConfiguration
+from openforms.config.models import (
+    GlobalConfiguration,
+    MapTileLayer,
+    MapWMSTileLayer,
+    Theme,
+)
 from openforms.config.tests.factories import (
     MapTileLayerFactory,
     MapWMSTileLayerFactory,
@@ -26,12 +35,17 @@ from openforms.emails.models import ConfirmationEmailTemplate
 from openforms.emails.tests.factories import ConfirmationEmailTemplateFactory
 from openforms.import_export.typing import (
     AdditionalFormConfigurationOptions,
+    FormConfigurationOptions,
     FormExportOptions,
+    FormImportOptions,
+    LinksToUnknownDomainsOptions,
+    ReusableFormDefinitionsOptions,
 )
 from openforms.payments.contrib.worldline.tests.factories import (
     WorldlineMerchantFactory,
 )
 from openforms.prefill.constants import IdentifierRoles
+from openforms.products.models import Product
 from openforms.products.tests.factories import ProductFactory
 from openforms.registrations.contrib.objects_api.config import (
     ObjectsAPIOptionsSerializer,
@@ -65,11 +79,10 @@ from openforms.utils.tests.vcr import OFVCRMixin
 from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
 
-from ...authentication.constants import AuthAttribute
-from ...authentication.tests.factories import AttributeGroupFactory
 from ..constants import EXPORT_META_KEY
 from ..disable_next_import_conversion import add_form_step_uuid_to_disable_next_actions
 from ..models import (
+    Category,
     Form,
     FormAuthenticationBackend,
     FormDefinition,
@@ -3022,6 +3035,1215 @@ class ImportExportTests(TempdirMixin, TestCase):
             self.assertEqual(
                 rule.actions[0]["form_step_uuid"], str(imported_steps[1].uuid)
             )
+
+    def test_import_with_options_remove_all_unknown_domains(self):
+        config = GlobalConfiguration.get_solo()
+
+        # Start with google domain in allowlist, so we can create the initial form
+        config.email_template_netloc_allowlist = ["https://google.com", "allowed.com"]  # pyright: ignore[reportAttributeAccessIssue]
+        config.save()
+
+        form = FormFactory.create(
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["some@email.com"],
+                "email_content_template_html": "<p>test https://google.com <a href='https://www.google.com'>Google</a> https://allowed.com test</p>",
+                "email_content_template_text": "test https://google.com https://allowed.com test",
+            },
+        )
+        ConfirmationEmailTemplateFactory(
+            form=form,
+            subject="Test",
+            content="<p>email content https://google.com <a href='https://www.google.com'>Google</a> https://allowed.com</p><p>{% appointment_information %}</p><p>{% payment_information %}</p>",
+            cosign_subject="Cosign test",
+            cosign_content="<p>cosign email content https://google.com <a href='https://www.google.com'>Google</a> https://allowed.com</p><p>{% payment_information %}</p><p>{% cosign_information %}</p>",
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=[FormConfigurationOptions.registration_backends],
+            ),
+        )
+
+        # Delete the original form to make the slug available
+        form.delete()
+
+        # Remove google domain from allowlist
+        config.email_template_netloc_allowlist = ["allowed.com"]  # pyright: ignore[reportAttributeAccessIssue]
+        config.save()
+
+        # Import form
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.registration_backends],
+                links_to_unknown_domains=LinksToUnknownDomainsOptions.remove,
+            ),
+        )
+
+        # The email templates of the imported form should not contain the google domain
+        imported_form = Form.objects.last()
+
+        self.assertEqual(len(imported_form.registration_backends.all()), 1)
+        self.assertEqual(
+            imported_form.registration_backends.first().options,
+            {
+                "to_emails": ["some@email.com"],
+                "attach_files_to_email": None,
+                "email_content_template_html": "<p>test  <a href=''>Google</a> https://allowed.com test</p>",
+                "email_content_template_text": "test  https://allowed.com test",
+            },
+        )
+
+        # The confirmation and cosign email templates should not contain the google domain
+        self.assertEqual(
+            imported_form.confirmation_email_template.content,
+            "<p>email content  <a href=''>Google</a> https://allowed.com</p><p>{% appointment_information %}</p><p>{% payment_information %}</p>",
+        )
+        self.assertEqual(
+            imported_form.confirmation_email_template.cosign_content,
+            "<p>cosign email content  <a href=''>Google</a> https://allowed.com</p><p>{% payment_information %}</p><p>{% cosign_information %}</p>",
+        )
+
+    def test_import_with_options_accept_all_unknown_domains(self):
+        config = GlobalConfiguration.get_solo()
+
+        # Start with google domain in allowlist, so we can create the initial form
+        config.email_template_netloc_allowlist = ["https://google.com", "allowed.com"]  # pyright: ignore[reportAttributeAccessIssue]
+        config.save()
+
+        form = FormFactory.create(
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["some@email.com"],
+                "email_content_template_html": "<p>test https://google.com <a href='https://www.google.com'>Google</a> https://allowed.com test</p>",
+                "email_content_template_text": "test https://google.com https://allowed.com test",
+            },
+        )
+        ConfirmationEmailTemplateFactory(
+            form=form,
+            subject="Test",
+            content="<p>email content https://google.com <a href='https://www.google.com'>Google</a> https://allowed.com</p><p>{% appointment_information %}</p><p>{% payment_information %}</p>",
+            cosign_subject="Cosign test",
+            cosign_content="<p>cosign email content https://google.com <a href='https://www.google.com'>Google</a> https://allowed.com</p><p>{% payment_information %}</p><p>{% cosign_information %}</p>",
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=[FormConfigurationOptions.registration_backends],
+            ),
+        )
+
+        # Delete the original form to make the slug available
+        form.delete()
+
+        # Remove google domain from allowlist
+        config.email_template_netloc_allowlist = ["allowed.com"]  # pyright: ignore[reportAttributeAccessIssue]
+        config.save()
+
+        # Import form
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.registration_backends],
+                links_to_unknown_domains=LinksToUnknownDomainsOptions.accept,
+            ),
+        )
+        config.refresh_from_db()
+
+        # The email templates of the imported form should contain all the google domain
+        imported_form = Form.objects.last()
+        self.assertEqual(len(imported_form.registration_backends.all()), 1)
+        self.assertEqual(
+            imported_form.registration_backends.first().options,
+            {
+                "to_emails": ["some@email.com"],
+                "attach_files_to_email": None,
+                "email_content_template_html": "<p>test https://google.com <a href='https://www.google.com'>Google</a> https://allowed.com test</p>",
+                "email_content_template_text": "test https://google.com https://allowed.com test",
+            },
+        )
+        # The confirmation and cosign email templates should contain the google domain
+        self.assertEqual(
+            form.confirmation_email_template.content,
+            "<p>email content https://google.com <a href='https://www.google.com'>Google</a> https://allowed.com</p><p>{% appointment_information %}</p><p>{% payment_information %}</p>",
+        )
+        self.assertEqual(
+            form.confirmation_email_template.cosign_content,
+            "<p>cosign email content https://google.com <a href='https://www.google.com'>Google</a> https://allowed.com</p><p>{% payment_information %}</p><p>{% cosign_information %}</p>",
+        )
+        # The google domain should again be present in the allowlist
+        self.assertEqual(len(config.email_template_netloc_allowlist), 3)
+        self.assertIn("allowed.com", config.email_template_netloc_allowlist)
+        self.assertIn("www.google.com", config.email_template_netloc_allowlist)
+        self.assertIn("google.com", config.email_template_netloc_allowlist)
+
+    def test_import_with_options_ignore_all_unknown_domains(self):
+        config = GlobalConfiguration.get_solo()
+
+        # Start with google domain in allowlist, so we can create the initial form
+        config.email_template_netloc_allowlist = ["https://google.com", "allowed.com"]  # pyright: ignore[reportAttributeAccessIssue]
+        config.save()
+
+        form = FormFactory.create(
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["some@email.com"],
+                "email_content_template_html": "<p>test https://google.com <a href='https://www.google.com'>Google</a> https://allowed.com test</p>",
+                "email_content_template_text": "test https://google.com https://allowed.com test",
+            },
+        )
+        ConfirmationEmailTemplateFactory(
+            form=form,
+            subject="Test",
+            content="<p>email content https://google.com <a href='https://www.google.com'>Google</a> https://allowed.com</p><p>{% appointment_information %}</p><p>{% payment_information %}</p>",
+            cosign_subject="Cosign test",
+            cosign_content="<p>cosign email content https://google.com <a href='https://www.google.com'>Google</a> https://allowed.com</p><p>{% payment_information %}</p><p>{% cosign_information %}</p>",
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=[FormConfigurationOptions.registration_backends],
+            ),
+        )
+
+        # Delete the original form to make the slug available
+        form.delete()
+
+        # Remove google domain from allowlist
+        config.email_template_netloc_allowlist = ["allowed.com"]  # pyright: ignore[reportAttributeAccessIssue]
+        config.save()
+
+        # Import form
+        with self.assertRaises(ValidationError) as error:
+            import_form(
+                import_file=self.filepath,
+                import_options=FormImportOptions(
+                    form_configuration=[FormConfigurationOptions.registration_backends],
+                    links_to_unknown_domains=LinksToUnknownDomainsOptions.ignore,
+                ),
+            )
+
+        domain_error_message = _(
+            "This domain is not in the global netloc allowlist: {netloc}"
+        )
+        detail = error.exception.detail
+
+        # Assert that the email templates in the email registration raise errors
+        self.assertEqual(
+            detail["registration_backends"][0]["options"][
+                "email_content_template_html"
+            ][0],
+            domain_error_message.format(netloc="google.com"),
+        )
+        self.assertEqual(
+            detail["registration_backends"][0]["options"][
+                "email_content_template_text"
+            ][0],
+            domain_error_message.format(netloc="google.com"),
+        )
+        # The confirmation and cosign email templates also throw errors
+        self.assertEqual(
+            detail["confirmation_email_template"]["content"][0],
+            domain_error_message.format(netloc="google.com"),
+        )
+        self.assertEqual(
+            detail["confirmation_email_template"]["cosign_content"][0],
+            domain_error_message.format(netloc="google.com"),
+        )
+
+        # The allowlist should still only contain the allowed domain
+        config.refresh_from_db()
+        self.assertListEqual(
+            config.email_template_netloc_allowlist,
+            ["allowed.com"],
+        )
+
+    def test_import_with_options_exclude_all_form_configuration(self):
+        merchant = WorldlineMerchantFactory.create()
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            identifier="test-objects-api-group"
+        )
+
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            authentication_backend="digid",
+            payment_backend="worldline",
+            payment_backend_options={"merchant": merchant.pspid},
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["abc@xyz.com"],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "prefill": {
+                            "plugin": "demo",
+                            "attribute": "random_number",
+                            "identifier_role": "authorised_person",
+                        },
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_demo_prefill",
+            user_defined=True,
+            prefill_plugin="demo",
+            prefill_attribute="random_string",
+            prefill_identifier_role=IdentifierRoles.authorizee,
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_objects_api_prefill",
+            user_defined=True,
+            prefill_plugin="objects_api",
+            prefill_options={
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=True,
+                form_configuration=[
+                    FormConfigurationOptions.registration_backends,
+                    FormConfigurationOptions.prefill,
+                    FormConfigurationOptions.payment_backend,
+                ],
+            ),
+        )
+        form.delete()
+
+        # Import form
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[],
+            ),
+        )
+
+        imported_form = Form.objects.last()
+
+        # Expect registration, payment, and auth to be excluded
+        self.assertEqual(len(imported_form.auth_backends.all()), 0)
+        self.assertEqual(len(imported_form.registration_backends.all()), 0)
+        self.assertEqual(imported_form.payment_backend, "")
+        self.assertEqual(imported_form.payment_backend_options, {})
+
+        # The prefill config of the component should be removed
+        fd = imported_form.formstep_set.get().form_definition
+        self.assertEqual(len(fd.configuration["components"]), 1)
+        component = fd.configuration["components"][0]
+        self.assertEqual(
+            component["prefill"],
+            {
+                "plugin": "",
+                "attribute": "",
+                "identifier_role": IdentifierRoles.main,
+            },
+        )
+
+        # There should be two user-defined variables, both without prefill config
+        variables = FormVariable.objects.filter(
+            form=imported_form, source="user_defined"
+        )
+        self.assertEqual(variables.count(), 2)
+        self.assertEqual(variables[0].prefill_plugin, "")
+        self.assertEqual(variables[0].prefill_attribute, "")
+        self.assertEqual(variables[0].prefill_identifier_role, IdentifierRoles.main)
+        self.assertEqual(variables[0].prefill_options, {})
+
+        self.assertEqual(variables[1].prefill_plugin, "")
+        self.assertEqual(variables[1].prefill_attribute, "")
+        self.assertEqual(variables[1].prefill_identifier_role, IdentifierRoles.main)
+        self.assertEqual(variables[1].prefill_options, {})
+
+    def test_import_with_options_include_all_form_configuration(self):
+        merchant = WorldlineMerchantFactory.create()
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            identifier="test-objects-api-group"
+        )
+
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            authentication_backend="digid",
+            payment_backend="worldline",
+            payment_backend_options={"merchant": merchant.pspid},
+            registration_backend="email",
+            registration_backend_options={
+                "to_emails": ["abc@xyz.com"],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "prefill": {
+                            "plugin": "demo",
+                            "attribute": "random_number",
+                            "identifier_role": IdentifierRoles.authorizee,
+                        },
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_demo_prefill",
+            user_defined=True,
+            prefill_plugin="demo",
+            prefill_attribute="random_string",
+            prefill_identifier_role=IdentifierRoles.authorizee,
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_objects_api_prefill",
+            user_defined=True,
+            prefill_plugin="objects_api",
+            prefill_options={
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=False,
+                form_configuration=[
+                    FormConfigurationOptions.registration_backends,
+                    FormConfigurationOptions.prefill,
+                    FormConfigurationOptions.payment_backend,
+                ],
+            ),
+        )
+        form.delete()
+
+        # Import form
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[
+                    FormConfigurationOptions.registration_backends,
+                    FormConfigurationOptions.prefill,
+                    FormConfigurationOptions.payment_backend,
+                    FormConfigurationOptions.auth_backends,
+                ],
+            ),
+        )
+
+        imported_form = Form.objects.last()
+
+        # Expect registration, payment, and auth to be the same as the exported form
+        self.assertEqual(len(imported_form.auth_backends.all()), 1)
+        self.assertEqual(imported_form.auth_backends.first().backend, "digid")
+
+        self.assertEqual(len(imported_form.registration_backends.all()), 1)
+        registration_backend = imported_form.registration_backends.first()
+        self.assertEqual(registration_backend.backend, "email")
+        self.assertEqual(
+            registration_backend.options["to_emails"],
+            ["abc@xyz.com"],
+        )
+
+        self.assertEqual(imported_form.payment_backend, "worldline")
+        self.assertEqual(
+            imported_form.payment_backend_options["merchant"], merchant.pspid
+        )
+
+        # The prefill config of the component should be removed
+        fd = imported_form.formstep_set.get().form_definition
+        self.assertEqual(len(fd.configuration["components"]), 1)
+        component = fd.configuration["components"][0]
+        self.assertEqual(
+            component["prefill"],
+            {
+                "plugin": "demo",
+                "attribute": "random_number",
+                "identifier_role": IdentifierRoles.authorizee,
+            },
+        )
+
+        # There should be two user-defined variables, both without prefill config
+        variables = FormVariable.objects.filter(
+            form=imported_form, source=FormVariableSources.user_defined
+        )
+        self.assertEqual(variables.count(), 2)
+        variable_with_demo = variables.get(key="variable_with_demo_prefill")
+        variable_with_objects_api = variables.get(
+            key="variable_with_objects_api_prefill"
+        )
+
+        self.assertEqual(variable_with_demo.prefill_plugin, "demo")
+        self.assertEqual(variable_with_demo.prefill_attribute, "random_string")
+        self.assertEqual(
+            variable_with_demo.prefill_identifier_role, IdentifierRoles.authorizee
+        )
+
+        self.assertEqual(variable_with_objects_api.prefill_plugin, "objects_api")
+        self.assertEqual(
+            variable_with_objects_api.prefill_options,
+            {
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+    def test_import_with_options_exclude_all_additional_form_configuration(self):
+        # Every OF instance has 5 default WMTS and 1 default WMS map tile layer. For more
+        # accurate and easier testing, we should start at zero.
+        MapTileLayer.objects.all().delete()
+        MapWMSTileLayer.objects.all().delete()
+
+        product = ProductFactory.create()
+        theme = ThemeFactory.create(design_token_values={"key": "token"})
+        category = CategoryFactory.create()
+
+        wmtsMap1 = MapTileLayerFactory.create()
+        wmtsMap2 = MapTileLayerFactory.create()
+        wmsMap1 = MapWMSTileLayerFactory.create()
+        wmsMap2 = MapWMSTileLayerFactory.create()
+        wmsMap3 = MapWMSTileLayerFactory.create()
+
+        yiviAttributeGroup1 = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+        yiviAttributeGroup2 = AttributeGroupFactory.create(attributes=["email_address"])
+
+        # Define form with all additional form configuration
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            theme=theme,
+            category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [
+                    # The uuids of the `personal` and `mail` attribute groups
+                    yiviAttributeGroup1.uuid,
+                    yiviAttributeGroup2.uuid,
+                ],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map 1",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmtsMap1.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wmsMap1.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                    {
+                        "label": "Map 2",
+                        "key": "map2",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmtsMap2.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wmsMap2.uuid),
+                                "label": "height",
+                                "layers": ["EL.GridCoverage"],
+                            },
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wmsMap3.uuid),
+                                "label": "LGN",
+                                "layers": ["lgn-actueel"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        # The export is made with all additional_form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                additional_form_configuration=[
+                    AdditionalFormConfigurationOptions.product,
+                    AdditionalFormConfigurationOptions.theme,
+                    AdditionalFormConfigurationOptions.category,
+                    AdditionalFormConfigurationOptions.wms_tile_layers,
+                    AdditionalFormConfigurationOptions.wmts_tile_layers,
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                ],
+            ),
+        )
+
+        # Delete all previous data
+        form.delete()
+        product.delete()
+        theme.delete()
+        category.delete()
+        wmtsMap1.delete()
+        wmtsMap2.delete()
+        wmsMap1.delete()
+        wmsMap2.delete()
+        wmsMap3.delete()
+        yiviAttributeGroup1.delete()
+        yiviAttributeGroup2.delete()
+
+        # Import form
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.auth_backends],
+                additional_form_configuration=[],
+            ),
+        )
+
+        imported_form = Form.objects.last()
+
+        # The imported form has no product, theme or category
+        self.assertEqual(imported_form.product, None)
+        self.assertEqual(imported_form.category, None)
+        self.assertEqual(imported_form.theme, None)
+
+        # Auth backend is imported without the additional attribute groups
+        self.assertEqual(len(imported_form.auth_backends.all()), 1)
+        auth_backend = imported_form.auth_backends.first()
+        self.assertEqual(auth_backend.backend, "yivi_oidc")
+        self.assertEqual(
+            auth_backend.options["authentication_options"], [AuthAttribute.bsn]
+        )
+        self.assertEqual(auth_backend.options["additional_attributes_groups"], [])
+
+        # Map components don't have configured background and overlay tile layers
+        fd = imported_form.formstep_set.get().form_definition
+        self.assertEqual(len(fd.configuration["components"]), 2)
+        map_component1 = fd.configuration["components"][0]
+        map_component2 = fd.configuration["components"][1]
+
+        self.assertEqual(map_component1["tileLayerIdentifier"], "")
+        self.assertEqual(
+            map_component1["overlays"],
+            [
+                {
+                    "url": "",
+                    "type": "wms",
+                    "uuid": "",
+                    "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                    "layers": [],
+                }
+            ],
+        )
+
+        self.assertEqual(map_component2["tileLayerIdentifier"], "")
+        self.assertEqual(
+            map_component2["overlays"],
+            [
+                {
+                    "url": "",
+                    "type": "wms",
+                    "uuid": "",
+                    "label": "height",
+                    "layers": [],
+                },
+                {
+                    "url": "",
+                    "type": "wms",
+                    "uuid": "",
+                    "label": "LGN",
+                    "layers": [],
+                },
+            ],
+        )
+
+        # None of the additional form configurations have been imported/created
+        self.assertEqual(Product.objects.count(), 0)
+        self.assertEqual(Theme.objects.count(), 0)
+        self.assertEqual(Category.objects.count(), 0)
+        self.assertEqual(MapTileLayer.objects.count(), 0)
+        self.assertEqual(MapWMSTileLayer.objects.count(), 0)
+        self.assertEqual(AttributeGroup.objects.count(), 0)
+
+    def test_import_with_options_include_all_additional_form_configuration(self):
+        product = ProductFactory.create()
+        theme = ThemeFactory.create(design_token_values={"key": "token"})
+        category = CategoryFactory.create()
+
+        wmtsMap1 = MapTileLayerFactory.create()
+        wmtsMap2 = MapTileLayerFactory.create()
+        wmsMap1 = MapWMSTileLayerFactory.create()
+        wmsMap2 = MapWMSTileLayerFactory.create()
+        wmsMap3 = MapWMSTileLayerFactory.create()
+
+        yiviAttributeGroup1 = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+        yiviAttributeGroup2 = AttributeGroupFactory.create(attributes=["email_address"])
+
+        # Define form with all additional form configuration
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            theme=theme,
+            category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [
+                    # The uuids of the `personal` and `mail` attribute groups
+                    yiviAttributeGroup1.uuid,
+                    yiviAttributeGroup2.uuid,
+                ],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map 1",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmtsMap1.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wmsMap1.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                    {
+                        "label": "Map 2",
+                        "key": "map2",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmtsMap2.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wmsMap2.uuid),
+                                "label": "height",
+                                "layers": ["EL.GridCoverage"],
+                            },
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wmsMap3.uuid),
+                                "label": "LGN",
+                                "layers": ["lgn-actueel"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        # The export is made with all additional_form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                additional_form_configuration=[
+                    AdditionalFormConfigurationOptions.product,
+                    AdditionalFormConfigurationOptions.theme,
+                    AdditionalFormConfigurationOptions.category,
+                    AdditionalFormConfigurationOptions.wms_tile_layers,
+                    AdditionalFormConfigurationOptions.wmts_tile_layers,
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                ],
+            ),
+        )
+
+        # Delete all previous data
+        form.delete()
+        product.delete()
+        theme.delete()
+        category.delete()
+        wmtsMap1.delete()
+        wmtsMap2.delete()
+        wmsMap1.delete()
+        wmsMap2.delete()
+        wmsMap3.delete()
+        yiviAttributeGroup1.delete()
+        yiviAttributeGroup2.delete()
+
+        # Import form
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.auth_backends],
+                additional_form_configuration=[
+                    AdditionalFormConfigurationOptions.product,
+                    AdditionalFormConfigurationOptions.theme,
+                    AdditionalFormConfigurationOptions.category,
+                    AdditionalFormConfigurationOptions.wms_tile_layers,
+                    AdditionalFormConfigurationOptions.wmts_tile_layers,
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                ],
+            ),
+        )
+
+        imported_form = Form.objects.last()
+
+        # All of the additional form configurations have been imported and created
+        self.assertEqual(Product.objects.count(), 1)
+        self.assertEqual(Theme.objects.count(), 1)
+        self.assertEqual(Category.objects.count(), 1)
+        self.assertEqual(MapTileLayer.objects.count(), 2)
+        self.assertEqual(MapWMSTileLayer.objects.count(), 3)
+        self.assertEqual(AttributeGroup.objects.count(), 2)
+        imported_product = Product.objects.last()
+        imported_theme = Theme.objects.last()
+        imported_category = Category.objects.last()
+        imported_wmts_layers = MapTileLayer.objects.all()
+        imported_wms_layers = MapWMSTileLayer.objects.all()
+        attribute_groups = AttributeGroup.objects.all()
+
+        # The imported form has product, theme or category
+        self.assertEqual(imported_form.product, str(imported_product.uuid))
+        self.assertEqual(imported_form.category, str(imported_category.uuid))
+        self.assertEqual(imported_form.theme, str(imported_theme.uuid))
+
+        # Auth backend is imported with the additional attribute groups
+        self.assertEqual(len(imported_form.auth_backends.all()), 1)
+        auth_backend = imported_form.auth_backends.first()
+        self.assertEqual(auth_backend.backend, "yivi_oidc")
+        self.assertEqual(
+            auth_backend.options["additional_attributes_groups"],
+            [
+                str(attribute_groups[0].uuid),
+                str(attribute_groups[1].uuid),
+            ],
+        )
+
+        # Map components have configured background and overlay tile layers
+        fd = imported_form.formstep_set.get().form_definition
+        self.assertEqual(len(fd.configuration["components"]), 2)
+        map_component1 = fd.configuration["components"][0]
+        map_component2 = fd.configuration["components"][1]
+
+        self.assertEqual(
+            map_component1["tileLayerIdentifier"],
+            str(imported_wmts_layers[0].identifier),
+        )
+        self.assertEqual(
+            map_component1["overlays"],
+            [
+                {
+                    "url": "",
+                    "type": "wms",
+                    "uuid": ANY,
+                    "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                    "layers": ["pand", "verblijfsobject"],
+                }
+            ],
+        )
+
+        self.assertEqual(
+            map_component2["tileLayerIdentifier"],
+            str(imported_wmts_layers[1].identifier),
+        )
+        self.assertEqual(
+            map_component2["overlays"],
+            [
+                {
+                    "url": "",
+                    "type": "wms",
+                    "uuid": ANY,
+                    "label": "height",
+                    "layers": ["EL.GridCoverage"],
+                },
+                {
+                    "url": "",
+                    "type": "wms",
+                    "uuid": ANY,
+                    "label": "LGN",
+                    "layers": ["lgn-actueel"],
+                },
+            ],
+        )
+
+    def test_import_with_options_include_all_additional_form_configuration_reuses_already_existing_objects(
+        self,
+    ):
+        # Every OF instance has 5 default WMTS and 1 default WMS map tile layer. For more
+        # accurate and easier testing, we should start at zero.
+        MapTileLayer.objects.all().delete()
+        MapWMSTileLayer.objects.all().delete()
+
+        product = ProductFactory.create()
+        theme = ThemeFactory.create(design_token_values={"key": "token"})
+        category = CategoryFactory.create()
+
+        wmts_layer = MapTileLayerFactory.create()
+        wms_layer = MapWMSTileLayerFactory.create()
+
+        yiviAttributeGroup = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+
+        # Define form with all additional form configuration
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            theme=theme,
+            category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [yiviAttributeGroup.uuid],
+            },
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "label": "Map 1",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmts_layer.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wms_layer.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+
+        # The export is made with all additional_form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                additional_form_configuration=[
+                    AdditionalFormConfigurationOptions.product,
+                    AdditionalFormConfigurationOptions.theme,
+                    AdditionalFormConfigurationOptions.category,
+                    AdditionalFormConfigurationOptions.wms_tile_layers,
+                    AdditionalFormConfigurationOptions.wmts_tile_layers,
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                ],
+            ),
+        )
+
+        # Only delete the form
+        form.delete()
+        # Change UUID's, as would be the case in a regular situation where a form is
+        # shared across different OF instances.
+        product.uuid = uuid4()
+        theme.uuid = uuid4()
+        category.uuid = uuid4()
+        wms_layer.uuid = uuid4()
+        yiviAttributeGroup.uuid = uuid4()
+        product.save()
+        theme.save()
+        category.save()
+        wms_layer.save()
+        yiviAttributeGroup.save()
+
+        # Import form
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                form_configuration=[FormConfigurationOptions.auth_backends],
+                additional_form_configuration=[
+                    AdditionalFormConfigurationOptions.product,
+                    AdditionalFormConfigurationOptions.theme,
+                    AdditionalFormConfigurationOptions.category,
+                    AdditionalFormConfigurationOptions.wms_tile_layers,
+                    AdditionalFormConfigurationOptions.wmts_tile_layers,
+                    AdditionalFormConfigurationOptions.yivi_attribute_groups,
+                ],
+            ),
+        )
+
+        imported_form = Form.objects.last()
+
+        # No new data was created
+        self.assertEqual(Product.objects.count(), 1)
+        self.assertEqual(Theme.objects.count(), 1)
+        self.assertEqual(Category.objects.count(), 1)
+        self.assertEqual(MapTileLayer.objects.count(), 1)
+        self.assertEqual(MapWMSTileLayer.objects.count(), 1)
+        self.assertEqual(AttributeGroup.objects.count(), 1)
+
+        # The imported form uses all existing objects
+        self.assertEqual(imported_form.product, str(product.uuid))
+        self.assertEqual(imported_form.theme, str(theme.uuid))
+        self.assertEqual(imported_form.category, str(category.uuid))
+
+        self.assertEqual(len(imported_form.auth_backends.all()), 1)
+        auth_backend = imported_form.auth_backends.first()
+        self.assertEqual(auth_backend.backend, "yivi_oidc")
+        self.assertEqual(
+            auth_backend.options["additional_attributes_groups"],
+            [str(yiviAttributeGroup.uuid)],
+        )
+
+        fd = imported_form.formstep_set.get().form_definition
+        self.assertEqual(len(fd.configuration["components"]), 1)
+        map_component1 = fd.configuration["components"][0]
+
+        self.assertEqual(
+            map_component1["tileLayerIdentifier"], str(wmts_layer.identifier)
+        )
+        self.assertEqual(
+            map_component1["overlays"],
+            [
+                {
+                    "url": "",
+                    "type": "wms",
+                    "uuid": str(wms_layer.uuid),
+                    "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                    "layers": ["pand", "verblijfsobject"],
+                }
+            ],
+        )
+
+    def test_import_with_options_reuse_form_definitions_with_duplicate_forms(self):
+        # Expect existing form definitions to be re-used
+        form = FormFactory.create()
+        form_definition = FormDefinitionFactory.create(
+            is_reusable=True,
+            configuration={
+                "components": [
+                    {
+                        "label": "Textfield",
+                        "key": "textfield",
+                        "type": "textfield",
+                    },
+                ],
+            },
+        )
+        FormStepFactory.create(form=form, form_definition=form_definition)
+
+        # The export is made with all additional_form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(),
+        )
+
+        # Only delete the form
+        form.delete()
+
+        # Import form
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                reusable_form_definitions=ReusableFormDefinitionsOptions.reuse_existing
+            ),
+        )
+
+        imported_form = Form.objects.last()
+
+        # No new form definitions have been created
+        self.assertEqual(FormDefinition.objects.count(), 1)
+
+        # Assert that the imported form FD is the same as the existing FD
+        imported_form_definition = imported_form.formstep_set.get().form_definition
+        self.assertEqual(imported_form_definition, form_definition)
+
+    def test_import_with_options_reuse_form_definitions_without_duplicate_forms(self):
+        # Expect existing form definitions to be re-used
+        form = FormFactory.create()
+        form_definition = FormDefinitionFactory.create(
+            is_reusable=True,
+            configuration={
+                "components": [
+                    {
+                        "label": "Textfield",
+                        "key": "textfield",
+                        "type": "textfield",
+                    },
+                ],
+            },
+        )
+        FormStepFactory.create(form=form, form_definition=form_definition)
+
+        # The export is made with all additional_form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(),
+        )
+
+        # Only delete the form
+        form.delete()
+
+        # Update form definition
+        form_definition.configuration = {
+            "components": [
+                {
+                    "label": "Textfield",
+                    "key": "textfield",
+                    "type": "textfield",
+                },
+                {
+                    "label": "Textfield 2",
+                    "key": "textfield2",
+                    "type": "textfield",
+                },
+            ],
+        }
+        form_definition.save()
+
+        # Import form
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                reusable_form_definitions=ReusableFormDefinitionsOptions.reuse_existing
+            ),
+        )
+
+        imported_form = Form.objects.last()
+
+        # A new form definition has been created, as the imported form FD differs from
+        # the existing FD
+        self.assertEqual(FormDefinition.objects.count(), 2)
+
+        # Assert that the imported form FD is the same as the existing FD
+        imported_form_definition = imported_form.formstep_set.get().form_definition
+        self.assertNotEqual(imported_form_definition, form_definition)
+        # The imported FD has the same configuration as the original form had during
+        # exporting
+        self.assertEqual(
+            imported_form_definition.configuration,
+            {
+                "components": [
+                    {
+                        "label": "Textfield",
+                        "key": "textfield",
+                        "type": "textfield",
+                    },
+                ],
+            },
+        )
+
+    def test_import_with_options_create_all_new_form_definitions(self):
+        # Expect existing form definitions to be re-used
+        form = FormFactory.create()
+        form_definition = FormDefinitionFactory.create(
+            is_reusable=True,
+            configuration={
+                "components": [
+                    {
+                        "label": "Textfield",
+                        "key": "textfield",
+                        "type": "textfield",
+                    },
+                ],
+            },
+        )
+        FormStepFactory.create(form=form, form_definition=form_definition)
+
+        # The export is made with all additional_form_configuration
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(),
+        )
+
+        # Only delete the form
+        form.delete()
+
+        # Import form
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                reusable_form_definitions=ReusableFormDefinitionsOptions.create_new
+            ),
+        )
+
+        imported_form = Form.objects.last()
+
+        # New form definition has been created
+        self.assertEqual(FormDefinition.objects.count(), 2)
+
+        # Assert that the imported form FD is similar to the existing FD
+        imported_form_definition = imported_form.formstep_set.get().form_definition
+        self.assertNotEqual(imported_form_definition, form_definition)
+        self.assertEqual(
+            imported_form_definition.configuration, form_definition.configuration
+        )
 
 
 class ExportObjectsAPITests(TempdirMixin, TestCase):

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -1369,7 +1369,12 @@ class ImportExportTests(TempdirMixin, TestCase):
 
         export_form(form.pk, archive_name=self.filepath)
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                reusable_form_definitions=ReusableFormDefinitionsOptions.reuse_existing
+            ),
+        )
 
         imported_form = Form.objects.last()
         imported_form_step = imported_form.formstep_set.get()
@@ -1413,7 +1418,12 @@ class ImportExportTests(TempdirMixin, TestCase):
         form.slug = "modified"
         form.save()
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                reusable_form_definitions=ReusableFormDefinitionsOptions.reuse_existing
+            ),
+        )
 
         forms = Form.objects.all()
         imported_form = forms.last()
@@ -1580,7 +1590,12 @@ class ImportExportTests(TempdirMixin, TestCase):
 
         export_form(form.pk, archive_name=self.filepath)
 
-        import_form(import_file=self.filepath)
+        import_form(
+            import_file=self.filepath,
+            import_options=FormImportOptions(
+                reusable_form_definitions=ReusableFormDefinitionsOptions.reuse_existing
+            ),
+        )
 
         form_definitions = FormDefinition.objects.all()
         fd2 = form_definitions.last()
@@ -1961,7 +1976,10 @@ class ImportExportTests(TempdirMixin, TestCase):
         export_form(form.pk, archive_name=self.filepath)
 
         converters = {"textfield": {"add_foo": add_foo}}
-        with patch("openforms.forms.utils.CONVERTERS", new=converters):
+        with patch(
+            "openforms.import_export.serializers.form_definition.CONVERTERS",
+            new=converters,
+        ):
             import_form(import_file=self.filepath)
 
         imported_form = Form.objects.exclude(pk=form.pk).get()

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -3789,16 +3789,33 @@ class ImportExportTests(TempdirMixin, TestCase):
         self.assertEqual(MapWMSTileLayer.objects.count(), 0)
         self.assertEqual(AttributeGroup.objects.count(), 0)
 
-    def test_import_with_options_include_all_additional_form_configuration(self):
+    def test_import_with_options_include_all_additional_form_configuration_create_new(
+        self,
+    ):
+        # Every OF instance has 5 default WMTS and 1 default WMS map tile layer. For more
+        # accurate and easier testing, we should start at zero.
+        MapTileLayer.objects.all().delete()
+        MapWMSTileLayer.objects.all().delete()
+
         product = ProductFactory.create()
         theme = ThemeFactory.create(design_token_values={"key": "token"})
         category = CategoryFactory.create()
 
-        wmtsMap1 = MapTileLayerFactory.create()
-        wmtsMap2 = MapTileLayerFactory.create()
-        wmsMap1 = MapWMSTileLayerFactory.create()
-        wmsMap2 = MapWMSTileLayerFactory.create()
-        wmsMap3 = MapWMSTileLayerFactory.create()
+        wmtsMap1 = MapTileLayerFactory.create(
+            identifier="wmts-map-1", url="https://example.wmts.1.com", label="wmtsMap1"
+        )
+        wmtsMap2 = MapTileLayerFactory.create(
+            identifier="wmts-map-2", url="https://example.wmts.2.com", label="wmtsMap2"
+        )
+        wmsMap1 = MapWMSTileLayerFactory.create(
+            url="https://example.wms.1.com", name="wmsMap1"
+        )
+        wmsMap2 = MapWMSTileLayerFactory.create(
+            url="https://example.wms.2.com", name="wmsMap2"
+        )
+        wmsMap3 = MapWMSTileLayerFactory.create(
+            url="https://example.wms.3.com", name="wmsMap3"
+        )
 
         yiviAttributeGroup1 = AttributeGroupFactory.create(
             attributes=["first_name", "last_name"]
@@ -3937,9 +3954,9 @@ class ImportExportTests(TempdirMixin, TestCase):
         attribute_groups = AttributeGroup.objects.all()
 
         # The imported form has product, theme or category
-        self.assertEqual(imported_form.product, str(imported_product.uuid))
-        self.assertEqual(imported_form.category, str(imported_category.uuid))
-        self.assertEqual(imported_form.theme, str(imported_theme.uuid))
+        self.assertEqual(str(imported_form.product.uuid), str(imported_product.uuid))
+        self.assertEqual(str(imported_form.category.uuid), str(imported_category.uuid))
+        self.assertEqual(str(imported_form.theme.uuid), str(imported_theme.uuid))
 
         # Auth backend is imported with the additional attribute groups
         self.assertEqual(len(imported_form.auth_backends.all()), 1)
@@ -3999,6 +4016,21 @@ class ImportExportTests(TempdirMixin, TestCase):
                 },
             ],
         )
+
+        # The configuration of the WMS and WMTS tile layers hasn't changed
+        wmts_layer_1 = imported_wmts_layers.get(identifier="wmts-map-1")
+        wmts_layer_2 = imported_wmts_layers.get(identifier="wmts-map-2")
+        self.assertEqual(wmts_layer_1.url, "https://example.wmts.1.com")
+        self.assertEqual(wmts_layer_1.label, "wmtsMap1")
+        self.assertEqual(wmts_layer_2.url, "https://example.wmts.2.com")
+        self.assertEqual(wmts_layer_2.label, "wmtsMap2")
+
+        wms_layer_1 = imported_wms_layers.get(name="wmsMap1")
+        wms_layer_2 = imported_wms_layers.get(name="wmsMap2")
+        wms_layer_3 = imported_wms_layers.get(name="wmsMap3")
+        self.assertEqual(wms_layer_1.url, "https://example.wms.1.com")
+        self.assertEqual(wms_layer_2.url, "https://example.wms.2.com")
+        self.assertEqual(wms_layer_3.url, "https://example.wms.3.com")
 
     def test_import_with_options_include_all_additional_form_configuration_reuses_already_existing_objects(
         self,
@@ -4115,9 +4147,9 @@ class ImportExportTests(TempdirMixin, TestCase):
         self.assertEqual(AttributeGroup.objects.count(), 1)
 
         # The imported form uses all existing objects
-        self.assertEqual(imported_form.product, str(product.uuid))
-        self.assertEqual(imported_form.theme, str(theme.uuid))
-        self.assertEqual(imported_form.category, str(category.uuid))
+        self.assertEqual(str(imported_form.product.uuid), str(product.uuid))
+        self.assertEqual(str(imported_form.category.uuid), str(category.uuid))
+        self.assertEqual(str(imported_form.theme.uuid), str(theme.uuid))
 
         self.assertEqual(len(imported_form.auth_backends.all()), 1)
         auth_backend = imported_form.auth_backends.first()

--- a/src/openforms/forms/tests/test_import_export.py
+++ b/src/openforms/forms/tests/test_import_export.py
@@ -512,6 +512,86 @@ class ImportExportTests(TempdirMixin, TestCase):
             component_definition = form_definitions[0]["configuration"]["components"][0]
             self.assertEqual(component_definition["defaultValue"], "")
 
+    def test_export_with_anonymize_option_anonymizes_nested_component_variable(self):
+        # Setting up a form with sensitive data in:
+        # - component variable initial value
+        # - component variable in logic rule
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            registration_backend="email",
+            registration_backend_options={"to_emails_from_variable": "textfield"},
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "fieldset",
+                        "label": "Fieldset",
+                        "type": "fieldset",
+                        "components": [
+                            {
+                                "key": "textfield",
+                                "type": "textfield",
+                                "label": "Textfield",
+                                "defaultValue": "personal@me.com",
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(form=form, user_defined=True, key="trigger")
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={"==": [{"var": "trigger"}, 1]},
+            actions=[
+                {
+                    "variable": "textfield",
+                    "action": {"type": "variable", "value": "internal@company.com"},
+                }
+            ],
+        )
+
+        export_form(
+            form.pk,
+            archive_name=self.filepath,
+            export_options=FormExportOptions(
+                remove_sensitive_content=True,
+            ),
+        )
+
+        with zipfile.ZipFile(self.filepath, "r") as f:
+            forms = json.loads(f.read("forms.json"))
+            form_logic = json.loads(f.read("formLogic.json"))
+            form_variables = json.loads(f.read("formVariables.json"))
+            form_definitions = json.loads(f.read("formDefinitions.json"))
+
+            self.assertEqual(len(forms), 1)
+            self.assertEqual(len(form_logic), 1)
+            self.assertEqual(len(form_variables), 1)
+            self.assertEqual(len(form_definitions), 1)
+
+            self.assertEqual(len(forms[0]["registration_backends"]), 1)
+            registration_backend = forms[0]["registration_backends"][0]
+
+            self.assertEqual(
+                registration_backend["options"]["to_emails_from_variable"],
+                "textfield",
+            )
+
+            # The logic rule that assigns the value of the component variable is cleared
+            self.assertEqual(len(form_logic[0]["actions"]), 1)
+            self.assertEqual(form_logic[0]["actions"][0]["variable"], "textfield")
+            self.assertEqual(
+                form_logic[0]["actions"][0]["action"],
+                {"type": "variable", "value": ""},
+            )
+
+            # The default value of the component variable used in the e-mail registration
+            # is cleared
+            self.assertEqual(len(form_definitions[0]["configuration"]["components"]), 1)
+            fieldset = form_definitions[0]["configuration"]["components"][0]
+            self.assertEqual(len(fieldset["components"]), 1)
+            self.assertEqual(fieldset["components"][0]["defaultValue"], "")
+
     def test_export_with_exclude_registration_backends_option(self):
         form = FormFactory.create(
             registration_backend="email",

--- a/src/openforms/forms/tests/test_management.py
+++ b/src/openforms/forms/tests/test_management.py
@@ -6,6 +6,7 @@ from privates.test import temp_private_root
 
 from openforms.accounts.tests.factories import StaffUserFactory
 
+from ...import_export.typing import FormExportOptions
 from ..admin.tasks import process_forms_export
 from ..models.form import FormsExport
 from .factories import FormFactory
@@ -25,6 +26,7 @@ class DeleteFormExportFilesTest(TestCase):
             process_forms_export(
                 forms_uuids=[form1.uuid, form2.uuid],
                 user_id=user.id,
+                export_options=FormExportOptions(),
             )
 
         forms_export = FormsExport.objects.get()

--- a/src/openforms/forms/tests/test_restore_version.py
+++ b/src/openforms/forms/tests/test_restore_version.py
@@ -1,6 +1,7 @@
 import copy
 import datetime
 import json
+import uuid
 
 from django.test import TestCase
 from django.utils import translation
@@ -8,10 +9,27 @@ from django.utils.translation import gettext as _
 
 from freezegun import freeze_time
 
+from openforms.authentication.constants import AuthAttribute
+from openforms.authentication.contrib.yivi_oidc.models import AttributeGroup
+from openforms.authentication.tests.factories import AttributeGroupFactory
+from openforms.config.models import MapTileLayer, MapWMSTileLayer, Theme
+from openforms.config.tests.factories import (
+    MapTileLayerFactory,
+    MapWMSTileLayerFactory,
+    ThemeFactory,
+)
+from openforms.contrib.objects_api.tests.factories import ObjectsAPIGroupConfigFactory
+from openforms.forms.models import Category, FormDefinition, FormStep, FormVersion
+from openforms.payments.contrib.worldline.tests.factories import (
+    WorldlineMerchantFactory,
+)
+from openforms.prefill.constants import IdentifierRoles
+from openforms.products.models import Product
+from openforms.products.tests.factories import ProductFactory
 from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 
-from ..models import FormDefinition, FormStep, FormVersion
 from .factories import (
+    CategoryFactory,
     FormDefinitionFactory,
     FormFactory,
     FormStepFactory,
@@ -324,6 +342,216 @@ class RestoreVersionTest(TestCase):
             },
         )
         self.assertFalse(form_steps[1].form_definition.is_reusable)
+
+    def test_full_form_save_and_restore(self):
+        """
+        Tests that all form configuration that receives dedicated attention from the
+        import/export is correctly saved and restored.
+
+        Ensuring all configuration is kept, especially the product, theme, category, and
+        service fetch. (@TODO service fetch is not yet implemented)
+        """
+        product = ProductFactory.create()
+        theme = ThemeFactory.create(design_token_values={"key": "token"})
+        category = CategoryFactory.create()
+
+        wmts_tile_layer = MapTileLayerFactory.create()
+        wms_tile_layer = MapWMSTileLayerFactory.create()
+
+        yivi_attribute_group = AttributeGroupFactory.create(
+            attributes=["first_name", "last_name"]
+        )
+
+        merchant = WorldlineMerchantFactory.create()
+        objects_api_group = ObjectsAPIGroupConfigFactory.create(
+            identifier="test-objects-api-group"
+        )
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            product=product,
+            theme=theme,
+            category=category,
+            authentication_backend="yivi_oidc",
+            authentication_backend__options={
+                "authentication_options": [AuthAttribute.bsn],
+                "additional_attributes_groups": [yivi_attribute_group.uuid],
+            },
+            internal_remarks="Some internal remark that should be kept",
+            payment_backend="worldline",
+            payment_backend_options={"merchant": merchant.pspid},
+            registration_backend="email",
+            registration_backend_options={"to_emails": ["abc@xyz.com"]},
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "key": "textfield",
+                        "type": "textfield",
+                        "label": "Textfield",
+                        "prefill": {
+                            "plugin": "demo",
+                            "attribute": "random_number",
+                            "identifier_role": IdentifierRoles.authorizee,
+                        },
+                    },
+                    {
+                        "label": "Map",
+                        "key": "map",
+                        "type": "map",
+                        "useConfigDefaultMapSettings": False,
+                        "interactions": {
+                            "marker": True,
+                            "polygon": False,
+                            "polyline": False,
+                        },
+                        "tileLayerIdentifier": wmts_tile_layer.identifier,
+                        "overlays": [
+                            {
+                                "url": "",
+                                "type": "wms",
+                                "uuid": str(wms_tile_layer.uuid),
+                                "label": "Basisregistratie Adressen en Gebouwen (BAG)",
+                                "layers": ["pand", "verblijfsobject"],
+                            },
+                        ],
+                    },
+                ],
+            },
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_demo_prefill",
+            user_defined=True,
+            prefill_plugin="demo",
+            prefill_attribute="random_string",
+            prefill_identifier_role=IdentifierRoles.authorizee,
+        )
+        FormVariableFactory.create(
+            form=form,
+            key="variable_with_objects_api_prefill",
+            user_defined=True,
+            prefill_plugin="objects_api",
+            prefill_options={
+                "objects_api_group": objects_api_group.identifier,
+                "objecttype_uuid": "8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
+                "objecttype_version": 3,
+                "variables_mapping": [
+                    {"variable_key": "lastName", "target_path": ["name", "last.name"]},
+                    {"variable_key": "age", "target_path": ["age"]},
+                ],
+                "auth_attribute_path": ["bsn"],
+            },
+        )
+
+        # Validate the initial setup
+        self.assertEqual(Product.objects.count(), 1)
+        self.assertEqual(Theme.objects.count(), 1)
+        self.assertEqual(Category.objects.count(), 1)
+        self.assertEqual(MapTileLayer.objects.count(), 6)
+        self.assertEqual(MapWMSTileLayer.objects.count(), 2)
+        self.assertEqual(AttributeGroup.objects.count(), 1)
+
+        version = FormVersionFactory.create(form=form)
+        self.assertNotEqual(version.export_blob, {})
+
+        # Restore it
+        form.restore_old_version(version.uuid)
+
+        # get all fresh DB records
+        form.refresh_from_db()
+
+        # Validate that no new additional data was created
+        self.assertEqual(Product.objects.count(), 1)
+        self.assertEqual(Theme.objects.count(), 1)
+        self.assertEqual(Category.objects.count(), 1)
+        self.assertEqual(MapTileLayer.objects.count(), 6)
+        self.assertEqual(MapWMSTileLayer.objects.count(), 2)
+        self.assertEqual(AttributeGroup.objects.count(), 1)
+
+        # Validate product, theme and category
+        self.assertEqual(form.product.uuid, product.uuid)
+        self.assertEqual(form.theme.uuid, theme.uuid)
+        self.assertEqual(form.category.uuid, category.uuid)
+
+        # Validate payment backend
+        self.assertEqual(form.payment_backend, "worldline")
+        self.assertEqual(form.payment_backend_options["merchant"], merchant.pspid)
+
+        # Validate auth backend
+        self.assertEqual(form.auth_backends.count(), 1)
+        auth_backend = form.auth_backends.first()
+        self.assertEqual(auth_backend.backend, "yivi_oidc")
+        self.assertEqual(
+            auth_backend.options["authentication_options"], [AuthAttribute.bsn]
+        )
+        self.assertEqual(
+            auth_backend.options["additional_attributes_groups"],
+            [str(yivi_attribute_group.uuid)],
+        )
+
+        # Validate registration backend and sensitive data was kept
+        self.assertEqual(
+            form.internal_remark,
+            "Some internal remark that should be kept",
+        )
+        self.assertEqual(form.registration_backends.count(), 1)
+        registration_backend = form.registration_backends.first()
+        self.assertEqual(registration_backend.backend, "email")
+        self.assertEqual(registration_backend.options["to_emails"], ["abc@xyz.com"])
+
+        # Validate map component tile layer configuration
+        fd = form.formstep_set.first().form_definition
+        map_component = fd.configuration["components"][1]
+        self.assertEqual(map_component["type"], "map")
+        self.assertEqual(
+            map_component["tileLayerIdentifier"], wmts_tile_layer.identifier
+        )
+        self.assertEqual(len(map_component["overlays"]), 1)
+        self.assertEqual(map_component["overlays"][0]["uuid"], str(wms_tile_layer.uuid))
+
+    def test_form_restore_creating_new_resources_when_existing_have_been_altered(self):
+        product = ProductFactory.create()
+        theme = ThemeFactory.create(design_token_values={"key": "token"})
+        category = CategoryFactory.create()
+
+        form = FormFactory.create(
+            product=product,
+            theme=theme,
+            category=category,
+        )
+        version = FormVersionFactory.create(form=form)
+        self.assertNotEqual(version.export_blob, {})
+
+        # now delete the product, and update the theme and category
+        with self.subTest("Modify used resources"):
+            product.delete()
+            theme.organization_name = "Evil .inc"
+            category.uuid = uuid.uuid4()
+
+            self.assertEqual(Product.objects.count(), 0)
+            self.assertEqual(Theme.objects.count(), 1)
+            self.assertEqual(Category.objects.count(), 1)
+
+        # Restore it
+        form.restore_old_version(version.uuid)
+
+        # get all fresh DB records
+        form.refresh_from_db()
+
+        # Because the product was deleted, a new product is created
+        self.assertEqual(Product.objects.count(), 1)
+        new_product = Product.objects.first()
+        self.assertEqual(form.product.uuid, new_product.uuid)
+
+        # Because the theme was modified, a new theme is created. This ensures that the
+        # existing theme, which could be used in other forms, doesn't change.
+        self.assertEqual(Theme.objects.count(), 2)
+        new_theme = Theme.objects.first()
+        self.assertEqual(form.theme.uuid, new_theme.uuid)
+
+        # Because we don't use the uuid as an identifier for the resources, we can re-use
+        # the category that was used in the original form.
+        self.assertEqual(Category.objects.count(), 1)
+        self.assertEqual(form.category.uuid, category.uuid)
 
 
 FORM_STEP = [

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -290,34 +290,6 @@ def import_form(
     return import_form_data(import_data, existing_form_instance, import_options)
 
 
-def check_form_definition(uuid: str, attrs: dict[str, Any], for_existing_form: bool):
-    """
-    Import a form definition with a given UUID.
-
-    If the UUID is already present, check if the configuration is the same or not. If
-    it's the same, the existing record is updated, otherwise a new form definition is
-    created.
-    """
-    existing = FormDefinition.objects.filter(uuid=uuid).first()
-    # no existing record -> let the import flow create one
-    if existing is None:
-        return None
-
-    # if there is an existing form definition, but it's not being related to the same
-    # form, then we need to create a copy
-    # if new form, existing is used, existing is not reusable
-    if not for_existing_form and existing.used_in.exists() and not existing.is_reusable:
-        return None
-
-    # Compare hashes to check if form fields configuration changed or not. If there are
-    # changes, the import data should be created as a new record.
-    existing_fd_hash = existing.get_hash()
-    imported_fd_hash = FormDefinition(configuration=attrs["configuration"]).get_hash()
-    if existing_fd_hash == imported_fd_hash:
-        return existing
-    return None
-
-
 @transaction.atomic
 @override(language=settings.LANGUAGE_CODE)
 def import_form_data(
@@ -348,10 +320,14 @@ def import_form_data(
         for entry in json.loads(data):
             old_uuid = entry.get("uuid")
 
+            instance = serializer_config.serializer.resolve_instance(
+                entry, import_options
+            )
             deserialized = serializer_config.serializer(
                 **serializer_config.serializer_kwargs(
                     entry, created_form, import_options, request
-                )
+                ),
+                instance=instance,
             )
 
             try:

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -21,12 +21,17 @@ from openforms.formio.utils import iter_components
 from openforms.forms.constants import FormTypeChoices
 from openforms.import_export.serializers import (
     FormDefinitionExportSerializer,
+    FormDefinitionImportSerializer,
     FormExportSerializer,
+    FormImportSerializer,
     FormLogicExportSerializer,
+    FormLogicImportSerializer,
     FormStepExportSerializer,
+    FormStepImportSerializer,
     FormVariableExportSerializer,
+    FormVariableImportSerializer,
 )
-from openforms.import_export.typing import FormExportOptions
+from openforms.import_export.typing import FormExportOptions, FormImportOptions
 from openforms.import_export.utils import (
     get_additional_form_configuration_data,
 )
@@ -43,13 +48,6 @@ from openforms.typing import JSONObject
 from openforms.variables.constants import FormVariableSources
 
 from .api.datastructures import FormVariableWrapper
-from .api.serializers import (
-    FormDefinitionSerializer,
-    FormLogicSerializer,
-    FormSerializer,
-    FormStepSerializer,
-    FormVariableSerializer,
-)
 from .constants import EXPORT_META_KEY, LogicActionTypes
 from .models import Form, FormDefinition, FormLogic, FormStep, FormVariable
 
@@ -65,11 +63,11 @@ IMPORT_ORDER = {
 }
 
 SERIALIZERS = {
-    "formDefinitions": FormDefinitionSerializer,
-    "forms": FormSerializer,
-    "formSteps": FormStepSerializer,
-    "formLogic": FormLogicSerializer,
-    "formVariables": FormVariableSerializer,
+    "formDefinitions": FormDefinitionImportSerializer,
+    "forms": FormImportSerializer,
+    "formSteps": FormStepImportSerializer,
+    "formLogic": FormLogicImportSerializer,
+    "formVariables": FormVariableImportSerializer,
 }
 
 
@@ -181,14 +179,16 @@ def export_form(
 
 
 @transaction.atomic
-def import_form(import_file, existing_form_instance=None) -> Form | None:
+def import_form(
+    import_file, existing_form_instance=None, import_options: FormImportOptions = None
+) -> Form | None:
     import_data = {}
     with zipfile.ZipFile(import_file, "r") as zip_file:
         for resource in IMPORT_ORDER.keys():
             if f"{resource}.json" in zip_file.namelist():
                 import_data[resource] = zip_file.read(f"{resource}.json").decode()
 
-    return import_form_data(import_data, existing_form_instance)
+    return import_form_data(import_data, existing_form_instance, import_options)
 
 
 def check_form_definition(uuid: str, attrs: dict[str, Any], for_existing_form: bool):
@@ -223,6 +223,7 @@ def check_form_definition(uuid: str, attrs: dict[str, Any], for_existing_form: b
 def import_form_data(
     import_data: dict,
     existing_form_instance: Form | None = None,
+    import_options: FormImportOptions = None,
 ) -> Form | None:
     uuid_mapping = {}
 
@@ -297,6 +298,7 @@ def import_form_data(
                     "request": request,
                     "form": created_form,
                     "is_import": True,
+                    "import_options": import_options,
                 },
             }
 
@@ -410,6 +412,7 @@ def import_form_data(
                             "request": request,
                             "form": created_form,
                             "is_import": True,
+                            "import_options": import_options,
                         },
                         instance=existing_form_instance,
                     )

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -27,6 +27,9 @@ from openforms.import_export.serializers import (
     FormVariableExportSerializer,
 )
 from openforms.import_export.typing import FormExportOptions
+from openforms.import_export.utils import (
+    get_additional_form_configuration_data,
+)
 from openforms.registrations.contrib.objects_api.constants import (
     PLUGIN_IDENTIFIER as OBJECTS_API_PLUGIN_IDENTIFIER,
 )
@@ -88,9 +91,6 @@ def to_json(obj: Any):
 def form_to_json(form_id: int, export_options: FormExportOptions = None) -> dict:
     form = Form.objects.get(pk=form_id)
 
-    # Ignore products in the export
-    form.product = None
-
     # Reset the submission counter
     form.submission_counter = 0
 
@@ -150,6 +150,12 @@ def form_to_json(form_id: int, export_options: FormExportOptions = None) -> dict
         "formDefinitions": to_json(form_definitions),
         "formLogic": to_json(form_logic),
         "formVariables": to_json(form_variables),
+        # Include additional configuration data in the export resources, based on the form.
+        **(
+            get_additional_form_configuration_data(form, export_options)
+            if export_options is not None
+            else {}
+        ),
         EXPORT_META_KEY: to_json(
             {
                 "of_release": settings.RELEASE,

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -36,6 +36,7 @@ from openforms.import_export.typing import (
 )
 from openforms.import_export.utils import (
     get_additional_form_configuration_data,
+    import_additional_form_configuration_data,
 )
 from openforms.registrations.contrib.objects_api.constants import (
     PLUGIN_IDENTIFIER as OBJECTS_API_PLUGIN_IDENTIFIER,
@@ -241,6 +242,11 @@ def import_form_data(
     created_form = None
 
     _form_definitions = []
+
+    # Import additional data
+    import_additional_form_configuration_data(
+        resources=import_data, import_options=import_options
+    )
 
     for resource in IMPORT_ORDER:
         if resource not in import_data:

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -321,7 +321,7 @@ def import_form_data(
             old_uuid = entry.get("uuid")
 
             instance = serializer_config.serializer.resolve_instance(
-                entry, import_options
+                entry, import_options, existing_form_instance
             )
             deserialized = serializer_config.serializer(
                 **serializer_config.serializer_kwargs(

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -16,8 +16,6 @@ import structlog
 from rest_framework.exceptions import ValidationError
 from rest_framework.test import APIRequestFactory
 
-from openforms.formio.migration_converters import CONVERTERS, DEFINITION_CONVERTERS
-from openforms.formio.utils import iter_components
 from openforms.import_export.serializers import (
     FormDefinitionExportSerializer,
     FormDefinitionImportSerializer,
@@ -47,11 +45,10 @@ from openforms.registrations.contrib.stuf_zds.plugin import (
 from openforms.registrations.contrib.zgw_apis.plugin import (
     PLUGIN_IDENTIFIER as ZGW_APIS_PLUGIN_IDENTIFIER,
 )
-from openforms.typing import JSONObject
 from openforms.variables.constants import FormVariableSources
 
 from .api.datastructures import FormVariableWrapper
-from .constants import EXPORT_META_KEY, LogicActionTypes
+from .constants import EXPORT_META_KEY
 from .models import Form, FormDefinition, FormLogic, FormStep, FormVariable
 
 logger = structlog.stdlib.get_logger(__name__)
@@ -348,20 +345,6 @@ def import_form_data(
                 )
                 deserialized.is_valid(raise_exception=True)
 
-                # @TODO Move to FormDefinitionImportSerializer. Maybe a generic post_import()?
-                if resource == "formDefinitions":
-                    apply_component_conversions(
-                        deserialized.validated_data["configuration"]
-                    )
-
-                    apply_definition_conversions(
-                        deserialized.validated_data["configuration"]
-                    )
-
-                # @TODO move to FormLogicImportSerializer.
-                if resource == "formLogic":
-                    clear_old_service_fetch_config(deserialized.validated_data)
-
                 instance = deserialized.save()
                 if resource == "forms":
                     created_form = deserialized.instance
@@ -410,28 +393,6 @@ def import_form_data(
     return created_form
 
 
-def apply_component_conversions(configuration):
-    """
-    Apply the known formio component conversions to the entire form definition.
-    """
-    log = logger.bind(action="forms.apply_component_conversions")
-    for component in iter_components(configuration):
-        if not (component_type := component.get("type")):  # pragma: no cover
-            continue
-        if not (converters := CONVERTERS.get(component_type)):
-            continue
-        for identifier, apply_converter in converters.items():
-            log.debug(
-                "apply_converter", component_type=component_type, identifier=identifier
-            )
-            apply_converter(component)
-
-
-def apply_definition_conversions(configuration: JSONObject) -> None:
-    for converter in DEFINITION_CONVERTERS:
-        converter(configuration)
-
-
 def remove_key_from_dict(dictionary, key):
     for dict_key in list(dictionary.keys()):
         if key == dict_key:
@@ -442,21 +403,6 @@ def remove_key_from_dict(dictionary, key):
             for value in dictionary[dict_key]:
                 if isinstance(value, dict):
                     remove_key_from_dict(value, key)
-
-
-def clear_old_service_fetch_config(rule: dict) -> None:
-    for action in rule["actions"]:
-        if action["action"]["type"] != LogicActionTypes.fetch_from_service:
-            continue
-
-        if "value" not in action["action"] or action["action"]["value"] == "":
-            continue
-
-        # See comment above in `import_form_data` where we check if the variable has a
-        # `service_fetch_configuration` attribute.
-        # We can't reliably relate the service fetch configured to an existing configuration.
-        # So we don't add any existing service fetch config to the variables
-        action["action"]["value"] = ""
 
 
 class FileComponentOptions(TypedDict, total=False):

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -333,7 +333,7 @@ def import_form_data(
 
     # Import additional data
     import_additional_form_configuration_data(
-        resources=import_data, import_options=import_options
+        resources=import_data, import_options=import_options, uuid_mapping=uuid_mapping
     )
 
     for resource in IMPORT_SERIALIZER_CONFIGS:

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -19,6 +19,13 @@ from rest_framework.test import APIRequestFactory
 from openforms.formio.migration_converters import CONVERTERS, DEFINITION_CONVERTERS
 from openforms.formio.utils import iter_components
 from openforms.forms.constants import FormTypeChoices
+from openforms.import_export.serializers import (
+    FormDefinitionExportSerializer,
+    FormExportSerializer,
+    FormLogicExportSerializer,
+    FormStepExportSerializer,
+    FormVariableExportSerializer,
+)
 from openforms.import_export.typing import FormExportOptions
 from openforms.registrations.contrib.objects_api.constants import (
     PLUGIN_IDENTIFIER as OBJECTS_API_PLUGIN_IDENTIFIER,
@@ -35,7 +42,6 @@ from openforms.variables.constants import FormVariableSources
 from .api.datastructures import FormVariableWrapper
 from .api.serializers import (
     FormDefinitionSerializer,
-    FormExportSerializer,
     FormLogicSerializer,
     FormSerializer,
     FormStepSerializer,
@@ -79,7 +85,7 @@ def to_json(obj: Any):
     return json.dumps(obj, cls=DjangoJSONEncoder)
 
 
-def form_to_json(form_id: int) -> dict:
+def form_to_json(form_id: int, export_options: FormExportOptions = None) -> dict:
     form = Form.objects.get(pk=form_id)
 
     # Ignore products in the export
@@ -107,20 +113,35 @@ def form_to_json(form_id: int) -> dict:
 
     request = _get_mock_request()
 
-    forms = [FormExportSerializer(instance=form, context={"request": request}).data]
-    form_definitions = FormDefinitionSerializer(
+    forms = [
+        FormExportSerializer(
+            instance=form,
+            context={"request": request, "export_options": export_options},
+        ).data
+    ]
+    form_definitions = FormDefinitionExportSerializer(
         instance=form_definitions,
         many=True,
-        context={"request": request, "is_export": True},
+        context={
+            "request": request,
+            "export_options": export_options,
+            "form": form,
+        },
     ).data
-    form_steps = FormStepSerializer(
-        instance=form_steps, many=True, context={"request": request}
+    form_steps = FormStepExportSerializer(
+        instance=form_steps,
+        many=True,
+        context={"request": request, "export_options": export_options},
     ).data
-    form_logic = FormLogicSerializer(
-        instance=form_logic, many=True, context={"request": request}
+    form_logic = FormLogicExportSerializer(
+        instance=form_logic,
+        many=True,
+        context={"request": request, "export_options": export_options},
     ).data
-    form_variables = FormVariableSerializer(
-        instance=form_variables, many=True, context={"request": request}
+    form_variables = FormVariableExportSerializer(
+        instance=form_variables,
+        many=True,
+        context={"request": request, "export_options": export_options},
     ).data
 
     resources = {
@@ -144,7 +165,7 @@ def form_to_json(form_id: int) -> dict:
 def export_form(
     form_id, archive_name=None, response=None, export_options: FormExportOptions = None
 ):
-    resources = form_to_json(form_id)
+    resources = form_to_json(form_id, export_options)
 
     outfile = response or archive_name
     with zipfile.ZipFile(outfile, "w") as zip_file:

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -18,7 +18,6 @@ from rest_framework.test import APIRequestFactory
 
 from openforms.formio.migration_converters import CONVERTERS, DEFINITION_CONVERTERS
 from openforms.formio.utils import iter_components
-from openforms.forms.constants import FormTypeChoices
 from openforms.import_export.serializers import (
     FormDefinitionExportSerializer,
     FormDefinitionImportSerializer,
@@ -31,7 +30,10 @@ from openforms.import_export.serializers import (
     FormVariableExportSerializer,
     FormVariableImportSerializer,
 )
-from openforms.import_export.typing import FormExportOptions, FormImportOptions
+from openforms.import_export.typing import (
+    FormExportOptions,
+    FormImportOptions,
+)
 from openforms.import_export.utils import (
     get_additional_form_configuration_data,
 )
@@ -54,13 +56,19 @@ from .models import Form, FormDefinition, FormLogic, FormStep, FormVariable
 logger = structlog.stdlib.get_logger(__name__)
 
 
-IMPORT_ORDER = {
-    "formDefinitions": FormDefinition,
-    "forms": Form,
-    "formSteps": FormStep,
-    "formVariables": FormVariable,
-    "formLogic": FormLogic,
-}
+IMPORT_ORDER = (
+    "product",
+    "theme",
+    "category",
+    "wmsTileLayers",
+    "wmtsTileLayers",
+    "yiviAttributeGroups",
+    "formDefinitions",
+    "forms",
+    "formSteps",
+    "formVariables",
+    "formLogic",
+)
 
 SERIALIZERS = {
     "formDefinitions": FormDefinitionImportSerializer,
@@ -184,7 +192,7 @@ def import_form(
 ) -> Form | None:
     import_data = {}
     with zipfile.ZipFile(import_file, "r") as zip_file:
-        for resource in IMPORT_ORDER.keys():
+        for resource in IMPORT_ORDER:
             if f"{resource}.json" in zip_file.namelist():
                 import_data[resource] = zip_file.read(f"{resource}.json").decode()
 
@@ -206,6 +214,7 @@ def check_form_definition(uuid: str, attrs: dict[str, Any], for_existing_form: b
 
     # if there is an existing form definition, but it's not being related to the same
     # form, then we need to create a copy
+    # if new form, existing is used, existing is not reusable
     if not for_existing_form and existing.used_in.exists() and not existing.is_reusable:
         return None
 
@@ -231,24 +240,9 @@ def import_form_data(
 
     created_form = None
 
-    # when restoring a previous version, delete the current form configuration,
-    # it will be replaced with the import data.
-    if existing_form_instance:
-        form_steps = FormStep.objects.filter(form=existing_form_instance)
-        # delete single-use form definitions, they're orphan nodes when deleting the steps
-        fd_ids = list(
-            FormDefinition.objects.filter(
-                is_reusable=False, formstep__in=form_steps
-            ).values_list("id", flat=True)
-        )
-        form_steps.delete()
-        FormDefinition.objects.filter(id__in=fd_ids).delete()
-        FormLogic.objects.filter(form=existing_form_instance).delete()
-        FormVariable.objects.filter(form=existing_form_instance).delete()
-
     _form_definitions = []
 
-    for resource in IMPORT_ORDER.keys():
+    for resource in IMPORT_ORDER:
         if resource not in import_data:
             continue
 
@@ -266,31 +260,10 @@ def import_form_data(
                 entry["uuid"] = str(uuid4())
 
             if resource == "forms":
-                # we can only extract a category UUID from the URL here, but that requires
-                # an exact match and we currently don't provide import/export functionality
-                # for categories. Relying on ID/Name is not much better than guesswork either,
-                # so we always import forms with NO category at all to prevent import errors.
-                # See #1774 for one such example of an error.
-                entry["category"] = None
-                # theme overrides cannot be imported, since the theme records/FKs have to
-                # exist in the target environment. Importing/exporting themes is also not
-                # possible at this time, so we reset the theme and admins need to update
-                # the imported form.
-                entry["theme"] = None
-
-                # forms before v4.0 do not have the type field so in case we import an
-                # old appointment form we have to make sure that the form has the right
-                # type configured (by default is regular)
-                if appointment_options := entry.get("appointment_options"):
-                    if appointment_options.get("is_appointment"):
-                        entry["type"] = FormTypeChoices.appointment
-
                 # check for file components in the form definitions and move
                 # registration options to the backend registration options
+                # @TODO Implement on FormDefinitionImportSerializer?
                 move_file_registration_options(entry, _form_definitions)
-
-            if resource == "forms" and not existing_form_instance:
-                entry["active"] = False
 
             serializer_kwargs = {
                 "data": entry,
@@ -306,7 +279,9 @@ def import_form_data(
                 existing_form_definition_instance = check_form_definition(
                     old_uuid,
                     entry,
-                    for_existing_form=existing_form_instance is not None,
+                    for_existing_form=False,
+                    # @TODO is this needed?
+                    # for_existing_form=existing_form_instance is not None,
                 )
                 if existing_form_definition_instance:
                     # The form definition that is being imported is identical to
@@ -326,6 +301,7 @@ def import_form_data(
             if resource in ("formVariables", "formLogic"):
                 # by now, the form resource has been created (or it was an existing one)
                 _form = existing_form_instance or created_form
+                # @TODO inspect serializers for why this is needed.
                 serializer_kwargs["context"].update(
                     {
                         "forms": {str(_form.uuid): _form},
@@ -342,6 +318,7 @@ def import_form_data(
                     # better not import these, we don't know where this came from.
                     # services and ids may point to different things
                     # in different OF instances.
+                    # @TODO move to import serializers?
                     del entry["service_fetch_configuration"]
 
             if resource == "formLogic":
@@ -359,15 +336,13 @@ def import_form_data(
 
             deserialized = serializer(**serializer_kwargs)
 
-            if resource == "formLogic" and "order" not in entry:
-                entry["order"] = 0
-
             try:
                 is_create = (
                     deserialized.instance is None or not deserialized.instance.pk
                 )
                 deserialized.is_valid(raise_exception=True)
 
+                # @TODO Move to FormDefinitionImportSerializer. Maybe a generic post_import()?
                 if resource == "formDefinitions":
                     apply_component_conversions(
                         deserialized.validated_data["configuration"]
@@ -377,6 +352,7 @@ def import_form_data(
                         deserialized.validated_data["configuration"]
                     )
 
+                # @TODO move to FormLogicImportSerializer.
                 if resource == "formLogic":
                     clear_old_service_fetch_config(deserialized.validated_data)
 
@@ -384,6 +360,7 @@ def import_form_data(
                 if resource == "forms":
                     created_form = deserialized.instance
                 if resource == "formSteps":
+                    # @TODO move to FormStepImportSerializer?
                     # Once the form steps have been created, we create the component FormVariables
                     # based on the form definition configurations.
                     FormVariable.objects.create_for_form(created_form)

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -19,6 +19,7 @@ from rest_framework.test import APIRequestFactory
 from openforms.formio.migration_converters import CONVERTERS, DEFINITION_CONVERTERS
 from openforms.formio.utils import iter_components
 from openforms.forms.constants import FormTypeChoices
+from openforms.import_export.typing import FormExportOptions
 from openforms.registrations.contrib.objects_api.constants import (
     PLUGIN_IDENTIFIER as OBJECTS_API_PLUGIN_IDENTIFIER,
 )
@@ -140,7 +141,9 @@ def form_to_json(form_id: int) -> dict:
     return resources
 
 
-def export_form(form_id, archive_name=None, response=None):
+def export_form(
+    form_id, archive_name=None, response=None, export_options: FormExportOptions = None
+):
     resources = form_to_json(form_id)
 
     outfile = response or archive_name

--- a/src/openforms/forms/utils.py
+++ b/src/openforms/forms/utils.py
@@ -1,10 +1,8 @@
 import json
-import random
-import string
 import zipfile
-from collections.abc import Collection
-from typing import Any, Required, TypedDict
-from uuid import uuid4
+from collections.abc import Callable, Collection
+from dataclasses import dataclass
+from typing import Any, Literal, Required, TypedDict
 
 from django.conf import settings
 from django.core.serializers.json import DjangoJSONEncoder
@@ -14,9 +12,11 @@ from django.utils.translation import override
 
 import structlog
 from rest_framework.exceptions import ValidationError
+from rest_framework.request import Request
 from rest_framework.test import APIRequestFactory
 
 from openforms.import_export.serializers import (
+    BaseImportSerializer,
     FormDefinitionExportSerializer,
     FormDefinitionImportSerializer,
     FormExportSerializer,
@@ -49,7 +49,7 @@ from openforms.variables.constants import FormVariableSources
 
 from .api.datastructures import FormVariableWrapper
 from .constants import EXPORT_META_KEY
-from .models import Form, FormDefinition, FormLogic, FormStep, FormVariable
+from .models import Form, FormDefinition, FormLogic, FormStep
 
 logger = structlog.stdlib.get_logger(__name__)
 
@@ -68,12 +68,105 @@ IMPORT_ORDER = (
     "formLogic",
 )
 
-SERIALIZERS = {
-    "formDefinitions": FormDefinitionImportSerializer,
-    "forms": FormImportSerializer,
-    "formSteps": FormStepImportSerializer,
-    "formLogic": FormLogicImportSerializer,
-    "formVariables": FormVariableImportSerializer,
+
+@dataclass(frozen=True)
+class ImportSerializerConfig:
+    serializer: type[BaseImportSerializer]
+    serializer_kwargs: Callable[
+        [dict[str, Any], Form | None, FormImportOptions, Request],
+        [dict[str, Any]],
+    ]
+    type: Literal["form", "formDefinition", "formStep", "formVariable", "formLogic"]
+
+
+def get_serializer_kwargs(
+    data: dict[str, Any],
+    form: Form | None,
+    import_options: FormImportOptions,
+    request: Request,
+) -> dict[str, Any]:
+    return {
+        "data": data,
+        "context": {
+            "request": request,
+            "form": form,
+            "is_import": True,
+            "import_options": import_options,
+        },
+    }
+
+
+def get_form_variable_serializer_kwargs(
+    data: dict[str, Any],
+    form: Form | None,
+    import_options: FormImportOptions,
+    request: Request,
+) -> dict[str, Any]:
+    kwargs = get_serializer_kwargs(data, form, import_options, request)
+    kwargs["context"] = {
+        **kwargs["context"],
+        "forms": ({str(form.uuid): form}),
+        "form_definitions": {
+            str(fd.uuid): fd
+            for fd in FormDefinition.objects.filter(formstep__form=form)
+        },
+    }
+    return kwargs
+
+
+def get_form_logic_serializer_kwargs(
+    data: dict[str, Any],
+    form: Form | None,
+    import_options: FormImportOptions,
+    request: Request,
+) -> dict[str, Any]:
+    kwargs = get_serializer_kwargs(data, form, import_options, request)
+    kwargs["context"] = {
+        **kwargs["context"],
+        "forms": ({str(form.uuid): form}),
+        "form_definitions": {
+            str(fd.uuid): fd
+            for fd in FormDefinition.objects.filter(formstep__form=form)
+        },
+        "form_variables": FormVariableWrapper(form),
+        "form_steps": {
+            form_step.uuid: form_step
+            for form_step in form.formstep_set.all().order_by("order")
+        },
+    }
+    return kwargs
+
+
+"""
+Serializer configuration for the import process. The key is the name of the resource
+in the import file, and the value is the serializer class and serializer kwargs.
+"""
+IMPORT_SERIALIZER_CONFIGS: dict[str, ImportSerializerConfig] = {
+    "forms": ImportSerializerConfig(
+        serializer=FormImportSerializer,
+        serializer_kwargs=get_serializer_kwargs,
+        type="form",
+    ),
+    "formDefinitions": ImportSerializerConfig(
+        serializer=FormDefinitionImportSerializer,
+        serializer_kwargs=get_serializer_kwargs,
+        type="formDefinition",
+    ),
+    "formSteps": ImportSerializerConfig(
+        serializer=FormStepImportSerializer,
+        serializer_kwargs=get_serializer_kwargs,
+        type="formStep",
+    ),
+    "formVariables": ImportSerializerConfig(
+        serializer=FormVariableImportSerializer,
+        serializer_kwargs=get_form_variable_serializer_kwargs,
+        type="formVariable",
+    ),
+    "formLogic": ImportSerializerConfig(
+        serializer=FormLogicImportSerializer,
+        serializer_kwargs=get_form_logic_serializer_kwargs,
+        type="formLogic",
+    ),
 }
 
 
@@ -235,17 +328,15 @@ def import_form_data(
     uuid_mapping = {}
 
     request = _get_mock_request()
-
     created_form = None
-
-    _form_definitions = []
+    form_definitions = []
 
     # Import additional data
     import_additional_form_configuration_data(
         resources=import_data, import_options=import_options
     )
 
-    for resource in IMPORT_ORDER:
+    for resource in IMPORT_SERIALIZER_CONFIGS:
         if resource not in import_data:
             continue
 
@@ -253,142 +344,32 @@ def import_form_data(
         for old, new in uuid_mapping.items():
             data = data.replace(old, new)
 
-        try:
-            serializer = SERIALIZERS[resource]
-        except KeyError:
-            raise ValidationError(f"Unknown resource {resource}")
-
+        serializer_config = IMPORT_SERIALIZER_CONFIGS[resource]
         for entry in json.loads(data):
-            if old_uuid := entry.get("uuid"):
-                entry["uuid"] = str(uuid4())
+            old_uuid = entry.get("uuid")
 
-            if resource == "forms":
-                # check for file components in the form definitions and move
-                # registration options to the backend registration options
-                # @TODO Implement on FormDefinitionImportSerializer?
-                move_file_registration_options(entry, _form_definitions)
-
-            serializer_kwargs = {
-                "data": entry,
-                "context": {
-                    "request": request,
-                    "form": created_form,
-                    "is_import": True,
-                    "import_options": import_options,
-                },
-            }
-
-            if resource == "formDefinitions":
-                existing_form_definition_instance = check_form_definition(
-                    old_uuid,
-                    entry,
-                    for_existing_form=False,
-                    # @TODO is this needed?
-                    # for_existing_form=existing_form_instance is not None,
+            deserialized = serializer_config.serializer(
+                **serializer_config.serializer_kwargs(
+                    entry, created_form, import_options, request
                 )
-                if existing_form_definition_instance:
-                    # The form definition that is being imported is identical to
-                    # the existing form definition with the same UUID, use
-                    # existing instead of creating new definition. This may be
-                    # both single and multiple use (is_reusable=True) form
-                    # definitions, depending on whether it's for an existing form or not.
-                    # Note that the mapping will include the same UUID  here often,
-                    # which is okay for find-and-replace.
-                    serializer_kwargs["instance"] = existing_form_definition_instance
-                    entry["uuid"] = old_uuid
-                    uuid_mapping[old_uuid] = old_uuid
-
-            if resource == "forms" and existing_form_instance:
-                serializer_kwargs["instance"] = existing_form_instance
-
-            if resource in ("formVariables", "formLogic"):
-                # by now, the form resource has been created (or it was an existing one)
-                _form = existing_form_instance or created_form
-                # @TODO inspect serializers for why this is needed.
-                serializer_kwargs["context"].update(
-                    {
-                        "forms": {str(_form.uuid): _form},
-                        "form_definitions": {
-                            str(fd.uuid): fd
-                            for fd in FormDefinition.objects.filter(
-                                formstep__form=_form
-                            )
-                        },
-                    }
-                )
-                if "service_fetch_configuration" in entry:
-                    # The transferring between systems case is very tricky
-                    # better not import these, we don't know where this came from.
-                    # services and ids may point to different things
-                    # in different OF instances.
-                    # @TODO move to import serializers?
-                    del entry["service_fetch_configuration"]
-
-            if resource == "formLogic":
-                # by now, the form resource has been created (or it was an existing one)
-                _form = existing_form_instance or created_form
-                serializer_kwargs["context"].update(
-                    {
-                        "form_variables": FormVariableWrapper(_form),
-                        "form_steps": {
-                            form_step.uuid: form_step
-                            for form_step in _form.formstep_set.all().order_by("order")
-                        },
-                    }
-                )
-
-            deserialized = serializer(**serializer_kwargs)
+            )
 
             try:
-                is_create = (
-                    deserialized.instance is None or not deserialized.instance.pk
-                )
                 deserialized.is_valid(raise_exception=True)
 
                 instance = deserialized.save()
-                if resource == "forms":
-                    created_form = deserialized.instance
-                if resource == "formSteps":
-                    # @TODO move to FormStepImportSerializer?
-                    # Once the form steps have been created, we create the component FormVariables
-                    # based on the form definition configurations.
-                    FormVariable.objects.create_for_form(created_form)
-                if resource == "formDefinitions":
-                    _form_definitions.append(instance)
-                if resource == "formDefinitions" and is_create:
-                    uuid_mapping[old_uuid] = str(instance.uuid)
+                if serializer_config.type == "form" and created_form is None:
+                    created_form = instance
+                if serializer_config.type == "formDefinition":
+                    form_definitions.append(instance)
 
-                # The FormSerializer/FormStepSerializer/FormLogicSerializer have the uuid as a read only field.
-                # So the mapping between the old uuid and the new needs to be done after the instance is saved.
                 if hasattr(deserialized.instance, "uuid") and "uuid" in entry:
                     uuid_mapping[old_uuid] = str(deserialized.instance.uuid)
             except ValidationError as e:
-                if (
-                    resource == "forms"
-                    and "slug" in e.detail
-                    and e.detail["slug"][0].code == "unique"
-                ):
-                    entry["slug"] = (
-                        f"{entry['slug']}-{''.join(random.choices(string.hexdigits, k=6))}"
-                    )
+                raise e
 
-                    deserialized = serializer(
-                        data=entry,
-                        context={
-                            "request": request,
-                            "form": created_form,
-                            "is_import": True,
-                            "import_options": import_options,
-                        },
-                        instance=existing_form_instance,
-                    )
-                    deserialized.is_valid(raise_exception=True)
-                    deserialized.save()
-                    created_form = deserialized.instance
-                    uuid_mapping[old_uuid] = str(deserialized.instance.uuid)
-
-                else:
-                    raise e
+        if serializer_config.type == "formDefinition":
+            move_file_registration_options(created_form, form_definitions)
 
     return created_form
 
@@ -414,12 +395,12 @@ class FileComponentOptions(TypedDict, total=False):
 
 
 def move_file_registration_options(
-    form_data: dict, form_definitions: Collection[FormDefinition]
+    form: Form, form_definitions: Collection[FormDefinition]
 ):
     relevant_backends = [
         backend
-        for backend in form_data.get("registration_backends", [])
-        if backend.get("backend")
+        for backend in form.registration_backends.all()
+        if backend.backend
         in (
             OBJECTS_API_PLUGIN_IDENTIFIER,
             STUF_ZDS_PLUGIN_IDENTIFIER,
@@ -473,14 +454,17 @@ def move_file_registration_options(
     files_for_stuf_zds = [o for opts in files if (o := _file_for_stuf_zds(opts))]
 
     for backend in relevant_backends:
-        options = backend.get("options") or {}
+        options = backend.options
         if "files" in options:
             continue
 
-        plugin_id = backend.get("backend")
+        plugin_id = backend.backend
         if plugin_id in (OBJECTS_API_PLUGIN_IDENTIFIER, ZGW_APIS_PLUGIN_IDENTIFIER):
             options["files"] = files
         elif plugin_id == STUF_ZDS_PLUGIN_IDENTIFIER:
             options["files"] = files_for_stuf_zds
         else:  # pragma: no cover
             raise ValueError(f"Unknown registration plugin '{plugin_id}'.")
+
+        # Persist the changes made to the registration backend
+        backend.save()

--- a/src/openforms/import_export/resources/__init__.py
+++ b/src/openforms/import_export/resources/__init__.py
@@ -1,0 +1,17 @@
+from .base import BaseResource
+from .category import CategoryResource
+from .product import ProductResource
+from .theme import ThemeResource
+from .wms_tile_layer import WMSTileLayerResource
+from .wmts_tile_layer import WMTSTileLayerResource
+from .yivi_attribute_group import YiviAttributeGroupResource
+
+__all__ = [
+    "BaseResource",
+    "CategoryResource",
+    "ProductResource",
+    "ThemeResource",
+    "WMSTileLayerResource",
+    "WMTSTileLayerResource",
+    "YiviAttributeGroupResource",
+]

--- a/src/openforms/import_export/resources/base.py
+++ b/src/openforms/import_export/resources/base.py
@@ -1,0 +1,10 @@
+from import_export.resources import ModelResource
+
+from openforms.forms.models import Form
+
+
+class BaseResource(ModelResource):
+    def export_for_form(self, form: Form):
+        raise NotImplementedError(
+            f"{self.__class__.__name__} must implement export_for_form()"
+        )

--- a/src/openforms/import_export/resources/base.py
+++ b/src/openforms/import_export/resources/base.py
@@ -1,10 +1,55 @@
 from import_export.resources import ModelResource
 
 from openforms.forms.models import Form
+from openforms.typing import JSONObject
 
 
 class BaseResource(ModelResource):
+    deep_comparison_fields = ()
+
     def export_for_form(self, form: Form):
         raise NotImplementedError(
             f"{self.__class__.__name__} must implement export_for_form()"
         )
+
+    def get_or_init_instance(
+        self, instance_loader, row
+    ) -> tuple[dict[str, JSONObject], bool]:
+        """
+        Search for an existing AttributeGroup with matching attributes.
+
+        The default get_or_init_instance uses the import_id_fields. If there is no match,
+        we do a deep comparison with the name, description, and attributes, and return
+        the first match. If there is again no match, we create a new instance.
+
+        The return value is a tuple of (instance, is_new).
+        """
+        instance, is_new = super().get_or_init_instance(instance_loader, row)
+
+        if not is_new:
+            # Return the existing instance, found using the import_id_fields.
+            row["_matched_existing_instance"] = True
+            return instance, is_new
+
+        # Collect the parameters for the deep comparison.
+        params = {}
+        for key in self.deep_comparison_fields:
+            params[key] = self.fields[key].clean(row)
+
+        # Perform the deep comparison and return the first match.
+        if (
+            params
+            and (new_found := self.get_queryset().filter(**params).first()) is not None
+        ):
+            row["_matched_existing_instance"] = True
+            return new_found, False
+
+        # No match found, return a new instance.
+        return instance, is_new
+
+    def skip_row(self, instance, original, row, import_validation_errors=None):
+        if row.get("_matched_existing_instance"):
+            # When we found an existing instance, we don't update it.
+            return True
+
+        return super().skip_row(instance, original, row, import_validation_errors)

--- a/src/openforms/import_export/resources/category.py
+++ b/src/openforms/import_export/resources/category.py
@@ -4,9 +4,14 @@ from .base import BaseResource
 
 
 class CategoryResource(BaseResource):
+    deep_comparison_fields = ("name", "path", "depth")
+
     class Meta:
         model = Category
-        fields = ("uuid", "name")
+        import_id_fields = ("uuid",)
+        fields = ("uuid", "name", "path", "depth")
+        store_instance = True
+        store_row_values = True
 
     def export_for_form(self, form: Form):
         return self.export(

--- a/src/openforms/import_export/resources/category.py
+++ b/src/openforms/import_export/resources/category.py
@@ -1,0 +1,14 @@
+from openforms.forms.models import Category, Form
+
+from .base import BaseResource
+
+
+class CategoryResource(BaseResource):
+    class Meta:
+        model = Category
+        fields = ("uuid", "name")
+
+    def export_for_form(self, form: Form):
+        return self.export(
+            queryset=[form.category] if form.category is not None else []
+        )

--- a/src/openforms/import_export/resources/product.py
+++ b/src/openforms/import_export/resources/product.py
@@ -1,0 +1,13 @@
+from openforms.forms.models import Form
+from openforms.products.models import Product
+
+from .base import BaseResource
+
+
+class ProductResource(BaseResource):
+    class Meta:
+        model = Product
+        fields = ("uuid", "name", "price", "information")
+
+    def export_for_form(self, form: Form):
+        return self.export(queryset=[form.product] if form.product is not None else [])

--- a/src/openforms/import_export/resources/product.py
+++ b/src/openforms/import_export/resources/product.py
@@ -5,9 +5,14 @@ from .base import BaseResource
 
 
 class ProductResource(BaseResource):
+    deep_comparison_fields = ("name", "price", "information")
+
     class Meta:
         model = Product
+        import_id_fields = ("uuid",)
         fields = ("uuid", "name", "price", "information")
+        store_instance = True
+        store_row_values = True
 
     def export_for_form(self, form: Form):
         return self.export(queryset=[form.product] if form.product is not None else [])

--- a/src/openforms/import_export/resources/theme.py
+++ b/src/openforms/import_export/resources/theme.py
@@ -5,8 +5,11 @@ from .base import BaseResource
 
 
 class ThemeResource(BaseResource):
+    deep_comparison_fields = ("name", "organization_name", "main_website")
+
     class Meta:
         model = Theme
+        import_id_fields = ("uuid",)
         fields = (
             "uuid",
             "name",
@@ -19,6 +22,8 @@ class ThemeResource(BaseResource):
             "stylesheet_file",
             "design_token_values",
         )
+        store_instance = True
+        store_row_values = True
 
     def export_for_form(self, form: Form):
         return self.export(queryset=[form.theme] if form.theme is not None else [])

--- a/src/openforms/import_export/resources/theme.py
+++ b/src/openforms/import_export/resources/theme.py
@@ -1,0 +1,24 @@
+from openforms.config.models import Theme
+from openforms.forms.models import Form
+
+from .base import BaseResource
+
+
+class ThemeResource(BaseResource):
+    class Meta:
+        model = Theme
+        fields = (
+            "uuid",
+            "name",
+            "organization_name",
+            "main_website",
+            "favicon",
+            "email_logo",
+            "classname",
+            "stylesheet",
+            "stylesheet_file",
+            "design_token_values",
+        )
+
+    def export_for_form(self, form: Form):
+        return self.export(queryset=[form.theme] if form.theme is not None else [])

--- a/src/openforms/import_export/resources/wms_tile_layer.py
+++ b/src/openforms/import_export/resources/wms_tile_layer.py
@@ -1,0 +1,26 @@
+from openforms.config.models import MapWMSTileLayer
+from openforms.forms.models import Form
+
+from .base import BaseResource
+
+
+class WMSTileLayerResource(BaseResource):
+    class Meta:
+        model = MapWMSTileLayer
+        fields = ("uuid", "name", "url")
+
+    def export_for_form(self, form: Form):
+        wms_tile_layers = []
+        for step in form.form_step_map.values():
+            for component in step.form_definition.iter_components():
+                if component["type"] == "map":
+                    wms_tile_layers.extend(
+                        overlay["uuid"] for overlay in component.get("overlays", [])
+                    )
+
+        if len(wms_tile_layers) == 0:
+            return self.export(queryset=[])
+
+        return self.export(
+            queryset=MapWMSTileLayer.objects.filter(uuid__in=list(set(wms_tile_layers)))
+        )

--- a/src/openforms/import_export/resources/wms_tile_layer.py
+++ b/src/openforms/import_export/resources/wms_tile_layer.py
@@ -5,9 +5,14 @@ from .base import BaseResource
 
 
 class WMSTileLayerResource(BaseResource):
+    deep_comparison_fields = ("name", "url")
+
     class Meta:
         model = MapWMSTileLayer
+        import_id_fields = ("uuid",)
         fields = ("uuid", "name", "url")
+        store_instance = True
+        store_row_values = True
 
     def export_for_form(self, form: Form):
         wms_tile_layers = []

--- a/src/openforms/import_export/resources/wmts_tile_layer.py
+++ b/src/openforms/import_export/resources/wmts_tile_layer.py
@@ -7,7 +7,10 @@ from .base import BaseResource
 class WMTSTileLayerResource(BaseResource):
     class Meta:
         model = MapTileLayer
+        import_id_fields = ("identifier",)
         fields = ("identifier", "label", "url")
+        store_instance = True
+        store_row_values = True
 
     def export_for_form(self, form: Form):
         wmts_tile_layers = []

--- a/src/openforms/import_export/resources/wmts_tile_layer.py
+++ b/src/openforms/import_export/resources/wmts_tile_layer.py
@@ -1,0 +1,26 @@
+from openforms.config.models import MapTileLayer
+from openforms.forms.models import Form
+
+from .base import BaseResource
+
+
+class WMTSTileLayerResource(BaseResource):
+    class Meta:
+        model = MapTileLayer
+        fields = ("identifier", "label", "url")
+
+    def export_for_form(self, form: Form):
+        wmts_tile_layers = []
+        for step in form.form_step_map.values():
+            for component in step.form_definition.iter_components():
+                if component["type"] == "map":
+                    wmts_tile_layers.append(component.get("tileLayerIdentifier", ""))
+
+        if len(wmts_tile_layers) == 0:
+            return self.export(queryset=[])
+
+        return self.export(
+            queryset=MapTileLayer.objects.filter(
+                identifier__in=list(set(wmts_tile_layers))
+            )
+        )

--- a/src/openforms/import_export/resources/yivi_attribute_group.py
+++ b/src/openforms/import_export/resources/yivi_attribute_group.py
@@ -1,0 +1,21 @@
+from openforms.authentication.contrib.yivi_oidc.models import AttributeGroup
+from openforms.forms.models import Form
+
+from .base import BaseResource
+
+
+class YiviAttributeGroupResource(BaseResource):
+    class Meta:
+        model = AttributeGroup
+        fields = ("uuid", "name", "description", "attributes")
+
+    def export_for_form(self, form: Form):
+        yivi_auth_backend = form.auth_backends.all().filter(backend="yivi_oidc").first()
+        if yivi_auth_backend is None:
+            return self.export(queryset=[])
+
+        return self.export(
+            queryset=AttributeGroup.objects.filter(
+                uuid__in=yivi_auth_backend.options["additional_attributes_groups"]
+            )
+        )

--- a/src/openforms/import_export/resources/yivi_attribute_group.py
+++ b/src/openforms/import_export/resources/yivi_attribute_group.py
@@ -5,9 +5,14 @@ from .base import BaseResource
 
 
 class YiviAttributeGroupResource(BaseResource):
+    deep_comparison_fields = ("name", "description", "attributes")
+
     class Meta:
         model = AttributeGroup
+        import_id_fields = ("uuid",)
         fields = ("uuid", "name", "description", "attributes")
+        store_instance = True
+        store_row_values = True
 
     def export_for_form(self, form: Form):
         yivi_auth_backend = form.auth_backends.all().filter(backend="yivi_oidc").first()

--- a/src/openforms/import_export/serializers/__init__.py
+++ b/src/openforms/import_export/serializers/__init__.py
@@ -1,13 +1,21 @@
-from .form import FormExportSerializer
-from .form_definition import FormDefinitionExportSerializer
-from .form_logic import FormLogicExportSerializer
-from .form_step import FormStepExportSerializer
-from .form_variable import FormVariableExportSerializer
+from .form import FormExportSerializer, FormImportSerializer
+from .form_definition import (
+    FormDefinitionExportSerializer,
+    FormDefinitionImportSerializer,
+)
+from .form_logic import FormLogicExportSerializer, FormLogicImportSerializer
+from .form_step import FormStepExportSerializer, FormStepImportSerializer
+from .form_variable import FormVariableExportSerializer, FormVariableImportSerializer
 
 __all__ = [
     "FormExportSerializer",
+    "FormImportSerializer",
     "FormDefinitionExportSerializer",
+    "FormDefinitionImportSerializer",
     "FormLogicExportSerializer",
+    "FormLogicImportSerializer",
     "FormStepExportSerializer",
+    "FormStepImportSerializer",
     "FormVariableExportSerializer",
+    "FormVariableImportSerializer",
 ]

--- a/src/openforms/import_export/serializers/__init__.py
+++ b/src/openforms/import_export/serializers/__init__.py
@@ -1,3 +1,4 @@
+from .base import BaseImportSerializer
 from .form import FormExportSerializer, FormImportSerializer
 from .form_definition import (
     FormDefinitionExportSerializer,
@@ -8,6 +9,7 @@ from .form_step import FormStepExportSerializer, FormStepImportSerializer
 from .form_variable import FormVariableExportSerializer, FormVariableImportSerializer
 
 __all__ = [
+    "BaseImportSerializer",
     "FormExportSerializer",
     "FormImportSerializer",
     "FormDefinitionExportSerializer",

--- a/src/openforms/import_export/serializers/__init__.py
+++ b/src/openforms/import_export/serializers/__init__.py
@@ -1,0 +1,13 @@
+from .form import FormExportSerializer
+from .form_definition import FormDefinitionExportSerializer
+from .form_logic import FormLogicExportSerializer
+from .form_step import FormStepExportSerializer
+from .form_variable import FormVariableExportSerializer
+
+__all__ = [
+    "FormExportSerializer",
+    "FormDefinitionExportSerializer",
+    "FormLogicExportSerializer",
+    "FormStepExportSerializer",
+    "FormVariableExportSerializer",
+]

--- a/src/openforms/import_export/serializers/base.py
+++ b/src/openforms/import_export/serializers/base.py
@@ -1,0 +1,24 @@
+from rest_framework import serializers
+
+from openforms.import_export.typing import FormExportOptions
+from openforms.typing import JSONObject
+
+
+class BaseExportSerializer(serializers.Serializer):
+    def to_representation(self, instance):
+        representation = super().to_representation(instance)
+
+        if (
+            export_options := self.get_export_options()
+        ) is not None and export_options.remove_sensitive_content:
+            representation = self.remove_sensitive_content(instance, representation)
+
+        return representation
+
+    def remove_sensitive_content(
+        self, instance, representation: JSONObject
+    ) -> JSONObject:
+        return representation
+
+    def get_export_options(self) -> FormExportOptions | None:
+        return self.context.get("export_options", None)

--- a/src/openforms/import_export/serializers/base.py
+++ b/src/openforms/import_export/serializers/base.py
@@ -1,3 +1,5 @@
+from uuid import uuid4
+
 from rest_framework import serializers
 
 from openforms.import_export.typing import (
@@ -77,6 +79,7 @@ class BaseImportSerializer(serializers.Serializer):
 
     def to_internal_value(self, instance):
         value = instance.copy()
+        value = self.set_new_uuid(value)
         value = self.apply_backwards_compatibility(value)
 
         value = self.remove_excluded_form_configuration(value)
@@ -84,7 +87,11 @@ class BaseImportSerializer(serializers.Serializer):
 
         return super().to_internal_value(value)
 
-    def apply_backwards_compatibility(self, value: dict[str, Any]) -> dict[str, Any]:
+    def set_new_uuid(self, value: JSONObject) -> JSONObject:
+        value["uuid"] = uuid4()
+        return value
+
+    def apply_backwards_compatibility(self, value: JSONObject) -> JSONObject:
         return value
 
     def remove_excluded_form_configuration(self, value: JSONObject) -> JSONObject:

--- a/src/openforms/import_export/serializers/base.py
+++ b/src/openforms/import_export/serializers/base.py
@@ -77,9 +77,17 @@ class BaseImportSerializer(serializers.Serializer):
         AdditionalFormConfigurationCleanup
     ] = ()
 
+    @staticmethod
+    def resolve_instance(value: JSONObject, import_options: FormImportOptions | None):
+        return None
+
     def to_internal_value(self, instance):
         value = instance.copy()
-        value = self.set_new_uuid(value)
+
+        # When importing an existing instance, we should not overwrite the uuid
+        if not self.instance:
+            value = self.set_new_uuid(value)
+
         value = self.apply_backwards_compatibility(value)
 
         value = self.remove_excluded_form_configuration(value)

--- a/src/openforms/import_export/serializers/base.py
+++ b/src/openforms/import_export/serializers/base.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 
 from openforms.import_export.typing import (
+    AdditionalFormConfigurationCleanup,
     FormConfigurationCleanup,
     FormExportOptions,
 )
@@ -9,6 +10,9 @@ from openforms.typing import JSONObject
 
 class BaseExportSerializer(serializers.Serializer):
     excluded_form_configuration_cleanup: list[FormConfigurationCleanup] = ()
+    excluded_additional_form_configuration_cleanup: list[
+        AdditionalFormConfigurationCleanup
+    ] = ()
 
     def to_representation(self, instance):
         representation = super().to_representation(instance)
@@ -19,6 +23,9 @@ class BaseExportSerializer(serializers.Serializer):
             representation = self.remove_sensitive_content(instance, representation)
 
         representation = self.remove_excluded_form_configuration(representation)
+        representation = self.remove_excluded_additional_form_configuration(
+            representation
+        )
 
         return representation
 
@@ -37,6 +44,21 @@ class BaseExportSerializer(serializers.Serializer):
         )
 
         for config in self.excluded_form_configuration_cleanup:
+            if config.option not in selected_options:
+                config.cleanup(representation)
+
+        return representation
+
+    def remove_excluded_additional_form_configuration(
+        self, representation: JSONObject
+    ) -> JSONObject:
+        selected_options = (
+            set(export_options.additional_form_configuration)
+            if (export_options := self.get_export_options()) is not None
+            else []
+        )
+
+        for config in self.excluded_additional_form_configuration_cleanup:
             if config.option not in selected_options:
                 config.cleanup(representation)
 

--- a/src/openforms/import_export/serializers/base.py
+++ b/src/openforms/import_export/serializers/base.py
@@ -1,10 +1,15 @@
 from rest_framework import serializers
 
-from openforms.import_export.typing import FormExportOptions
+from openforms.import_export.typing import (
+    FormConfigurationCleanup,
+    FormExportOptions,
+)
 from openforms.typing import JSONObject
 
 
 class BaseExportSerializer(serializers.Serializer):
+    excluded_form_configuration_cleanup: list[FormConfigurationCleanup] = ()
+
     def to_representation(self, instance):
         representation = super().to_representation(instance)
 
@@ -13,11 +18,28 @@ class BaseExportSerializer(serializers.Serializer):
         ) is not None and export_options.remove_sensitive_content:
             representation = self.remove_sensitive_content(instance, representation)
 
+        representation = self.remove_excluded_form_configuration(representation)
+
         return representation
 
     def remove_sensitive_content(
         self, instance, representation: JSONObject
     ) -> JSONObject:
+        return representation
+
+    def remove_excluded_form_configuration(
+        self, representation: JSONObject
+    ) -> JSONObject:
+        selected_options = (
+            set(export_options.form_configuration)
+            if (export_options := self.get_export_options()) is not None
+            else []
+        )
+
+        for config in self.excluded_form_configuration_cleanup:
+            if config.option not in selected_options:
+                config.cleanup(representation)
+
         return representation
 
     def get_export_options(self) -> FormExportOptions | None:

--- a/src/openforms/import_export/serializers/base.py
+++ b/src/openforms/import_export/serializers/base.py
@@ -2,6 +2,7 @@ from uuid import uuid4
 
 from rest_framework import serializers
 
+from openforms.forms.models import Form
 from openforms.import_export.typing import (
     AdditionalFormConfigurationCleanup,
     FormConfigurationCleanup,
@@ -78,7 +79,11 @@ class BaseImportSerializer(serializers.Serializer):
     ] = ()
 
     @staticmethod
-    def resolve_instance(value: JSONObject, import_options: FormImportOptions | None):
+    def resolve_instance(
+        value: JSONObject,
+        import_options: FormImportOptions | None,
+        existing_form_instance: Form | None,
+    ):
         return None
 
     def to_internal_value(self, instance):

--- a/src/openforms/import_export/serializers/base.py
+++ b/src/openforms/import_export/serializers/base.py
@@ -4,6 +4,7 @@ from openforms.import_export.typing import (
     AdditionalFormConfigurationCleanup,
     FormConfigurationCleanup,
     FormExportOptions,
+    FormImportOptions,
 )
 from openforms.typing import JSONObject
 
@@ -66,3 +67,53 @@ class BaseExportSerializer(serializers.Serializer):
 
     def get_export_options(self) -> FormExportOptions | None:
         return self.context.get("export_options", None)
+
+
+class BaseImportSerializer(serializers.Serializer):
+    excluded_form_configuration_removal: list[FormConfigurationCleanup] = ()
+    excluded_additional_form_configuration_removal: list[
+        AdditionalFormConfigurationCleanup
+    ] = ()
+
+    def to_internal_value(self, instance):
+        value = instance.copy()
+        value = self.apply_backwards_compatibility(value)
+
+        value = self.remove_excluded_form_configuration(value)
+        value = self.remove_excluded_additional_form_configuration(value)
+
+        return super().to_internal_value(value)
+
+    def apply_backwards_compatibility(self, value: dict[str, Any]) -> dict[str, Any]:
+        return value
+
+    def remove_excluded_form_configuration(self, value: JSONObject) -> JSONObject:
+        selected_options = (
+            set(import_options.form_configuration)
+            if (import_options := self.get_import_options()) is not None
+            else []
+        )
+
+        for config in self.excluded_form_configuration_removal:
+            if config.option not in selected_options:
+                config.cleanup(value)
+
+        return value
+
+    def remove_excluded_additional_form_configuration(
+        self, value: JSONObject
+    ) -> JSONObject:
+        selected_options = (
+            set(import_options.additional_form_configuration)
+            if (import_options := self.get_import_options()) is not None
+            else []
+        )
+
+        for config in self.excluded_additional_form_configuration_removal:
+            if config.option not in selected_options:
+                config.cleanup(value)
+
+        return value
+
+    def get_import_options(self) -> FormImportOptions | None:
+        return self.context.get("import_options", None)

--- a/src/openforms/import_export/serializers/form.py
+++ b/src/openforms/import_export/serializers/form.py
@@ -1,11 +1,31 @@
 from openforms.forms.api.serializers import FormSerializer
 from openforms.import_export.typing import (
+    AdditionalFormConfigurationCleanup,
+    AdditionalFormConfigurationOptions,
     FormConfigurationCleanup,
     FormConfigurationOptions,
 )
 from openforms.typing import JSONObject
 
 from .base import BaseExportSerializer
+
+
+def clear_product(representation: JSONObject):
+    representation["product"] = None
+
+
+def clear_category(representation: JSONObject):
+    representation["category"] = None
+
+
+def clear_theme(representation: JSONObject):
+    representation["theme"] = None
+
+
+def clear_yivi_attribute_groups(representation: JSONObject):
+    for auth in representation.get("auth_backends", []):
+        if auth["backend"] == "yivi_oidc":
+            auth["options"]["additional_attributes_groups"] = []
 
 
 def exclude_registration_backends(representation: JSONObject):
@@ -18,6 +38,24 @@ def exclude_payment_backend(representation: JSONObject):
 
 
 class FormExportSerializer(FormSerializer, BaseExportSerializer):
+    excluded_additional_form_configuration_cleanup = (
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.product,
+            cleanup=clear_product,
+        ),
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.category,
+            cleanup=clear_category,
+        ),
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.theme,
+            cleanup=clear_theme,
+        ),
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.yivi_attribute_groups,
+            cleanup=clear_yivi_attribute_groups,
+        ),
+    )
     excluded_form_configuration_cleanup = (
         FormConfigurationCleanup(
             option=FormConfigurationOptions.registration_backends,

--- a/src/openforms/import_export/serializers/form.py
+++ b/src/openforms/import_export/serializers/form.py
@@ -1,3 +1,5 @@
+import random
+import string
 from urllib.parse import urlsplit
 
 from mail_cleaner.constants import URL_REGEX
@@ -7,6 +9,7 @@ from openforms.emails.utils import get_netloc_allowlist, sanitize_content
 from openforms.emails.validators import subdomains
 from openforms.forms.api.serializers import FormSerializer
 from openforms.forms.constants import FormTypeChoices
+from openforms.forms.models import Form
 from openforms.import_export.typing import (
     AdditionalFormConfigurationCleanup,
     AdditionalFormConfigurationOptions,
@@ -141,6 +144,12 @@ class FormImportSerializer(FormSerializer, BaseImportSerializer):
 
         # When importing a form, it should be non-active by default
         value["active"] = False
+
+        # Make sure the slug is unique
+        if Form.objects.filter(slug=value.get("slug")).first() is not None:
+            value["slug"] = (
+                f"{value['slug']}-{''.join(random.choices(string.hexdigits, k=6))}"
+            )
 
         return super().to_internal_value(value)
 

--- a/src/openforms/import_export/serializers/form.py
+++ b/src/openforms/import_export/serializers/form.py
@@ -6,6 +6,7 @@ from openforms.config.models import GlobalConfiguration
 from openforms.emails.utils import get_netloc_allowlist, sanitize_content
 from openforms.emails.validators import subdomains
 from openforms.forms.api.serializers import FormSerializer
+from openforms.forms.constants import FormTypeChoices
 from openforms.import_export.typing import (
     AdditionalFormConfigurationCleanup,
     AdditionalFormConfigurationOptions,
@@ -138,7 +139,20 @@ class FormImportSerializer(FormSerializer, BaseImportSerializer):
         value = instance.copy()
         value = self.handle_unknown_domains(value)
 
+        # When importing a form, it should be non-active by default
+        value["active"] = False
+
         return super().to_internal_value(value)
+
+    def apply_backwards_compatibility(self, value: JSONObject) -> JSONObject:
+        # forms before v4.0 do not have the type field so in case we import an
+        # old appointment form we have to make sure that the form has the right
+        # type configured (by default is regular)
+        if appointment_options := value.get("appointment_options"):
+            if appointment_options.get("is_appointment"):
+                value["type"] = FormTypeChoices.appointment
+
+        return value
 
     def handle_unknown_domains(self, value: JSONObject) -> JSONObject:
         if (import_options := self.get_import_options()) is None:

--- a/src/openforms/import_export/serializers/form.py
+++ b/src/openforms/import_export/serializers/form.py
@@ -1,0 +1,25 @@
+from openforms.forms.api.serializers import FormSerializer
+
+from .base import BaseExportSerializer
+
+
+class FormExportSerializer(FormSerializer, BaseExportSerializer):
+    def get_fields(self):
+        fields = super().get_fields()
+        # for export we want to use the list of plugin-id's instead of detailed info objects
+        if "login_options" in fields:
+            del fields["login_options"]
+        if "payment_options" in fields:
+            del fields["payment_options"]
+        return fields
+
+    def remove_sensitive_content(self, instance, representation):
+        representation = super().remove_sensitive_content(instance, representation)
+        representation["internal_remarks"] = ""
+
+        for registration in representation.get("registration_backends", []):
+            if registration["backend"] == "email":
+                registration["options"]["to_emails"] = []
+                registration["options"]["payment_emails"] = []
+
+        return representation

--- a/src/openforms/import_export/serializers/form.py
+++ b/src/openforms/import_export/serializers/form.py
@@ -15,6 +15,7 @@ from openforms.import_export.typing import (
     AdditionalFormConfigurationOptions,
     FormConfigurationCleanup,
     FormConfigurationOptions,
+    FormImportOptions,
     LinksToUnknownDomainsOptions,
 )
 from openforms.typing import JSONObject
@@ -137,6 +138,14 @@ class FormImportSerializer(FormSerializer, BaseImportSerializer):
             cleanup=exclude_auth_backends,
         ),
     )
+
+    @staticmethod
+    def resolve_instance(
+        value: JSONObject,
+        import_options: FormImportOptions | None,
+        existing_form_instance: Form | None,
+    ) -> Form | None:
+        return existing_form_instance
 
     def to_internal_value(self, instance):
         value = instance.copy()

--- a/src/openforms/import_export/serializers/form.py
+++ b/src/openforms/import_export/serializers/form.py
@@ -7,7 +7,7 @@ from openforms.import_export.typing import (
 )
 from openforms.typing import JSONObject
 
-from .base import BaseExportSerializer
+from .base import BaseExportSerializer, BaseImportSerializer
 
 
 def clear_product(representation: JSONObject):
@@ -35,6 +35,10 @@ def exclude_registration_backends(representation: JSONObject):
 def exclude_payment_backend(representation: JSONObject):
     representation["payment_backend"] = ""
     representation["payment_backend_options"] = {}
+
+
+def exclude_auth_backends(representation: dict[str, Any]):
+    representation["auth_backends"] = []
 
 
 class FormExportSerializer(FormSerializer, BaseExportSerializer):
@@ -86,3 +90,38 @@ class FormExportSerializer(FormSerializer, BaseExportSerializer):
                 registration["options"]["payment_emails"] = []
 
         return representation
+
+
+class FormImportSerializer(FormSerializer, BaseImportSerializer):
+    excluded_additional_form_configuration_removal = (
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.product,
+            cleanup=clear_product,
+        ),
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.category,
+            cleanup=clear_category,
+        ),
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.theme,
+            cleanup=clear_theme,
+        ),
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.yivi_attribute_groups,
+            cleanup=clear_yivi_attribute_groups,
+        ),
+    )
+    excluded_form_configuration_removal = (
+        FormConfigurationCleanup(
+            option=FormConfigurationOptions.registration_backends,
+            cleanup=exclude_registration_backends,
+        ),
+        FormConfigurationCleanup(
+            option=FormConfigurationOptions.payment_backend,
+            cleanup=exclude_payment_backend,
+        ),
+        FormConfigurationCleanup(
+            option=FormConfigurationOptions.auth_backends,
+            cleanup=exclude_auth_backends,
+        ),
+    )

--- a/src/openforms/import_export/serializers/form.py
+++ b/src/openforms/import_export/serializers/form.py
@@ -1,9 +1,34 @@
 from openforms.forms.api.serializers import FormSerializer
+from openforms.import_export.typing import (
+    FormConfigurationCleanup,
+    FormConfigurationOptions,
+)
+from openforms.typing import JSONObject
 
 from .base import BaseExportSerializer
 
 
+def exclude_registration_backends(representation: JSONObject):
+    representation["registration_backends"] = []
+
+
+def exclude_payment_backend(representation: JSONObject):
+    representation["payment_backend"] = ""
+    representation["payment_backend_options"] = {}
+
+
 class FormExportSerializer(FormSerializer, BaseExportSerializer):
+    excluded_form_configuration_cleanup = (
+        FormConfigurationCleanup(
+            option=FormConfigurationOptions.registration_backends,
+            cleanup=exclude_registration_backends,
+        ),
+        FormConfigurationCleanup(
+            option=FormConfigurationOptions.payment_backend,
+            cleanup=exclude_payment_backend,
+        ),
+    )
+
     def get_fields(self):
         fields = super().get_fields()
         # for export we want to use the list of plugin-id's instead of detailed info objects

--- a/src/openforms/import_export/serializers/form.py
+++ b/src/openforms/import_export/serializers/form.py
@@ -1,9 +1,17 @@
+from urllib.parse import urlsplit
+
+from mail_cleaner.constants import URL_REGEX
+
+from openforms.config.models import GlobalConfiguration
+from openforms.emails.utils import get_netloc_allowlist, sanitize_content
+from openforms.emails.validators import subdomains
 from openforms.forms.api.serializers import FormSerializer
 from openforms.import_export.typing import (
     AdditionalFormConfigurationCleanup,
     AdditionalFormConfigurationOptions,
     FormConfigurationCleanup,
     FormConfigurationOptions,
+    LinksToUnknownDomainsOptions,
 )
 from openforms.typing import JSONObject
 
@@ -37,7 +45,7 @@ def exclude_payment_backend(representation: JSONObject):
     representation["payment_backend_options"] = {}
 
 
-def exclude_auth_backends(representation: dict[str, Any]):
+def exclude_auth_backends(representation: JSONObject):
     representation["auth_backends"] = []
 
 
@@ -125,3 +133,114 @@ class FormImportSerializer(FormSerializer, BaseImportSerializer):
             cleanup=exclude_auth_backends,
         ),
     )
+
+    def to_internal_value(self, instance):
+        value = instance.copy()
+        value = self.handle_unknown_domains(value)
+
+        return super().to_internal_value(value)
+
+    def handle_unknown_domains(self, value: JSONObject) -> JSONObject:
+        if (import_options := self.get_import_options()) is None:
+            return value
+
+        match import_options.links_to_unknown_domains:
+            case LinksToUnknownDomainsOptions.accept:
+                # Collect all unique unknown domains and add them to the allowed domains
+                self.accept_all_unknown_domains(value)
+
+            case LinksToUnknownDomainsOptions.remove:
+                # Remove all unknown domains from the email templates
+                return self.sanitize_email_templates(value)
+
+            case LinksToUnknownDomainsOptions.ignore:
+                pass
+
+            case _:  # pragma: no cover
+                raise RuntimeError(
+                    f"Unknown 'links_to_unknown_domains' import option: {import_options.links_to_unknown_domains}"
+                )
+
+        return value
+
+    def get_unknown_domains(self, value: str) -> list[str]:
+        allowlist = get_netloc_allowlist()
+        unknown_domains = []
+
+        for m in URL_REGEX.finditer(value):
+            parsed = urlsplit(m.group())
+
+            if not any(stem for stem in subdomains(parsed.netloc) if stem in allowlist):
+                unknown_domains.append(parsed.netloc)
+
+        return unknown_domains
+
+    def accept_all_unknown_domains(self, value: JSONObject):
+        global_config = GlobalConfiguration.get_solo()
+
+        # Get the unknown domains from the confirmation email template
+        all_unknown_domains = [
+            *self.get_unknown_domains(
+                value.get("confirmation_email_template", {}).get("content", "")
+            ),
+            *self.get_unknown_domains(
+                value.get("confirmation_email_template", {}).get("cosign_content", "")
+            ),
+        ]
+
+        # Get the unknown domains from the email registration backends
+        for registration in value.get("registration_backends", []):
+            if registration["backend"] == "email":
+                options = registration.get("options", {})
+                all_unknown_domains.extend(
+                    [
+                        *self.get_unknown_domains(
+                            options.get("email_content_template_html", "")
+                        ),
+                        *self.get_unknown_domains(
+                            options.get("email_content_template_text", "")
+                        ),
+                    ]
+                )
+
+        # Get all unique unknown domains and add them all to the allowlist
+        global_config.email_template_netloc_allowlist.extend(
+            list(set(all_unknown_domains))
+        )
+
+        global_config.save()
+
+    def sanitize_email_templates(self, value: JSONObject) -> JSONObject:
+        # Sanitize confirmation email templates
+        if value.get("confirmation_email_template", None) is not None:
+            value["confirmation_email_template"]["content"] = sanitize_content(
+                value["confirmation_email_template"].get("content", "")
+            )
+            value["confirmation_email_template"]["cosign_content"] = sanitize_content(
+                value["confirmation_email_template"].get("cosign_content", "")
+            )
+            for translation in (
+                value["confirmation_email_template"].get("translations", {}).values()
+            ):
+                translation["content"] = sanitize_content(
+                    translation.get("content", "")
+                )
+                translation["cosign_content"] = sanitize_content(
+                    translation.get("cosign_content", "")
+                )
+
+        # Sanitize email registration backend email templates
+        for registration in value.get("registration_backends", []):
+            if registration["backend"] == "email":
+                registration["options"]["email_content_template_html"] = (
+                    sanitize_content(
+                        registration["options"].get("email_content_template_html", "")
+                    )
+                )
+                registration["options"]["email_content_template_text"] = (
+                    sanitize_content(
+                        registration["options"].get("email_content_template_text", "")
+                    )
+                )
+
+        return value

--- a/src/openforms/import_export/serializers/form_definition.py
+++ b/src/openforms/import_export/serializers/form_definition.py
@@ -104,9 +104,9 @@ class FormDefinitionImportSerializer(FormDefinitionSerializer, BaseImportSeriali
     def to_internal_value(self, instance):
         value = instance.copy()
 
-        # @TODO this was AFTER validation. So maybe in a to_representation call?
-        self.apply_component_conversions(value["configuration"])
-        self.apply_definition_conversions(value["configuration"])
+        if configuration := value.get("configuration"):
+            self.apply_component_conversions(configuration)
+            self.apply_definition_conversions(configuration)
 
         return super().to_internal_value(value)
 

--- a/src/openforms/import_export/serializers/form_definition.py
+++ b/src/openforms/import_export/serializers/form_definition.py
@@ -1,11 +1,32 @@
 from openforms.formio.utils import iter_components
 from openforms.forms.api.serializers import FormDefinitionSerializer
+from openforms.import_export.typing import (
+    FormConfigurationCleanup,
+    FormConfigurationOptions,
+)
+from openforms.prefill.constants import IdentifierRoles
+from openforms.typing import JSONObject
 
 from .base import BaseExportSerializer
 
 
+def remove_prefill_from_component_configuration(representation: JSONObject):
+    for component in representation.get("configuration", {}).get("components", []):
+        if "prefill" not in component:
+            return
+        component["prefill"]["plugin"] = ""
+        component["prefill"]["attribute"] = ""
+        component["prefill"]["identifier_role"] = IdentifierRoles.main
+
+
 class FormDefinitionExportSerializer(FormDefinitionSerializer, BaseExportSerializer):
     is_exporting = True
+    excluded_form_configuration_cleanup = (
+        FormConfigurationCleanup(
+            option=FormConfigurationOptions.prefill,
+            cleanup=remove_prefill_from_component_configuration,
+        ),
+    )
 
     def remove_sensitive_content(self, instance, representation):
         representation = super().remove_sensitive_content(instance, representation)

--- a/src/openforms/import_export/serializers/form_definition.py
+++ b/src/openforms/import_export/serializers/form_definition.py
@@ -1,0 +1,27 @@
+from openforms.formio.utils import iter_components
+from openforms.forms.api.serializers import FormDefinitionSerializer
+
+from .base import BaseExportSerializer
+
+
+class FormDefinitionExportSerializer(FormDefinitionSerializer, BaseExportSerializer):
+    is_exporting = True
+
+    def remove_sensitive_content(self, instance, representation):
+        representation = super().remove_sensitive_content(instance, representation)
+
+        if (form := self.context.get("form", None)) is None:
+            return representation
+
+        sensitive_variables = [
+            registration.options["to_emails_from_variable"]
+            for registration in form.registration_backends.all()
+            if registration.backend == "email"
+            and "to_emails_from_variable" in registration.options
+        ]
+
+        for component in iter_components(representation.get("configuration", {})):
+            if component["key"] in sensitive_variables:
+                component["defaultValue"] = ""
+
+        return representation

--- a/src/openforms/import_export/serializers/form_definition.py
+++ b/src/openforms/import_export/serializers/form_definition.py
@@ -3,11 +3,14 @@ import structlog
 from openforms.formio.migration_converters import CONVERTERS, DEFINITION_CONVERTERS
 from openforms.formio.utils import iter_components
 from openforms.forms.api.serializers import FormDefinitionSerializer
+from openforms.forms.models import FormDefinition
 from openforms.import_export.typing import (
     AdditionalFormConfigurationCleanup,
     AdditionalFormConfigurationOptions,
     FormConfigurationCleanup,
     FormConfigurationOptions,
+    FormImportOptions,
+    ReusableFormDefinitionsOptions,
 )
 from openforms.prefill.constants import IdentifierRoles
 from openforms.typing import JSONObject
@@ -100,6 +103,28 @@ class FormDefinitionImportSerializer(FormDefinitionSerializer, BaseImportSeriali
             cleanup=remove_prefill_from_component_configuration,
         ),
     )
+
+    @staticmethod
+    def resolve_instance(
+        value: JSONObject, import_options: FormImportOptions | None
+    ) -> FormDefinition | None:
+        if import_options is None:
+            return None
+
+        match import_options.reusable_form_definitions:
+            case ReusableFormDefinitionsOptions.create_new:
+                return None
+
+            case ReusableFormDefinitionsOptions.reuse_existing:
+                return FormDefinition.objects.filter(
+                    configuration=value.get("configuration"),
+                    is_reusable=True,
+                ).first()
+
+            case _:
+                raise RuntimeError(
+                    f"Form definition import option {import_options.reusable_form_definitions} is not supported"
+                )
 
     def to_internal_value(self, instance):
         value = instance.copy()

--- a/src/openforms/import_export/serializers/form_definition.py
+++ b/src/openforms/import_export/serializers/form_definition.py
@@ -9,7 +9,7 @@ from openforms.import_export.typing import (
 from openforms.prefill.constants import IdentifierRoles
 from openforms.typing import JSONObject
 
-from .base import BaseExportSerializer
+from .base import BaseExportSerializer, BaseImportSerializer
 
 
 def clear_wms_tile_layers(representation: JSONObject):
@@ -76,3 +76,22 @@ class FormDefinitionExportSerializer(FormDefinitionSerializer, BaseExportSeriali
                 component["defaultValue"] = ""
 
         return representation
+
+
+class FormDefinitionImportSerializer(FormDefinitionSerializer, BaseImportSerializer):
+    excluded_additional_form_configuration_removal = (
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.wms_tile_layers,
+            cleanup=clear_wms_tile_layers,
+        ),
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.wmts_tile_layers,
+            cleanup=clear_wmts_tile_layers,
+        ),
+    )
+    excluded_form_configuration_removal = (
+        FormConfigurationCleanup(
+            option=FormConfigurationOptions.prefill,
+            cleanup=remove_prefill_from_component_configuration,
+        ),
+    )

--- a/src/openforms/import_export/serializers/form_definition.py
+++ b/src/openforms/import_export/serializers/form_definition.py
@@ -1,3 +1,6 @@
+import structlog
+
+from openforms.formio.migration_converters import CONVERTERS, DEFINITION_CONVERTERS
 from openforms.formio.utils import iter_components
 from openforms.forms.api.serializers import FormDefinitionSerializer
 from openforms.import_export.typing import (
@@ -10,6 +13,8 @@ from openforms.prefill.constants import IdentifierRoles
 from openforms.typing import JSONObject
 
 from .base import BaseExportSerializer, BaseImportSerializer
+
+logger = structlog.stdlib.get_logger(__name__)
 
 
 def clear_wms_tile_layers(representation: JSONObject):
@@ -95,3 +100,34 @@ class FormDefinitionImportSerializer(FormDefinitionSerializer, BaseImportSeriali
             cleanup=remove_prefill_from_component_configuration,
         ),
     )
+
+    def to_internal_value(self, instance):
+        value = instance.copy()
+
+        # @TODO this was AFTER validation. So maybe in a to_representation call?
+        self.apply_component_conversions(value["configuration"])
+        self.apply_definition_conversions(value["configuration"])
+
+        return super().to_internal_value(value)
+
+    def apply_component_conversions(self, configuration: JSONObject):
+        """
+        Apply the known formio component conversions to the entire form definition.
+        """
+        log = logger.bind(action="forms.apply_component_conversions")
+        for component in iter_components(configuration):
+            if not (component_type := component.get("type")):  # pragma: no cover
+                continue
+            if not (converters := CONVERTERS.get(component_type)):
+                continue
+            for identifier, apply_converter in converters.items():
+                log.debug(
+                    "apply_converter",
+                    component_type=component_type,
+                    identifier=identifier,
+                )
+                apply_converter(component)
+
+    def apply_definition_conversions(self, configuration: JSONObject):
+        for converter in DEFINITION_CONVERTERS:
+            converter(configuration)

--- a/src/openforms/import_export/serializers/form_definition.py
+++ b/src/openforms/import_export/serializers/form_definition.py
@@ -1,6 +1,8 @@
 from openforms.formio.utils import iter_components
 from openforms.forms.api.serializers import FormDefinitionSerializer
 from openforms.import_export.typing import (
+    AdditionalFormConfigurationCleanup,
+    AdditionalFormConfigurationOptions,
     FormConfigurationCleanup,
     FormConfigurationOptions,
 )
@@ -8,6 +10,24 @@ from openforms.prefill.constants import IdentifierRoles
 from openforms.typing import JSONObject
 
 from .base import BaseExportSerializer
+
+
+def clear_wms_tile_layers(representation: JSONObject):
+    for component in representation.get("configuration", {}).get("components", []):
+        if component["type"] != "map":
+            continue
+
+        for overlay in component.get("overlays", []):
+            overlay["uuid"] = ""
+            overlay["layers"] = []
+
+
+def clear_wmts_tile_layers(representation: JSONObject):
+    for component in representation.get("configuration", {}).get("components", []):
+        if component["type"] != "map" or "tileLayerIdentifier" not in component:
+            continue
+
+        component["tileLayerIdentifier"] = ""
 
 
 def remove_prefill_from_component_configuration(representation: JSONObject):
@@ -21,6 +41,16 @@ def remove_prefill_from_component_configuration(representation: JSONObject):
 
 class FormDefinitionExportSerializer(FormDefinitionSerializer, BaseExportSerializer):
     is_exporting = True
+    excluded_additional_form_configuration_cleanup = (
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.wms_tile_layers,
+            cleanup=clear_wms_tile_layers,
+        ),
+        AdditionalFormConfigurationCleanup(
+            option=AdditionalFormConfigurationOptions.wmts_tile_layers,
+            cleanup=clear_wmts_tile_layers,
+        ),
+    )
     excluded_form_configuration_cleanup = (
         FormConfigurationCleanup(
             option=FormConfigurationOptions.prefill,

--- a/src/openforms/import_export/serializers/form_definition.py
+++ b/src/openforms/import_export/serializers/form_definition.py
@@ -3,7 +3,7 @@ import structlog
 from openforms.formio.migration_converters import CONVERTERS, DEFINITION_CONVERTERS
 from openforms.formio.utils import iter_components
 from openforms.forms.api.serializers import FormDefinitionSerializer
-from openforms.forms.models import FormDefinition
+from openforms.forms.models import FormDefinition, Form
 from openforms.import_export.typing import (
     AdditionalFormConfigurationCleanup,
     AdditionalFormConfigurationOptions,
@@ -106,7 +106,9 @@ class FormDefinitionImportSerializer(FormDefinitionSerializer, BaseImportSeriali
 
     @staticmethod
     def resolve_instance(
-        value: JSONObject, import_options: FormImportOptions | None
+        value: JSONObject,
+        import_options: FormImportOptions | None,
+        existing_form_instance: Form | None,
     ) -> FormDefinition | None:
         if import_options is None:
             return None

--- a/src/openforms/import_export/serializers/form_logic.py
+++ b/src/openforms/import_export/serializers/form_logic.py
@@ -35,7 +35,14 @@ class FormLogicImportSerializer(FormLogicSerializer, BaseImportSerializer):
         if "order" not in value:
             value["order"] = 0
 
-        # @TODO this was AFTER validation. So maybe in a to_representation call?
+        if "service_fetch_configuration" in value:
+            # The transferring between systems case is very tricky
+            # better not import these, we don't know where this came from.
+            # services and ids may point to different things
+            # in different OF instances.
+            # @TODO should not happen by version restore
+            del value["service_fetch_configuration"]
+
         self.clear_old_service_fetch_config(value)
 
         return super().to_internal_value(value)
@@ -48,8 +55,8 @@ class FormLogicImportSerializer(FormLogicSerializer, BaseImportSerializer):
             if "value" not in action["action"] or action["action"]["value"] == "":
                 continue
 
-            # See comment above in `import_form_data` where we check if the variable has a
-            # `service_fetch_configuration` attribute.
+            # See comment in FormVariableImportSerializer `to_internal_value` where we
+            # check if the variable has a `service_fetch_configuration` attribute.
             # We can't reliably relate the service fetch configured to an existing configuration.
             # So we don't add any existing service fetch config to the variables
             action["action"]["value"] = ""

--- a/src/openforms/import_export/serializers/form_logic.py
+++ b/src/openforms/import_export/serializers/form_logic.py
@@ -1,4 +1,5 @@
 from openforms.forms.api.serializers import FormLogicSerializer
+from openforms.forms.constants import LogicActionTypes
 from openforms.import_export.serializers.base import (
     BaseExportSerializer,
     BaseImportSerializer,
@@ -34,4 +35,21 @@ class FormLogicImportSerializer(FormLogicSerializer, BaseImportSerializer):
         if "order" not in value:
             value["order"] = 0
 
+        # @TODO this was AFTER validation. So maybe in a to_representation call?
+        self.clear_old_service_fetch_config(value)
+
         return super().to_internal_value(value)
+
+    def clear_old_service_fetch_config(self, rule: dict) -> None:
+        for action in rule["actions"]:
+            if action["action"]["type"] != LogicActionTypes.fetch_from_service:
+                continue
+
+            if "value" not in action["action"] or action["action"]["value"] == "":
+                continue
+
+            # See comment above in `import_form_data` where we check if the variable has a
+            # `service_fetch_configuration` attribute.
+            # We can't reliably relate the service fetch configured to an existing configuration.
+            # So we don't add any existing service fetch config to the variables
+            action["action"]["value"] = ""

--- a/src/openforms/import_export/serializers/form_logic.py
+++ b/src/openforms/import_export/serializers/form_logic.py
@@ -1,0 +1,24 @@
+from openforms.forms.api.serializers import FormLogicSerializer
+from openforms.import_export.serializers.base import BaseExportSerializer
+
+
+class FormLogicExportSerializer(FormLogicSerializer, BaseExportSerializer):
+    def remove_sensitive_content(self, instance, representation):
+        representation = super().remove_sensitive_content(instance, representation)
+        form = instance.form
+
+        sensitive_variables = (
+            registration.options["to_emails_from_variable"]
+            for registration in form.registration_backends.all()
+            if registration.backend == "email"
+            and "to_emails_from_variable" in registration.options
+        )
+
+        for action in representation["actions"]:
+            if (
+                action["action"]["type"] == "variable"
+                and action["variable"] in sensitive_variables
+            ):
+                action["action"]["value"] = ""
+
+        return representation

--- a/src/openforms/import_export/serializers/form_logic.py
+++ b/src/openforms/import_export/serializers/form_logic.py
@@ -28,4 +28,10 @@ class FormLogicExportSerializer(FormLogicSerializer, BaseExportSerializer):
 
 
 class FormLogicImportSerializer(FormLogicSerializer, BaseImportSerializer):
-    pass
+    def to_internal_value(self, instance):
+        value = instance.copy()
+
+        if "order" not in value:
+            value["order"] = 0
+
+        return super().to_internal_value(value)

--- a/src/openforms/import_export/serializers/form_logic.py
+++ b/src/openforms/import_export/serializers/form_logic.py
@@ -1,5 +1,8 @@
 from openforms.forms.api.serializers import FormLogicSerializer
-from openforms.import_export.serializers.base import BaseExportSerializer
+from openforms.import_export.serializers.base import (
+    BaseExportSerializer,
+    BaseImportSerializer,
+)
 
 
 class FormLogicExportSerializer(FormLogicSerializer, BaseExportSerializer):
@@ -22,3 +25,7 @@ class FormLogicExportSerializer(FormLogicSerializer, BaseExportSerializer):
                 action["action"]["value"] = ""
 
         return representation
+
+
+class FormLogicImportSerializer(FormLogicSerializer, BaseImportSerializer):
+    pass

--- a/src/openforms/import_export/serializers/form_step.py
+++ b/src/openforms/import_export/serializers/form_step.py
@@ -1,6 +1,13 @@
 from openforms.forms.api.serializers import FormStepSerializer
-from openforms.import_export.serializers.base import BaseExportSerializer
+from openforms.import_export.serializers.base import (
+    BaseExportSerializer,
+    BaseImportSerializer,
+)
 
 
 class FormStepExportSerializer(FormStepSerializer, BaseExportSerializer):
+    pass
+
+
+class FormStepImportSerializer(FormStepSerializer, BaseImportSerializer):
     pass

--- a/src/openforms/import_export/serializers/form_step.py
+++ b/src/openforms/import_export/serializers/form_step.py
@@ -1,0 +1,6 @@
+from openforms.forms.api.serializers import FormStepSerializer
+from openforms.import_export.serializers.base import BaseExportSerializer
+
+
+class FormStepExportSerializer(FormStepSerializer, BaseExportSerializer):
+    pass

--- a/src/openforms/import_export/serializers/form_step.py
+++ b/src/openforms/import_export/serializers/form_step.py
@@ -1,4 +1,5 @@
 from openforms.forms.api.serializers import FormStepSerializer
+from openforms.forms.models import FormVariable
 from openforms.import_export.serializers.base import (
     BaseExportSerializer,
     BaseImportSerializer,
@@ -10,4 +11,10 @@ class FormStepExportSerializer(FormStepSerializer, BaseExportSerializer):
 
 
 class FormStepImportSerializer(FormStepSerializer, BaseImportSerializer):
-    pass
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+
+        if (form := self.context.get("form")) is not None:
+            # Once the form steps have been created, we create the component
+            # FormVariables based on the form definition configurations.
+            FormVariable.objects.create_for_form(form)

--- a/src/openforms/import_export/serializers/form_variable.py
+++ b/src/openforms/import_export/serializers/form_variable.py
@@ -1,9 +1,29 @@
 from openforms.forms.api.serializers import FormVariableSerializer
+from openforms.import_export.typing import (
+    FormConfigurationCleanup,
+    FormConfigurationOptions,
+)
+from openforms.prefill.constants import IdentifierRoles
+from openforms.typing import JSONObject
 
 from .base import BaseExportSerializer
 
 
+def remove_prefill_from_variable(representation: JSONObject):
+    representation["prefill_plugin"] = ""
+    representation["prefill_attribute"] = ""
+    representation["prefill_identifier_role"] = IdentifierRoles.main
+    representation["prefill_options"] = {}
+
+
 class FormVariableExportSerializer(FormVariableSerializer, BaseExportSerializer):
+    excluded_form_configuration_cleanup = (
+        FormConfigurationCleanup(
+            option=FormConfigurationOptions.prefill,
+            cleanup=remove_prefill_from_variable,
+        ),
+    )
+
     def remove_sensitive_content(self, instance, representation):
         representation = super().remove_sensitive_content(instance, representation)
         form = instance.form

--- a/src/openforms/import_export/serializers/form_variable.py
+++ b/src/openforms/import_export/serializers/form_variable.py
@@ -6,7 +6,7 @@ from openforms.import_export.typing import (
 from openforms.prefill.constants import IdentifierRoles
 from openforms.typing import JSONObject
 
-from .base import BaseExportSerializer
+from .base import BaseExportSerializer, BaseImportSerializer
 
 
 def remove_prefill_from_variable(representation: JSONObject):
@@ -39,3 +39,12 @@ class FormVariableExportSerializer(FormVariableSerializer, BaseExportSerializer)
                 return representation
 
         return representation
+
+
+class FormVariableImportSerializer(FormVariableSerializer, BaseImportSerializer):
+    excluded_form_configuration_removal = (
+        FormConfigurationCleanup(
+            option=FormConfigurationOptions.prefill,
+            cleanup=remove_prefill_from_variable,
+        ),
+    )

--- a/src/openforms/import_export/serializers/form_variable.py
+++ b/src/openforms/import_export/serializers/form_variable.py
@@ -1,0 +1,21 @@
+from openforms.forms.api.serializers import FormVariableSerializer
+
+from .base import BaseExportSerializer
+
+
+class FormVariableExportSerializer(FormVariableSerializer, BaseExportSerializer):
+    def remove_sensitive_content(self, instance, representation):
+        representation = super().remove_sensitive_content(instance, representation)
+        form = instance.form
+
+        for registration in form.registration_backends.all():
+            if (
+                registration.backend == "email"
+                and "to_emails_from_variable" in registration.options
+                and registration.options["to_emails_from_variable"]
+                == representation["key"]
+            ):
+                representation["initial_value"] = ""
+                return representation
+
+        return representation

--- a/src/openforms/import_export/serializers/form_variable.py
+++ b/src/openforms/import_export/serializers/form_variable.py
@@ -48,3 +48,16 @@ class FormVariableImportSerializer(FormVariableSerializer, BaseImportSerializer)
             cleanup=remove_prefill_from_variable,
         ),
     )
+
+    def to_internal_value(self, instance):
+        value = instance.copy()
+
+        if "service_fetch_configuration" in value:
+            # The transferring between systems case is very tricky
+            # better not import these, we don't know where this came from.
+            # services and ids may point to different things
+            # in different OF instances.
+            # @TODO should not happen by version restore
+            del value["service_fetch_configuration"]
+
+        return super().to_internal_value(value)

--- a/src/openforms/import_export/typing.py
+++ b/src/openforms/import_export/typing.py
@@ -51,6 +51,12 @@ class FormExportOptions:
 
 
 @dataclass(frozen=True)
+class AdditionalFormConfigurationCleanup:
+    option: AdditionalFormConfigurationOptions
+    cleanup: Callable[[JSONObject], None]
+
+
+@dataclass(frozen=True)
 class FormConfigurationCleanup:
     option: FormConfigurationOptions
     cleanup: Callable[[JSONObject], None]

--- a/src/openforms/import_export/typing.py
+++ b/src/openforms/import_export/typing.py
@@ -1,7 +1,10 @@
-from dataclasses import dataclass
+from collections.abc import Callable
+from dataclasses import dataclass, field
 
 from django.db import models
 from django.utils.translation import gettext_lazy as _
+
+from openforms.typing import JSONObject
 
 
 class FormConfigurationOptions(models.TextChoices):
@@ -45,3 +48,9 @@ class FormExportOptions:
     additional_form_configuration: list[AdditionalFormConfigurationOptions] = field(
         default_factory=list
     )
+
+
+@dataclass(frozen=True)
+class FormConfigurationCleanup:
+    option: FormConfigurationOptions
+    cleanup: Callable[[JSONObject], None]

--- a/src/openforms/import_export/typing.py
+++ b/src/openforms/import_export/typing.py
@@ -1,0 +1,47 @@
+from dataclasses import dataclass
+
+from django.db import models
+from django.utils.translation import gettext_lazy as _
+
+
+class FormConfigurationOptions(models.TextChoices):
+    registration_backends = "registrationBackends", _("Registration backends")
+    prefill = "prefill", _("Prefill")
+    payment_backend = "paymentBackend", _("Payment backend")
+    auth_backends = "authBackends", _("Authentication backends")
+
+
+EXPORT_FORM_CONFIGURATION_CHOICES: list[tuple[str, str]] = [
+    choice
+    for choice in FormConfigurationOptions.choices
+    if choice[0]
+    in {
+        FormConfigurationOptions.registration_backends,
+        FormConfigurationOptions.prefill,
+        FormConfigurationOptions.payment_backend,
+    }
+]
+
+
+class AdditionalFormConfigurationOptions(models.TextChoices):
+    product = "product", _("Product")
+    wms_tile_layers = "wmsTileLayers", _("WMS-tile layers")
+    wmts_tile_layers = "wmtsTileLayers", _("WMTS-tile layers")
+    yivi_attribute_groups = "yiviAttributeGroups", _("Yivi attribute groups")
+    theme = "theme", _("Theme")
+    category = "category", _("Category")
+
+
+@dataclass(slots=True)
+class FormExportOptions:
+    remove_sensitive_content: bool = True
+    form_configuration: list[EXPORT_FORM_CONFIGURATION_CHOICES] = field(
+        default_factory=lambda: [
+            FormConfigurationOptions.registration_backends,
+            FormConfigurationOptions.prefill,
+            FormConfigurationOptions.payment_backend,
+        ]
+    )
+    additional_form_configuration: list[AdditionalFormConfigurationOptions] = field(
+        default_factory=list
+    )

--- a/src/openforms/import_export/typing.py
+++ b/src/openforms/import_export/typing.py
@@ -35,6 +35,17 @@ class AdditionalFormConfigurationOptions(models.TextChoices):
     category = "category", _("Category")
 
 
+class ReusableFormDefinitionsOptions(models.TextChoices):
+    reuse_existing = "reuseExisting", _("Reuse existing form definitions")
+    create_new = "createNew", _("Create all new form definitions")
+
+
+class LinksToUnknownDomainsOptions(models.TextChoices):
+    ignore = "ignore", _("Keep links to unknown domains as-is")
+    remove = "remove", _("Remove the links to unknown domains")
+    accept = "accept", _("Accept all unknown domains")
+
+
 @dataclass(slots=True)
 class FormExportOptions:
     remove_sensitive_content: bool = True
@@ -44,6 +55,26 @@ class FormExportOptions:
             FormConfigurationOptions.prefill,
             FormConfigurationOptions.payment_backend,
         ]
+    )
+    additional_form_configuration: list[AdditionalFormConfigurationOptions] = field(
+        default_factory=list
+    )
+
+
+@dataclass(slots=True)
+class FormImportOptions:
+    form_configuration: list[FormConfigurationOptions] = field(
+        default_factory=lambda: [
+            FormConfigurationOptions.registration_backends,
+            FormConfigurationOptions.prefill,
+            FormConfigurationOptions.payment_backend,
+        ]
+    )
+    reusable_form_definitions: ReusableFormDefinitionsOptions = field(
+        default=ReusableFormDefinitionsOptions.create_new,
+    )
+    links_to_unknown_domains: LinksToUnknownDomainsOptions = field(
+        default=LinksToUnknownDomainsOptions.ignore,
     )
     additional_form_configuration: list[AdditionalFormConfigurationOptions] = field(
         default_factory=list

--- a/src/openforms/import_export/utils.py
+++ b/src/openforms/import_export/utils.py
@@ -1,0 +1,79 @@
+from dataclasses import dataclass
+
+from openforms.forms.models import Form
+from openforms.typing import JSONObject
+
+from .resources import (
+    BaseResource,
+    CategoryResource,
+    ProductResource,
+    ThemeResource,
+    WMSTileLayerResource,
+    WMTSTileLayerResource,
+    YiviAttributeGroupResource,
+)
+from .typing import AdditionalFormConfigurationOptions, FormExportOptions
+
+
+@dataclass(frozen=True)
+class ExportResourceConfig:
+    resource: type[BaseResource]
+    output_name: str
+
+
+ADDITIONAL_FORM_CONFIGURATION_RESOURCES: dict[
+    AdditionalFormConfigurationOptions,
+    ExportResourceConfig,
+] = {
+    AdditionalFormConfigurationOptions.product: ExportResourceConfig(
+        resource=ProductResource,
+        output_name="product",
+    ),
+    AdditionalFormConfigurationOptions.theme: ExportResourceConfig(
+        resource=ThemeResource,
+        output_name="theme",
+    ),
+    AdditionalFormConfigurationOptions.category: ExportResourceConfig(
+        resource=CategoryResource,
+        output_name="category",
+    ),
+    AdditionalFormConfigurationOptions.wms_tile_layers: ExportResourceConfig(
+        resource=WMSTileLayerResource,
+        output_name="wmsTileLayers",
+    ),
+    AdditionalFormConfigurationOptions.wmts_tile_layers: ExportResourceConfig(
+        resource=WMTSTileLayerResource,
+        output_name="wmtsTileLayers",
+    ),
+    AdditionalFormConfigurationOptions.yivi_attribute_groups: ExportResourceConfig(
+        resource=YiviAttributeGroupResource,
+        output_name="yiviAttributeGroups",
+    ),
+}
+
+
+def get_additional_form_configuration_data(
+    form: Form, export_options: FormExportOptions
+) -> JSONObject:
+    """
+    Create a dictionary of additional form configuration data for the given form.
+
+    The keys are the names for the export files, and the values are the JSON data
+    representing the resource data. This should be used in the form export process, in
+    connection with `remove_excluded_additional_configuration_from_form`.
+    """
+    resources = {}
+
+    selected_options = set(export_options.additional_form_configuration)
+    unknown_options = selected_options - set(ADDITIONAL_FORM_CONFIGURATION_RESOURCES)
+
+    if unknown_options:
+        raise ValueError(
+            f"Invalid additional form configuration option(s): {unknown_options}"
+        )
+
+    for option, config in ADDITIONAL_FORM_CONFIGURATION_RESOURCES.items():
+        if option in selected_options:
+            resources[config.output_name] = config.resource().export_for_form(form).json
+
+    return resources

--- a/src/openforms/import_export/utils.py
+++ b/src/openforms/import_export/utils.py
@@ -86,7 +86,9 @@ def get_additional_form_configuration_data(
 
 
 def import_additional_form_configuration_data(
-    resources: JSONObject, import_options: FormImportOptions
+    resources: JSONObject,
+    import_options: FormImportOptions,
+    uuid_mapping=dict[str, str],
 ):
     if import_options is None:
         return
@@ -101,5 +103,15 @@ def import_additional_form_configuration_data(
 
     for option, config in ADDITIONAL_FORM_CONFIGURATION_RESOURCES.items():
         if option in selected_options and config.output_name in resources:
-            dataset = tablib.Dataset(resources[config.output_name])
-            config.resource().import_data(dataset)
+            dataset = tablib.Dataset().load(resources[config.output_name], "json")
+            results = config.resource().import_data(dataset)
+
+            for row_result in results:
+                old_uuid = row_result.row_values.get("uuid")
+
+                if row_result.is_skip() and hasattr(row_result.original, "uuid"):
+                    uuid_mapping[old_uuid] = str(row_result.original.uuid)
+
+                elif row_result.is_new() and row_result.instance:
+                    if hasattr(row_result.instance, "uuid"):
+                        uuid_mapping[old_uuid] = str(row_result.instance.uuid)

--- a/src/openforms/import_export/utils.py
+++ b/src/openforms/import_export/utils.py
@@ -1,5 +1,7 @@
 from dataclasses import dataclass
 
+import tablib
+
 from openforms.forms.models import Form
 from openforms.typing import JSONObject
 
@@ -12,40 +14,44 @@ from .resources import (
     WMTSTileLayerResource,
     YiviAttributeGroupResource,
 )
-from .typing import AdditionalFormConfigurationOptions, FormExportOptions
+from .typing import (
+    AdditionalFormConfigurationOptions,
+    FormExportOptions,
+    FormImportOptions,
+)
 
 
 @dataclass(frozen=True)
-class ExportResourceConfig:
+class ResourceConfig:
     resource: type[BaseResource]
     output_name: str
 
 
 ADDITIONAL_FORM_CONFIGURATION_RESOURCES: dict[
     AdditionalFormConfigurationOptions,
-    ExportResourceConfig,
+    ResourceConfig,
 ] = {
-    AdditionalFormConfigurationOptions.product: ExportResourceConfig(
+    AdditionalFormConfigurationOptions.product: ResourceConfig(
         resource=ProductResource,
         output_name="product",
     ),
-    AdditionalFormConfigurationOptions.theme: ExportResourceConfig(
+    AdditionalFormConfigurationOptions.theme: ResourceConfig(
         resource=ThemeResource,
         output_name="theme",
     ),
-    AdditionalFormConfigurationOptions.category: ExportResourceConfig(
+    AdditionalFormConfigurationOptions.category: ResourceConfig(
         resource=CategoryResource,
         output_name="category",
     ),
-    AdditionalFormConfigurationOptions.wms_tile_layers: ExportResourceConfig(
+    AdditionalFormConfigurationOptions.wms_tile_layers: ResourceConfig(
         resource=WMSTileLayerResource,
         output_name="wmsTileLayers",
     ),
-    AdditionalFormConfigurationOptions.wmts_tile_layers: ExportResourceConfig(
+    AdditionalFormConfigurationOptions.wmts_tile_layers: ResourceConfig(
         resource=WMTSTileLayerResource,
         output_name="wmtsTileLayers",
     ),
-    AdditionalFormConfigurationOptions.yivi_attribute_groups: ExportResourceConfig(
+    AdditionalFormConfigurationOptions.yivi_attribute_groups: ResourceConfig(
         resource=YiviAttributeGroupResource,
         output_name="yiviAttributeGroups",
     ),
@@ -77,3 +83,23 @@ def get_additional_form_configuration_data(
             resources[config.output_name] = config.resource().export_for_form(form).json
 
     return resources
+
+
+def import_additional_form_configuration_data(
+    resources: JSONObject, import_options: FormImportOptions
+):
+    if import_options is None:
+        return
+
+    selected_options = set(import_options.additional_form_configuration)
+    unknown_options = selected_options - set(ADDITIONAL_FORM_CONFIGURATION_RESOURCES)
+
+    if unknown_options:
+        raise ValueError(
+            f"Invalid additional form configuration option(s): {unknown_options}"
+        )
+
+    for option, config in ADDITIONAL_FORM_CONFIGURATION_RESOURCES.items():
+        if option in selected_options and config.output_name in resources:
+            dataset = tablib.Dataset(resources[config.output_name])
+            config.resource().import_data(dataset)

--- a/src/openforms/js/compiled-lang/en.json
+++ b/src/openforms/js/compiled-lang/en.json
@@ -87,6 +87,12 @@
       "value": "Mark the form step as applicable"
     }
   ],
+  "/GRLBW": [
+    {
+      "type": 0,
+      "value": "Export file content"
+    }
+  ],
   "/XbK4W": [
     {
       "type": 0,
@@ -175,6 +181,12 @@
     {
       "type": 0,
       "value": "Receives confirmation email"
+    }
+  ],
+  "0PB1XV": [
+    {
+      "type": 0,
+      "value": "WMS tile layers"
     }
   ],
   "0PhQl9": [
@@ -283,6 +295,12 @@
     {
       "type": 0,
       "value": "The 'rsin' attribute for the Catalogus resource in the Catalogi API."
+    }
+  ],
+  "1cMfAA": [
+    {
+      "type": 0,
+      "value": "Product"
     }
   ],
   "1fD+K4": [
@@ -1961,6 +1979,12 @@
       "value": "Button labels"
     }
   ],
+  "E3pztQ": [
+    {
+      "type": 0,
+      "value": "Whether sensative form configuration should be anonymized during exporting."
+    }
+  ],
   "E5FZz/": [
     {
       "type": 0,
@@ -2363,6 +2387,12 @@
       "value": "Derive city"
     }
   ],
+  "H51Ms+": [
+    {
+      "type": 0,
+      "value": "Export form"
+    }
+  ],
   "H6VxhG": [
     {
       "type": 0,
@@ -2403,6 +2433,12 @@
     {
       "type": 0,
       "value": "Amount of days errored submissions of this form will remain before being removed. Leave blank to use value in General Configuration."
+    }
+  ],
+  "HKwvbG": [
+    {
+      "type": 0,
+      "value": "Which form configuration should be included in the export file content."
     }
   ],
   "HNoGb8": [
@@ -3107,6 +3143,12 @@
       "value": "Overlays"
     }
   ],
+  "OH+T6k": [
+    {
+      "type": 0,
+      "value": "Payment provider"
+    }
+  ],
   "OX8wxE": [
     {
       "type": 0,
@@ -3119,6 +3161,12 @@
     {
       "type": 0,
       "value": ". Extend your session if you wish to continue."
+    }
+  ],
+  "OaS7Pf": [
+    {
+      "type": 0,
+      "value": "Export options"
     }
   ],
   "OaeVI8": [
@@ -3507,6 +3555,12 @@
       "value": "When this is checked, the filetypes configured in the global settings will be used."
     }
   ],
+  "S2Wv2u": [
+    {
+      "type": 0,
+      "value": "Form configuration"
+    }
+  ],
   "S4Lvvs": [
     {
       "type": 0,
@@ -3877,6 +3931,12 @@
     {
       "type": 0,
       "value": "File"
+    }
+  ],
+  "V072C5": [
+    {
+      "type": 0,
+      "value": "Category"
     }
   ],
   "V6ClU9": [
@@ -4281,6 +4341,12 @@
       "value": "Content of the registration email message (as html)."
     }
   ],
+  "Z4/E9e": [
+    {
+      "type": 0,
+      "value": "Authentication backends"
+    }
+  ],
   "Z8f4hI": [
     {
       "type": 0,
@@ -4379,6 +4445,12 @@
     {
       "type": 0,
       "value": "The processing (\"verwerking\") for queries to the BRP Persoon API."
+    }
+  ],
+  "ZRv5W+": [
+    {
+      "type": 0,
+      "value": "WMTS tile layers"
     }
   ],
   "ZYWsHs": [
@@ -5113,6 +5185,12 @@
       "value": "Loading..."
     }
   ],
+  "eBHgYL": [
+    {
+      "type": 0,
+      "value": "Additional form configuration"
+    }
+  ],
   "eC2etA": [
     {
       "type": 0,
@@ -5147,6 +5225,12 @@
     {
       "type": 0,
       "value": "'Save row' text"
+    }
+  ],
+  "eVpjb6": [
+    {
+      "type": 0,
+      "value": "Anonymize form configuration"
     }
   ],
   "ee4oWr": [
@@ -5631,6 +5715,12 @@
       "value": "Label"
     }
   ],
+  "iAFlLD": [
+    {
+      "type": 0,
+      "value": "Registration backends"
+    }
+  ],
   "iNmPDd": [
     {
       "type": 0,
@@ -6029,6 +6119,12 @@
       "value": "Value"
     }
   ],
+  "lIwiA/": [
+    {
+      "type": 0,
+      "value": "Prefill"
+    }
+  ],
   "lKijv2": [
     {
       "type": 0,
@@ -6251,6 +6347,12 @@
     {
       "type": 0,
       "value": "The sum of column sizes may not exceed 12."
+    }
+  ],
+  "n55FhL": [
+    {
+      "type": 0,
+      "value": "Security"
     }
   ],
   "n9T2Oy": [
@@ -7217,6 +7319,12 @@
       "value": "History"
     }
   ],
+  "um9Dtq": [
+    {
+      "type": 0,
+      "value": "Theme"
+    }
+  ],
   "unjdIB": [
     {
       "type": 0,
@@ -7351,6 +7459,12 @@
       "value": "Specify the attribute holding the pre-fill data."
     }
   ],
+  "w2UNV6": [
+    {
+      "type": 0,
+      "value": "Yivi attribute groups"
+    }
+  ],
   "w4e4jx": [
     {
       "type": 0,
@@ -7427,6 +7541,12 @@
     {
       "type": 0,
       "value": "API group"
+    }
+  ],
+  "wdvWi/": [
+    {
+      "type": 0,
+      "value": "Which additional form configuration should be included in the export file content."
     }
   ],
   "wnTTZr": [

--- a/src/openforms/js/compiled-lang/nl.json
+++ b/src/openforms/js/compiled-lang/nl.json
@@ -87,6 +87,12 @@
       "value": "markeer de formulierstap als van toepassing"
     }
   ],
+  "/GRLBW": [
+    {
+      "type": 0,
+      "value": "Inhoud van het exportbestand"
+    }
+  ],
   "/XbK4W": [
     {
       "type": 0,
@@ -175,6 +181,12 @@
     {
       "type": 0,
       "value": "Ontvangt bevestigingsmail"
+    }
+  ],
+  "0PB1XV": [
+    {
+      "type": 0,
+      "value": "WMS-kaartlagen"
     }
   ],
   "0PhQl9": [
@@ -283,6 +295,12 @@
     {
       "type": 0,
       "value": "Het 'rsin'-attribuut van de catalogus-entiteit in de Catalogi API."
+    }
+  ],
+  "1cMfAA": [
+    {
+      "type": 0,
+      "value": "Product"
     }
   ],
   "1fD+K4": [
@@ -1948,6 +1966,12 @@
       "value": "Knopteksten"
     }
   ],
+  "E3pztQ": [
+    {
+      "type": 0,
+      "value": "Anonimiseer gevoelige formulierinstellingen bij het exporteren."
+    }
+  ],
   "E5FZz/": [
     {
       "type": 0,
@@ -2350,6 +2374,12 @@
       "value": "Stad afleiden"
     }
   ],
+  "H51Ms+": [
+    {
+      "type": 0,
+      "value": "Formulier exporteren"
+    }
+  ],
   "H6VxhG": [
     {
       "type": 0,
@@ -2390,6 +2420,12 @@
     {
       "type": 0,
       "value": "Aantal dagen dat een niet voltooide inzendingen (door fouten in de afhandeling) bewaard blijft. Laat leeg om de waarde van de algemene configuratie te gebruiken."
+    }
+  ],
+  "HKwvbG": [
+    {
+      "type": 0,
+      "value": "Welke formulierinstellingen mee geëxporteerd worden."
     }
   ],
   "HNoGb8": [
@@ -3094,6 +3130,12 @@
       "value": "Kaartlagen"
     }
   ],
+  "OH+T6k": [
+    {
+      "type": 0,
+      "value": "Betaalprovider"
+    }
+  ],
   "OX8wxE": [
     {
       "type": 0,
@@ -3106,6 +3148,12 @@
     {
       "type": 0,
       "value": ". Verleng uw sessie indien u wenst door te gaan."
+    }
+  ],
+  "OaS7Pf": [
+    {
+      "type": 0,
+      "value": "Formulier exportopties"
     }
   ],
   "OaeVI8": [
@@ -3490,6 +3538,12 @@
       "value": "Indien ingeschakeld, gebruik dan de algemene instellingen voor toegestane bestandstypen."
     }
   ],
+  "S2Wv2u": [
+    {
+      "type": 0,
+      "value": "Formulierinstellingen"
+    }
+  ],
   "S4Lvvs": [
     {
       "type": 0,
@@ -3860,6 +3914,12 @@
     {
       "type": 0,
       "value": "Bestand"
+    }
+  ],
+  "V072C5": [
+    {
+      "type": 0,
+      "value": "Categorie"
     }
   ],
   "V6ClU9": [
@@ -4264,6 +4324,12 @@
       "value": "Inhoud van de registratiemail (HTML)."
     }
   ],
+  "Z4/E9e": [
+    {
+      "type": 0,
+      "value": "Authenticatie plugins"
+    }
+  ],
   "Z8f4hI": [
     {
       "type": 0,
@@ -4363,6 +4429,12 @@
     {
       "type": 0,
       "value": "De waarde voor \"verwerking\" die meegestuurd wordt bij het bevragen van de BRP Personen API. Mogelijke waarden hiervoor zijn afhankelijk van je gateway-leverancier."
+    }
+  ],
+  "ZRv5W+": [
+    {
+      "type": 0,
+      "value": "WMTS-kaartlagen"
     }
   ],
   "ZYWsHs": [
@@ -5101,6 +5173,12 @@
       "value": "Aan het laden..."
     }
   ],
+  "eBHgYL": [
+    {
+      "type": 0,
+      "value": "Aanvullende formulierinstellingen"
+    }
+  ],
   "eC2etA": [
     {
       "type": 0,
@@ -5135,6 +5213,12 @@
     {
       "type": 0,
       "value": "'Groep bewaren'-tekst"
+    }
+  ],
+  "eVpjb6": [
+    {
+      "type": 0,
+      "value": "Anonimiseer formulierinstellingen"
     }
   ],
   "ee4oWr": [
@@ -5619,6 +5703,12 @@
       "value": "Label"
     }
   ],
+  "iAFlLD": [
+    {
+      "type": 0,
+      "value": "Registratie backends"
+    }
+  ],
   "iNmPDd": [
     {
       "type": 0,
@@ -6017,6 +6107,12 @@
       "value": "Waarde"
     }
   ],
+  "lIwiA/": [
+    {
+      "type": 0,
+      "value": "Prefill"
+    }
+  ],
   "lKijv2": [
     {
       "type": 0,
@@ -6239,6 +6335,12 @@
     {
       "type": 0,
       "value": "De som van de kolombreedtes mag niet meer dan 12 zijn."
+    }
+  ],
+  "n55FhL": [
+    {
+      "type": 0,
+      "value": "Beveiliging"
     }
   ],
   "n9T2Oy": [
@@ -7201,6 +7303,12 @@
       "value": "Geschiedenis"
     }
   ],
+  "um9Dtq": [
+    {
+      "type": 0,
+      "value": "Thema"
+    }
+  ],
   "unjdIB": [
     {
       "type": 0,
@@ -7335,6 +7443,12 @@
       "value": "Geef het attribuut op wat de prefill-gegevens bevat."
     }
   ],
+  "w2UNV6": [
+    {
+      "type": 0,
+      "value": "Yivi attribuut groepen"
+    }
+  ],
   "w4e4jx": [
     {
       "type": 0,
@@ -7411,6 +7525,12 @@
     {
       "type": 0,
       "value": "API-groep"
+    }
+  ],
+  "wdvWi/": [
+    {
+      "type": 0,
+      "value": "Welke aanvullende formulierinstellingen mee geëxporteerd worden."
     }
   ],
   "wnTTZr": [

--- a/src/openforms/js/components/admin/form_design/FormSubmit.js
+++ b/src/openforms/js/components/admin/form_design/FormSubmit.js
@@ -1,9 +1,11 @@
 import PropTypes from 'prop-types';
-import React from 'react';
+import React, {useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
 
 import ActionButton from 'components/admin/forms/ActionButton';
 import SubmitRow from 'components/admin/forms/SubmitRow';
+import ExportOptionsModal from 'components/admin/import_export/ExportOptionsModal';
+import {serializeExportOptions} from 'components/admin/import_export/utils';
 
 const CopyAction = () => {
   const intl = useIntl();
@@ -19,6 +21,10 @@ const CopyAction = () => {
 };
 
 const ExportAction = () => {
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const exportButtonRef = useRef(null);
+  const exportOptionsRef = useRef(null);
+
   const intl = useIntl();
   const btnText = intl.formatMessage({
     defaultMessage: 'Export',
@@ -28,7 +34,27 @@ const ExportAction = () => {
     defaultMessage: 'Export this form',
     description: 'Export form button title',
   });
-  return <ActionButton name="_export" text={btnText} title={btnTitle} />;
+
+  return (
+    <>
+      <input ref={exportButtonRef} type="submit" name="_export" hidden />
+      <input ref={exportOptionsRef} type="hidden" name="export_options" />
+      <ActionButton
+        text={btnText}
+        title={btnTitle}
+        type="button"
+        onClick={() => setIsModalOpen(true)}
+      />
+      <ExportOptionsModal
+        isOpen={isModalOpen}
+        onSubmit={exportOptions => {
+          exportOptionsRef.current.value = JSON.stringify(serializeExportOptions(exportOptions));
+          exportButtonRef.current.click();
+        }}
+        onCloseModal={() => setIsModalOpen(false)}
+      />
+    </>
+  );
 };
 
 const FormSubmit = ({onSubmit, displayActions = false}) => (

--- a/src/openforms/js/components/admin/import_export/AdditionalFormConfigurationField.js
+++ b/src/openforms/js/components/admin/import_export/AdditionalFormConfigurationField.js
@@ -1,0 +1,86 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedMessage, defineMessages} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import {Checkbox} from 'components/admin/forms/Inputs';
+
+export const FIELD_LABELS = defineMessages({
+  product: {
+    description: 'Label for additionalFormConfiguration product input',
+    defaultMessage: 'Product',
+  },
+  wmsTileLayers: {
+    description: 'Label for additionalFormConfiguration wmsTileLayers input',
+    defaultMessage: 'WMS tile layers',
+  },
+  wmtsTileLayers: {
+    description: 'Label for additionalFormConfiguration wmtsTileLayers input',
+    defaultMessage: 'WMTS tile layers',
+  },
+  yiviAttributeGroups: {
+    description: 'Label for additionalFormConfiguration yiviAttributeGroups input',
+    defaultMessage: 'Yivi attribute groups',
+  },
+  theme: {
+    description: 'Label for additionalFormConfiguration theme input',
+    defaultMessage: 'Theme',
+  },
+  category: {
+    description: 'Label for additionalFormConfiguration category input',
+    defaultMessage: 'Category',
+  },
+});
+
+const AdditionalFormConfigurationField = ({selectedAdditionalFormConfiguration, onChange}) => {
+  const options = [
+    'product',
+    'wmsTileLayers',
+    'wmtsTileLayers',
+    'yiviAttributeGroups',
+    'theme',
+    'category',
+  ];
+
+  return (
+    <Field
+      name="additionalFormConfiguration"
+      label={
+        <FormattedMessage
+          defaultMessage="Additional form configuration"
+          description="Form import/export options 'additionalFormConfiguration' field label"
+        />
+      }
+      helpText={
+        <FormattedMessage
+          defaultMessage="Which additional form configuration should be included in the export file content."
+          description="Form import/export options 'additionalFormConfiguration' field help text"
+        />
+      }
+    >
+      <ul>
+        {options.map(option => (
+          <li key={option}>
+            <Checkbox
+              name={option}
+              value={option}
+              label={
+                option in FIELD_LABELS ? <FormattedMessage {...FIELD_LABELS[option]} /> : option
+              }
+              onChange={onChange}
+              checked={selectedAdditionalFormConfiguration.includes(option)}
+              noVCheckbox
+            />
+          </li>
+        ))}
+      </ul>
+    </Field>
+  );
+};
+
+AdditionalFormConfigurationField.prototype = {
+  onChange: PropTypes.func,
+  selectedAdditionalFormConfiguration: PropTypes.arrayOf(PropTypes.string).isRequired,
+};
+
+export default AdditionalFormConfigurationField;

--- a/src/openforms/js/components/admin/import_export/ExportOptionsModal.js
+++ b/src/openforms/js/components/admin/import_export/ExportOptionsModal.js
@@ -1,0 +1,125 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedMessage, useIntl} from 'react-intl';
+import {useImmer} from 'use-immer';
+
+import {SubmitAction} from 'components/admin/forms/ActionButton';
+import Fieldset from 'components/admin/forms/Fieldset';
+import FormRow from 'components/admin/forms/FormRow';
+import SubmitRow from 'components/admin/forms/SubmitRow';
+import {FormModal} from 'components/admin/modals';
+
+import AdditionalFormConfigurationField from './AdditionalFormConfigurationField';
+import FormConfigurationField from './FormConfigurationField';
+import RemoveSensitiveContentField from './RemoveSensitiveContentField';
+
+const ExportOptionsModal = ({isOpen, onSubmit, onCloseModal}) => {
+  const intl = useIntl();
+  const [exportOptions, setExportOptions] = useImmer({
+    removeSensitiveContent: true,
+    formConfiguration: ['registrationBackends', 'prefill', 'paymentBackend'],
+    additionalFormConfiguration: [],
+  });
+
+  return (
+    <FormModal
+      isOpen={isOpen}
+      title={
+        <FormattedMessage
+          defaultMessage="Export options"
+          description="Form export options modal title"
+        />
+      }
+      closeModal={onCloseModal}
+      onFormSubmit={event => {
+        event.preventDefault();
+        onSubmit(exportOptions);
+        onCloseModal();
+      }}
+      extraModifiers={['large']}
+    >
+      <Fieldset
+        title={
+          <FormattedMessage
+            defaultMessage="Security"
+            description="Form export 'security' options fieldset title"
+          />
+        }
+      >
+        <FormRow>
+          <RemoveSensitiveContentField
+            value={exportOptions.removeSensitiveContent}
+            onChange={e => {
+              setExportOptions(draft => {
+                draft.removeSensitiveContent = e.target.value;
+              });
+            }}
+          />
+        </FormRow>
+      </Fieldset>
+      <Fieldset
+        title={
+          <FormattedMessage
+            defaultMessage="Export file content"
+            description="Form export 'export file content' options fieldset title"
+          />
+        }
+      >
+        <FormRow>
+          <FormConfigurationField
+            selectedFormConfiguration={exportOptions.formConfiguration}
+            availableFormConfiguration={['registrationBackends', 'prefill', 'paymentBackend']}
+            onChange={e =>
+              setExportOptions(draft => {
+                const value = e.target.value;
+
+                if (draft.formConfiguration.includes(value)) {
+                  draft.formConfiguration = draft.formConfiguration.filter(
+                    option => option !== value
+                  );
+                } else {
+                  draft.formConfiguration.push(value);
+                }
+              })
+            }
+          />
+        </FormRow>
+        <FormRow>
+          <AdditionalFormConfigurationField
+            selectedAdditionalFormConfiguration={exportOptions.additionalFormConfiguration}
+            onChange={e =>
+              setExportOptions(draft => {
+                const value = e.target.value;
+
+                if (draft.additionalFormConfiguration.includes(value)) {
+                  draft.additionalFormConfiguration = draft.additionalFormConfiguration.filter(
+                    option => option !== value
+                  );
+                } else {
+                  draft.additionalFormConfiguration.push(value);
+                }
+              })
+            }
+          />
+        </FormRow>
+      </Fieldset>
+
+      <SubmitRow isDefault>
+        <SubmitAction
+          text={intl.formatMessage({
+            defaultMessage: 'Export form',
+            description: 'Form export options modal submit button text',
+          })}
+        />
+      </SubmitRow>
+    </FormModal>
+  );
+};
+
+ExportOptionsModal.prototype = {
+  isOpen: PropTypes.bool.isRequired,
+  onSubmit: PropTypes.func.isRequired,
+  onCloseModal: PropTypes.func.isRequired,
+};
+
+export default ExportOptionsModal;

--- a/src/openforms/js/components/admin/import_export/ExportOptionsModal.stories.js
+++ b/src/openforms/js/components/admin/import_export/ExportOptionsModal.stories.js
@@ -1,0 +1,78 @@
+import {expect, fn, userEvent, within} from 'storybook/test';
+
+import ExportOptionsModal from './ExportOptionsModal';
+
+export default {
+  title: 'Admin / Form import & export / ExportOptionsModal',
+  component: ExportOptionsModal,
+  args: {
+    isOpen: true,
+    onCloseModal: fn(),
+  },
+};
+
+export const Default = {
+  play: async ({canvasElement, step, args}) => {
+    const canvas = within(canvasElement);
+
+    const sensitiveContentField = canvas.getByLabelText('Anonimiseer formulierinstellingen');
+
+    const registrationBackendsInput = canvas.getByLabelText('Registratie backends');
+    const prefillInput = canvas.getByLabelText('Prefill');
+    const paymentBackendInput = canvas.getByLabelText('Betaalprovider');
+
+    const productInput = canvas.getByLabelText('Product');
+    const wmsTileLayersInput = canvas.getByLabelText('WMS-kaartlagen');
+    const wmtsTileLayersInput = canvas.getByLabelText('WMTS-kaartlagen');
+    const yiviAttributeGroupsInput = canvas.getByLabelText('Yivi attribuut groepen');
+    const themeInput = canvas.getByLabelText('Thema');
+    const categoryInput = canvas.getByLabelText('Categorie');
+
+    step('Initial state', () => {
+      // All inputs should be visible
+      expect(sensitiveContentField).toBeVisible();
+
+      expect(registrationBackendsInput).toBeVisible();
+      expect(prefillInput).toBeVisible();
+      expect(paymentBackendInput).toBeVisible();
+
+      expect(productInput).toBeVisible();
+      expect(wmsTileLayersInput).toBeVisible();
+      expect(wmtsTileLayersInput).toBeVisible();
+      expect(yiviAttributeGroupsInput).toBeVisible();
+      expect(themeInput).toBeVisible();
+      expect(categoryInput).toBeVisible();
+
+      // The sensitive content field and form data inputs should be checked
+      expect(sensitiveContentField).toBeChecked();
+      expect(registrationBackendsInput).toBeChecked();
+      expect(prefillInput).toBeChecked();
+      expect(paymentBackendInput).toBeChecked();
+
+      // The additional form data inputs should be unchecked
+      expect(productInput).not.toBeChecked();
+      expect(wmsTileLayersInput).not.toBeChecked();
+      expect(wmtsTileLayersInput).not.toBeChecked();
+      expect(yiviAttributeGroupsInput).not.toBeChecked();
+      expect(themeInput).not.toBeChecked();
+      expect(categoryInput).not.toBeChecked();
+    });
+
+    await step('Make selection state', async () => {
+      await userEvent.click(sensitiveContentField);
+      expect(sensitiveContentField).not.toBeChecked();
+
+      await userEvent.click(registrationBackendsInput);
+      await userEvent.click(paymentBackendInput);
+      expect(registrationBackendsInput).not.toBeChecked();
+      expect(paymentBackendInput).not.toBeChecked();
+
+      await userEvent.click(wmsTileLayersInput);
+      await userEvent.click(wmtsTileLayersInput);
+      await userEvent.click(yiviAttributeGroupsInput);
+      expect(wmsTileLayersInput).toBeChecked();
+      expect(wmtsTileLayersInput).toBeChecked();
+      expect(yiviAttributeGroupsInput).toBeChecked();
+    });
+  },
+};

--- a/src/openforms/js/components/admin/import_export/FormConfigurationField.js
+++ b/src/openforms/js/components/admin/import_export/FormConfigurationField.js
@@ -1,0 +1,78 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedMessage, defineMessages} from 'react-intl';
+
+import Field from 'components/admin/forms/Field';
+import {Checkbox} from 'components/admin/forms/Inputs';
+
+export const FIELD_LABELS = defineMessages({
+  registrationBackends: {
+    description: 'Label for formConfiguration registrationBackends input',
+    defaultMessage: 'Registration backends',
+  },
+  prefill: {
+    description: 'Label for formConfiguration prefill input',
+    defaultMessage: 'Prefill',
+  },
+  paymentBackend: {
+    description: 'Label for formConfiguration paymentBackend input',
+    defaultMessage: 'Payment provider',
+  },
+  authBackends: {
+    description: 'Label for formConfiguration authBackends input',
+    defaultMessage: 'Authentication backends',
+  },
+});
+
+const FormConfigurationField = ({
+  selectedFormConfiguration,
+  availableFormConfiguration,
+  onChange,
+}) => {
+  return (
+    <Field
+      name="formConfiguration"
+      label={
+        <FormattedMessage
+          defaultMessage="Form configuration"
+          description="Form import/export options 'formConfiguration' field label"
+        />
+      }
+      helpText={
+        <FormattedMessage
+          defaultMessage="Which form configuration should be included in the export file content."
+          description="Form import/export options 'formConfiguration' field help text"
+        />
+      }
+    >
+      <ul>
+        {availableFormConfiguration.map(option => (
+          <li key={option}>
+            <Checkbox
+              name={option}
+              value={option}
+              label={
+                option in FIELD_LABELS ? <FormattedMessage {...FIELD_LABELS[option]} /> : option
+              }
+              onChange={onChange}
+              checked={selectedFormConfiguration.includes(option)}
+              noVCheckbox
+            />
+          </li>
+        ))}
+      </ul>
+    </Field>
+  );
+};
+
+FormConfigurationField.prototype = {
+  onChange: PropTypes.func,
+  selectedFormConfiguration: PropTypes.arrayOf(
+    PropTypes.oneOf(['registrationBackends', 'prefill', 'paymentBackend', 'authBackends'])
+  ).isRequired,
+  availableFormConfiguration: PropTypes.arrayOf(
+    PropTypes.oneOf(['registrationBackends', 'prefill', 'paymentBackend', 'authBackends'])
+  ).isRequired,
+};
+
+export default FormConfigurationField;

--- a/src/openforms/js/components/admin/import_export/RemoveSensitiveContentField.js
+++ b/src/openforms/js/components/admin/import_export/RemoveSensitiveContentField.js
@@ -1,0 +1,32 @@
+import PropTypes from 'prop-types';
+import React from 'react';
+import {FormattedMessage} from 'react-intl';
+
+import {Checkbox} from 'components/admin/forms/Inputs';
+
+const RemoveSensitiveContentField = ({value, onChange}) => (
+  <Checkbox
+    name="removeSensitiveContent"
+    label={
+      <FormattedMessage
+        defaultMessage="Anonymize form configuration"
+        description="Form export options 'removeSensitiveContent' field label"
+      />
+    }
+    helpText={
+      <FormattedMessage
+        defaultMessage="Whether sensative form configuration should be anonymized during exporting."
+        description="Form export options 'removeSensitiveContent' help text"
+      />
+    }
+    checked={value}
+    onChange={() => onChange({target: {name: 'removeSensitiveContent', value: !value}})}
+  />
+);
+
+RemoveSensitiveContentField.prototype = {
+  value: PropTypes.bool,
+  onChange: PropTypes.func,
+};
+
+export default RemoveSensitiveContentField;

--- a/src/openforms/js/components/admin/import_export/utils.js
+++ b/src/openforms/js/components/admin/import_export/utils.js
@@ -1,0 +1,8 @@
+/**
+ * Convert camelCase export options to snake_case, for API compatibility.
+ */
+export const serializeExportOptions = exportOptions => ({
+  remove_sensitive_content: exportOptions.removeSensitiveContent,
+  form_configuration: exportOptions.formConfiguration,
+  additional_form_configuration: exportOptions.additionalFormConfiguration,
+});

--- a/src/openforms/js/lang/en.json
+++ b/src/openforms/js/lang/en.json
@@ -44,6 +44,11 @@
     "description": "action type \"step-applicable\" label",
     "originalDefault": "Mark the form step as applicable"
   },
+  "/GRLBW": {
+    "defaultMessage": "Export file content",
+    "description": "Form export 'export file content' options fieldset title",
+    "originalDefault": "Export file content"
+  },
   "/fAEsY": {
     "defaultMessage": "Submission report CSV informatieobjecttype",
     "description": "Objects API registration options \"Submission report CSV informatieobjecttype\" label",
@@ -68,6 +73,11 @@
     "defaultMessage": "DMN variable",
     "description": "DMN variable label",
     "originalDefault": "DMN variable"
+  },
+  "0PB1XV": {
+    "defaultMessage": "WMS tile layers",
+    "description": "Label for additionalFormConfiguration wmsTileLayers input",
+    "originalDefault": "WMS tile layers"
   },
   "0PhQl9": {
     "defaultMessage": "If enabled, any deceased children will be displayed too.",
@@ -113,6 +123,11 @@
     "defaultMessage": "Configure options",
     "description": "Link label to open registration options modal",
     "originalDefault": "Configure options"
+  },
+  "1cMfAA": {
+    "defaultMessage": "Product",
+    "description": "Label for additionalFormConfiguration product input",
+    "originalDefault": "Product"
   },
   "1fD+K4": {
     "defaultMessage": "Incomplete Submissions Removal Method",
@@ -869,6 +884,11 @@
     "description": "Objects API registration: uploadSubmissionCsv helpText",
     "originalDefault": "Indicates whether or not the submission CSV should be uploaded as a Document in Documenten API and attached to the product request."
   },
+  "E3pztQ": {
+    "defaultMessage": "Whether sensative form configuration should be anonymized during exporting.",
+    "description": "Form export options 'removeSensitiveContent' help text",
+    "originalDefault": "Whether sensative form configuration should be anonymized during exporting."
+  },
   "EDwCbX": {
     "defaultMessage": "<code>{componentKey}</code>: in {numSteps, plural, =1 {{tail}} other {{lead} and {tail}} }",
     "description": "Description of which key is duplicated in which steps.",
@@ -1069,6 +1089,11 @@
     "description": "StUF-ZDS registration variablesMapping label",
     "originalDefault": "Variables mapping (case)"
   },
+  "H51Ms+": {
+    "defaultMessage": "Export form",
+    "description": "Form export options modal submit button text",
+    "originalDefault": "Export form"
+  },
   "H6VxhG": {
     "defaultMessage": "Maintenance mode",
     "description": "Form maintenance mode field label",
@@ -1098,6 +1123,11 @@
     "defaultMessage": "Amount of days errored submissions of this form will remain before being removed. Leave blank to use value in General Configuration.",
     "description": "Errored Submissions Removal Limit help text",
     "originalDefault": "Amount of days errored submissions of this form will remain before being removed. Leave blank to use value in General Configuration."
+  },
+  "HKwvbG": {
+    "defaultMessage": "Which form configuration should be included in the export file content.",
+    "description": "Form import/export options 'formConfiguration' field help text",
+    "originalDefault": "Which form configuration should be included in the export file content."
   },
   "HVG1xy": {
     "defaultMessage": "Cosign content",
@@ -1519,10 +1549,20 @@
     "description": "Form registration options tab title",
     "originalDefault": "Registration"
   },
+  "OH+T6k": {
+    "defaultMessage": "Payment provider",
+    "description": "Label for formConfiguration paymentBackend input",
+    "originalDefault": "Payment provider"
+  },
   "OX8wxE": {
     "defaultMessage": "Your session is about to expire {delta}. Extend your session if you wish to continue.",
     "description": "Session expiry warning (in modal)",
     "originalDefault": "Your session is about to expire {delta}. Extend your session if you wish to continue."
+  },
+  "OaS7Pf": {
+    "defaultMessage": "Export options",
+    "description": "Form export options modal title",
+    "originalDefault": "Export options"
   },
   "Od+jm6": {
     "defaultMessage": "Values:",
@@ -1709,6 +1749,11 @@
     "description": "action type \"variable\" label",
     "originalDefault": "change the value of a variable/component"
   },
+  "S2Wv2u": {
+    "defaultMessage": "Form configuration",
+    "description": "Form import/export options 'formConfiguration' field label",
+    "originalDefault": "Form configuration"
+  },
   "S6eF5o": {
     "defaultMessage": "Data removal",
     "description": "Data removal tab title",
@@ -1863,6 +1908,11 @@
     "defaultMessage": "-",
     "description": "Registration summary no registration backend fallback message",
     "originalDefault": "-"
+  },
+  "V072C5": {
+    "defaultMessage": "Category",
+    "description": "Label for additionalFormConfiguration category input",
+    "originalDefault": "Category"
   },
   "VMMOA0": {
     "defaultMessage": "Page content",
@@ -2039,6 +2089,11 @@
     "description": "Email registration options 'emailContentTemplateHtml' helpText",
     "originalDefault": "Content of the registration email message (as html)."
   },
+  "Z4/E9e": {
+    "defaultMessage": "Authentication backends",
+    "description": "Label for formConfiguration authBackends input",
+    "originalDefault": "Authentication backends"
+  },
   "Z8f4hI": {
     "defaultMessage": "Document confidentiality level",
     "description": "StUF-ZDS registration options 'zdsZaakdocVertrouwelijkheid' label",
@@ -2078,6 +2133,11 @@
     "defaultMessage": "The processing (\"verwerking\") for queries to the BRP Persoon API.",
     "description": "Form 'BRP Personen processing header value' field help text",
     "originalDefault": "The processing (\"verwerking\") for queries to the BRP Persoon API."
+  },
+  "ZRv5W+": {
+    "defaultMessage": "WMTS tile layers",
+    "description": "Label for additionalFormConfiguration wmtsTileLayers input",
+    "originalDefault": "WMTS tile layers"
   },
   "ZdZ2Mb": {
     "defaultMessage": "Set the registration backend to use for the submission",
@@ -2364,6 +2424,11 @@
     "description": "ZGW APIs registration options 'partnersDescription' label",
     "originalDefault": "Partners description"
   },
+  "eBHgYL": {
+    "defaultMessage": "Additional form configuration",
+    "description": "Form import/export options 'additionalFormConfiguration' field label",
+    "originalDefault": "Additional form configuration"
+  },
   "eC2etA": {
     "defaultMessage": "Name of the product request type. It is available in the JSON template as the 'productaanvraag_type' variable.",
     "description": "Legacy objects API registration options: 'productaanvraagType' helpText",
@@ -2383,6 +2448,11 @@
     "defaultMessage": "Zds zaaktype status code",
     "description": "StUF-ZDS registration options 'zdsZaaktypeStatusCode' label",
     "originalDefault": "Zds zaaktype status code"
+  },
+  "eVpjb6": {
+    "defaultMessage": "Anonymize form configuration",
+    "description": "Form export options 'removeSensitiveContent' field label",
+    "originalDefault": "Anonymize form configuration"
   },
   "efsF8+": {
     "defaultMessage": "{label} {isPublished, select, false {<draft>(not published)</draft>} other {}}",
@@ -2619,6 +2689,11 @@
     "description": "DMN Input clause label header",
     "originalDefault": "Label"
   },
+  "iAFlLD": {
+    "defaultMessage": "Registration backends",
+    "description": "Label for formConfiguration registrationBackends input",
+    "originalDefault": "Registration backends"
+  },
   "iNmPDd": {
     "defaultMessage": "Attachment informatieobjecttype",
     "description": "Objects API registration options \"Attachment informatieobjecttype\" label",
@@ -2819,6 +2894,11 @@
     "description": "Label for 'value' in MappingArrayInput table column",
     "originalDefault": "Value"
   },
+  "lIwiA/": {
+    "defaultMessage": "Prefill",
+    "description": "Label for formConfiguration prefill input",
+    "originalDefault": "Prefill"
+  },
   "lNBZdl": {
     "defaultMessage": "The path of the folder where folders containing Open-Forms related documents will be created. You can use the expressions <code>'{{' year '}}'</code>, <code>'{{' month '}}'</code> and <code>'{{' day '}}'</code>. The path must start with <code>/</code>.",
     "description": "MS Graph registration options 'folderPath' help text",
@@ -2898,6 +2978,11 @@
     "defaultMessage": "Name",
     "description": "Fixed metadata table name title",
     "originalDefault": "Name"
+  },
+  "n55FhL": {
+    "defaultMessage": "Security",
+    "description": "Form export 'security' options fieldset title",
+    "originalDefault": "Security"
   },
   "nEg4dr": {
     "defaultMessage": "Metadata:",
@@ -3354,6 +3439,11 @@
     "description": "History link button",
     "originalDefault": "History"
   },
+  "um9Dtq": {
+    "defaultMessage": "Theme",
+    "description": "Label for additionalFormConfiguration theme input",
+    "originalDefault": "Theme"
+  },
   "vAZDY4": {
     "defaultMessage": "Source path",
     "description": "Prefill / Objects API: column header for object type property selection",
@@ -3399,6 +3489,11 @@
     "description": "JSON editor: object entry has empty key name",
     "originalDefault": "Set a key name before you can configure this variable"
   },
+  "w2UNV6": {
+    "defaultMessage": "Yivi attribute groups",
+    "description": "Label for additionalFormConfiguration yiviAttributeGroups input",
+    "originalDefault": "Yivi attribute groups"
+  },
   "w4e4jx": {
     "defaultMessage": "After how many seconds should the cached response expire.",
     "description": "Help text cache timeout",
@@ -3428,6 +3523,11 @@
     "defaultMessage": "API group",
     "description": "Customer interactions API group field label",
     "originalDefault": "API group"
+  },
+  "wdvWi/": {
+    "defaultMessage": "Which additional form configuration should be included in the export file content.",
+    "description": "Form import/export options 'additionalFormConfiguration' field help text",
+    "originalDefault": "Which additional form configuration should be included in the export file content."
   },
   "wnTTZr": {
     "defaultMessage": "ID of the drive to use. If left empty, the default drive will be used.",

--- a/src/openforms/js/lang/nl.json
+++ b/src/openforms/js/lang/nl.json
@@ -44,6 +44,11 @@
     "description": "action type \"step-applicable\" label",
     "originalDefault": "Mark the form step as applicable"
   },
+  "/GRLBW": {
+    "defaultMessage": "Inhoud van het exportbestand",
+    "description": "Form export 'export file content' options fieldset title",
+    "originalDefault": "Export file content"
+  },
   "/fAEsY": {
     "defaultMessage": "Informatieobjecttype CSV-document met inzendingsgegevens",
     "description": "Objects API registration options \"Submission report CSV informatieobjecttype\" label",
@@ -69,6 +74,11 @@
     "defaultMessage": "DMN-variabele",
     "description": "DMN variable label",
     "originalDefault": "DMN variable"
+  },
+  "0PB1XV": {
+    "defaultMessage": "WMS-kaartlagen",
+    "description": "Label for additionalFormConfiguration wmsTileLayers input",
+    "originalDefault": "WMS tile layers"
   },
   "0PhQl9": {
     "defaultMessage": "Indien aangevinkt, dan worden overleden kinderen ook weergegeven.",
@@ -114,6 +124,12 @@
     "defaultMessage": "Opties instellen",
     "description": "Link label to open registration options modal",
     "originalDefault": "Configure options"
+  },
+  "1cMfAA": {
+    "defaultMessage": "Product",
+    "description": "Label for additionalFormConfiguration product input",
+    "isTranslated": true,
+    "originalDefault": "Product"
   },
   "1fD+K4": {
     "defaultMessage": "Opschoonmethode voor niet voltooide inzendingen",
@@ -879,6 +895,11 @@
     "description": "Objects API registration: uploadSubmissionCsv helpText",
     "originalDefault": "Indicates whether or not the submission CSV should be uploaded as a Document in Documenten API and attached to the product request."
   },
+  "E3pztQ": {
+    "defaultMessage": "Anonimiseer gevoelige formulierinstellingen bij het exporteren.",
+    "description": "Form export options 'removeSensitiveContent' help text",
+    "originalDefault": "Whether sensative form configuration should be anonymized during exporting."
+  },
   "EDwCbX": {
     "defaultMessage": "<code>{componentKey}</code>: in {numSteps, plural, =1 {{tail}} other {{lead} en {tail}} }",
     "description": "Description of which key is duplicated in which steps.",
@@ -1080,6 +1101,11 @@
     "description": "StUF-ZDS registration variablesMapping label",
     "originalDefault": "Variables mapping (case)"
   },
+  "H51Ms+": {
+    "defaultMessage": "Formulier exporteren",
+    "description": "Form export options modal submit button text",
+    "originalDefault": "Export form"
+  },
   "H6VxhG": {
     "defaultMessage": "Onderhoudsmodus",
     "description": "Form maintenance mode field label",
@@ -1109,6 +1135,11 @@
     "defaultMessage": "Aantal dagen dat een niet voltooide inzendingen (door fouten in de afhandeling) bewaard blijft. Laat leeg om de waarde van de algemene configuratie te gebruiken.",
     "description": "Errored Submissions Removal Limit help text",
     "originalDefault": "Amount of days errored submissions of this form will remain before being removed. Leave blank to use value in General Configuration."
+  },
+  "HKwvbG": {
+    "defaultMessage": "Welke formulierinstellingen mee geëxporteerd worden.",
+    "description": "Form import/export options 'formConfiguration' field help text",
+    "originalDefault": "Which form configuration should be included in the export file content."
   },
   "HVG1xy": {
     "defaultMessage": "Inhoud (bij mede-ondertekenen)",
@@ -1532,10 +1563,20 @@
     "description": "Form registration options tab title",
     "originalDefault": "Registration"
   },
+  "OH+T6k": {
+    "defaultMessage": "Betaalprovider",
+    "description": "Label for formConfiguration paymentBackend input",
+    "originalDefault": "Payment provider"
+  },
   "OX8wxE": {
     "defaultMessage": "Uw sessie vervalt {delta}. Verleng uw sessie indien u wenst door te gaan.",
     "description": "Session expiry warning (in modal)",
     "originalDefault": "Your session is about to expire {delta}. Extend your session if you wish to continue."
+  },
+  "OaS7Pf": {
+    "defaultMessage": "Formulier exportopties",
+    "description": "Form export options modal title",
+    "originalDefault": "Export options"
   },
   "Od+jm6": {
     "defaultMessage": "Waarden:",
@@ -1725,6 +1766,11 @@
     "description": "action type \"variable\" label",
     "originalDefault": "change the value of a variable/component"
   },
+  "S2Wv2u": {
+    "defaultMessage": "Formulierinstellingen",
+    "description": "Form import/export options 'formConfiguration' field label",
+    "originalDefault": "Form configuration"
+  },
   "S6eF5o": {
     "defaultMessage": "Gegevens opschonen",
     "description": "Data removal tab title",
@@ -1880,6 +1926,11 @@
     "description": "Registration summary no registration backend fallback message",
     "isTranslated": true,
     "originalDefault": "-"
+  },
+  "V072C5": {
+    "defaultMessage": "Categorie",
+    "description": "Label for additionalFormConfiguration category input",
+    "originalDefault": "Category"
   },
   "VMMOA0": {
     "defaultMessage": "Inhoud",
@@ -2059,6 +2110,11 @@
     "description": "Email registration options 'emailContentTemplateHtml' helpText",
     "originalDefault": "Content of the registration email message (as html)."
   },
+  "Z4/E9e": {
+    "defaultMessage": "Authenticatie plugins",
+    "description": "Label for formConfiguration authBackends input",
+    "originalDefault": "Authentication backends"
+  },
   "Z8f4hI": {
     "defaultMessage": "Vertrouwelijkheidaanduiding documenten",
     "description": "StUF-ZDS registration options 'zdsZaakdocVertrouwelijkheid' label",
@@ -2098,6 +2154,11 @@
     "defaultMessage": "De waarde voor \"verwerking\" die meegestuurd wordt bij het bevragen van de BRP Personen API. Mogelijke waarden hiervoor zijn afhankelijk van je gateway-leverancier.",
     "description": "Form 'BRP Personen processing header value' field help text",
     "originalDefault": "The processing (\"verwerking\") for queries to the BRP Persoon API."
+  },
+  "ZRv5W+": {
+    "defaultMessage": "WMTS-kaartlagen",
+    "description": "Label for additionalFormConfiguration wmtsTileLayers input",
+    "originalDefault": "WMTS tile layers"
   },
   "ZdZ2Mb": {
     "defaultMessage": "Zet registratieplugin voor de inzending",
@@ -2386,6 +2447,11 @@
     "description": "ZGW APIs registration options 'partnersDescription' label",
     "originalDefault": "Partners description"
   },
+  "eBHgYL": {
+    "defaultMessage": "Aanvullende formulierinstellingen",
+    "description": "Form import/export options 'additionalFormConfiguration' field label",
+    "originalDefault": "Additional form configuration"
+  },
   "eC2etA": {
     "defaultMessage": "Naam van het productaanvraagtype. Deze naam is in het JSON-inhoudsjabloon beschikbaar als de 'productaanvraag_type' variabele.",
     "description": "Legacy objects API registration options: 'productaanvraagType' helpText",
@@ -2405,6 +2471,11 @@
     "defaultMessage": "Zaakstatuscode",
     "description": "StUF-ZDS registration options 'zdsZaaktypeStatusCode' label",
     "originalDefault": "Zds zaaktype status code"
+  },
+  "eVpjb6": {
+    "defaultMessage": "Anonimiseer formulierinstellingen",
+    "description": "Form export options 'removeSensitiveContent' field label",
+    "originalDefault": "Anonymize form configuration"
   },
   "efsF8+": {
     "defaultMessage": "{label} {isPublished, select, false {<draft>(concept)</draft>} other {}}",
@@ -2642,6 +2713,11 @@
     "isTranslated": true,
     "originalDefault": "Label"
   },
+  "iAFlLD": {
+    "defaultMessage": "Registratie backends",
+    "description": "Label for formConfiguration registrationBackends input",
+    "originalDefault": "Registration backends"
+  },
   "iNmPDd": {
     "defaultMessage": "Informatieobjecttype bijlagen",
     "description": "Objects API registration options \"Attachment informatieobjecttype\" label",
@@ -2842,6 +2918,12 @@
     "description": "Label for 'value' in MappingArrayInput table column",
     "originalDefault": "Value"
   },
+  "lIwiA/": {
+    "defaultMessage": "Prefill",
+    "description": "Label for formConfiguration prefill input",
+    "isTranslated": true,
+    "originalDefault": "Prefill"
+  },
   "lNBZdl": {
     "defaultMessage": "Het pad naar de map waar mappen voor documenten van Open Formulieren aangemaakt worden. Je kan de expressies <code>'{{' year '}}'</code>, <code>'{{' month '}}'</code> en <code>'{{' day '}}'</code> gebruiken. Het pad moet beginnen met <code>/</code>.",
     "description": "MS Graph registration options 'folderPath' help text",
@@ -2921,6 +3003,11 @@
     "defaultMessage": "Naam",
     "description": "Fixed metadata table name title",
     "originalDefault": "Name"
+  },
+  "n55FhL": {
+    "defaultMessage": "Beveiliging",
+    "description": "Form export 'security' options fieldset title",
+    "originalDefault": "Security"
   },
   "nEg4dr": {
     "defaultMessage": "Metagegevens:",
@@ -3379,6 +3466,11 @@
     "description": "History link button",
     "originalDefault": "History"
   },
+  "um9Dtq": {
+    "defaultMessage": "Thema",
+    "description": "Label for additionalFormConfiguration theme input",
+    "originalDefault": "Theme"
+  },
   "vAZDY4": {
     "defaultMessage": "Bronpad",
     "description": "Prefill / Objects API: column header for object type property selection",
@@ -3424,6 +3516,11 @@
     "description": "JSON editor: object entry has empty key name",
     "originalDefault": "Set a key name before you can configure this variable"
   },
+  "w2UNV6": {
+    "defaultMessage": "Yivi attribuut groepen",
+    "description": "Label for additionalFormConfiguration yiviAttributeGroups input",
+    "originalDefault": "Yivi attribute groups"
+  },
   "w4e4jx": {
     "defaultMessage": "Na hoeveel seconden moeten gecachete resultaten vervallen.",
     "description": "Help text cache timeout",
@@ -3453,6 +3550,11 @@
     "defaultMessage": "API-groep",
     "description": "Customer interactions API group field label",
     "originalDefault": "API group"
+  },
+  "wdvWi/": {
+    "defaultMessage": "Welke aanvullende formulierinstellingen mee geëxporteerd worden.",
+    "description": "Form import/export options 'additionalFormConfiguration' field help text",
+    "originalDefault": "Which additional form configuration should be included in the export file content."
   },
   "wnTTZr": {
     "defaultMessage": "ID van de schijf/drive waar bestanden terecht moeten komen. Indien leeg, dan wordt de standaard-drive gebruikt.",


### PR DESCRIPTION
Closes #6430, #6431 
Depends on, and build ontop of #6429

**Changes**

This PR further extends the import/export module by processing the new export options (#6429), adding additional import options, and updating the form version handling

1. **Refactor of the import code**
2. **Added UI for new import options**
3. **Preventing duplicate creation of form definitions and additional configuration (product, theme, etc.)**
4. **Saving additional configuration as part of the form version**
(this allows us to fully restore a form to its previous version, with the product, theme, category, tile layers and yivi attributes that were used at the time the form version was created)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [ ] Added documentation which describes the changes
