### PR TITLE
Prevent camelcase conversion of formio configuration in the v3 forms endpoint

### DIFF
--- a/src/openforms/forms/api/drf_camel_case.py
+++ b/src/openforms/forms/api/drf_camel_case.py
@@ -17,7 +17,10 @@ class FormCamelCaseMixin:
            while we'd rather be able to just validate this depending on the applicable
            registration backend. Future improvement!
         """
-        ignore_fields = []
+
+        # Needed to not mangle the formio definitions - all processing assumes the
+        # original camel case keys.
+        ignore_fields = ["configuration"]
         for plugin in register:
             if not plugin.camel_case_ignore_fields:
                 continue

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -8,7 +8,6 @@ from django.utils import timezone
 from django.utils.text import get_text_list
 from django.utils.translation import gettext as _
 
-from djangorestframework_camel_case.util import underscoreize
 from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.test import APIClient, APITestCase, APITransactionTestCase
@@ -340,14 +339,14 @@ class FormEndpointTests(APITestCase):
                         "key": "component1",
                         "label": "component1",
                         "hidden": False,
-                        "clear_on_hide": True,
+                        "clearOnHide": True,
                     },
                     {
                         "type": "textfield",
                         "key": "component2",
                         "label": "component2",
                         "hidden": False,
-                        "clear_on_hide": True,
+                        "clearOnHide": True,
                     },
                 ],
             },
@@ -578,14 +577,14 @@ class FormEndpointTests(APITestCase):
                         "key": "component1",
                         "label": "component1",
                         "hidden": False,
-                        "clear_on_hide": True,
+                        "clearOnHide": True,
                     },
                     {
                         "type": "textfield",
                         "key": "component2",
                         "label": "component2",
                         "hidden": False,
-                        "clear_on_hide": True,
+                        "clearOnHide": True,
                     },
                 ],
             },
@@ -1247,7 +1246,7 @@ class FormEndpointTests(APITestCase):
                         "key": "component1",
                         "label": "component1",
                         "hidden": False,
-                        "clear_on_hide": True,
+                        "clearOnHide": True,
                     },
                 ],
             },
@@ -1266,14 +1265,14 @@ class FormEndpointTests(APITestCase):
                         "key": "component2",
                         "label": "component2",
                         "hidden": False,
-                        "clear_on_hide": True,
+                        "clearOnHide": True,
                     },
                     {
                         "type": "textfield",
                         "key": "component3",
                         "label": "component3",
                         "hidden": False,
-                        "clear_on_hide": True,
+                        "clearOnHide": True,
                     },
                 ],
             },
@@ -1359,14 +1358,14 @@ class FormEndpointTests(APITestCase):
                         "key": "component1",
                         "label": "component1",
                         "hidden": False,
-                        "clear_on_hide": True,
+                        "clearOnHide": True,
                     },
                     {
                         "type": "textfield",
                         "key": "component2",
                         "label": "component2",
                         "hidden": False,
-                        "clear_on_hide": True,
+                        "clearOnHide": True,
                     },
                 ],
             },
@@ -3484,8 +3483,8 @@ class FormEndpointConcurrentTests(APITransactionTestCase):
         ]
         self.assertEqual(len(error_responses), 1)
         self.assertEqual(len(success_responses), 1)
-        response_data = underscoreize(success_responses[0].json())
-        expected_form_definition = response_data["steps"][0]["form_definition"][  # pyright: ignore[reportArgumentType,reportCallIssue,reportIndexIssue]
+        response_data = success_responses[0].json()
+        expected_form_definition = response_data["steps"][0]["formDefinition"][
             "configuration"
         ]
 
@@ -3625,8 +3624,8 @@ class FormEndpointConcurrentTests(APITransactionTestCase):
         ]
         self.assertEqual(len(error_responses), 1)
         self.assertEqual(len(success_responses), 1)
-        response_data = underscoreize(success_responses[0].json())
-        expected_form_definition = response_data["steps"][0]["form_definition"][  # pyright: ignore[reportArgumentType,reportCallIssue,reportIndexIssue]
+        response_data = success_responses[0].json()
+        expected_form_definition = response_data["steps"][0]["formDefinition"][
             "configuration"
         ]
 
@@ -3635,7 +3634,7 @@ class FormEndpointConcurrentTests(APITransactionTestCase):
             (
                 form
                 for form in (form_1, form_2)
-                if response_data["uuid"] == str(form.uuid)  # pyright: ignore[reportArgumentType,reportCallIssue,reportIndexIssue]
+                if response_data["uuid"] == str(form.uuid)
             ),
             None,
         )
@@ -3652,4 +3651,4 @@ class FormEndpointConcurrentTests(APITransactionTestCase):
         self.assertEqual(
             form_step.form_definition.configuration, expected_form_definition
         )
-        self.assertEqual(FormDefinition.objects.count(), 1)  # pyright: ignore[reportAttributeAccessIssue]
+        self.assertEqual(FormDefinition.objects.count(), 1)

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -112,6 +112,23 @@ class FormEndpointTests(APITestCase):
         self.assertEqual(form.name, "Create form")
         self.assertEqual(form.slug, "create-form")
 
+        with self.subTest("formio config is kept as-is"):
+            fd = FormDefinition.objects.get()
+            self.assertEqual(
+                fd.configuration,
+                {
+                    "components": [
+                        {
+                            "type": "textfield",
+                            "key": "component1",
+                            "label": "component1",
+                            "hidden": False,
+                            "clearOnHide": True,
+                        },
+                    ],
+                },
+            )
+
     def test_create_detailed_form(self):
         product = ProductFactory.create()
         category = CategoryFactory.create()
@@ -1667,11 +1684,15 @@ class FormEndpointTests(APITestCase):
                                             "type": "file",
                                             "key": "fileInRepeatingGroup1",
                                             "label": "fileInRepeatingGroup1",
+                                            "file": {"type": []},
+                                            "filePattern": "",
                                         },
                                         {
                                             "type": "file",
                                             "key": "fileInRepeatingGroup1",
                                             "label": "fileInRepeatingGroup1",
+                                            "file": {"type": []},
+                                            "filePattern": "",
                                         },
                                     ],
                                 },


### PR DESCRIPTION
**Changes**

See title

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
