### PR TITLE
:construction_worker: Re-enable OAS lint job with new workflow that uses vacuum

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -417,21 +417,21 @@ jobs:
           # ensure local image gets used
           TAG: ${{ needs.setup.outputs.version }}
 
-  # oas:
-  #   name: OAS
-  #   uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@0a5525c13f8eea10be40c8eaee5e535ea3a10721 # v6.4.1
-  #   with:
-  #     python-version: '3.12'
-  #     apt-packages: 'libxml2 libxmlsec1 libxmlsec1-openssl gdal-bin'
-  #     django-settings-module: openforms.conf.ci
-  #     oas-generate-command: ./bin/generate_oas.sh
-  #     schema-path: src/openapi.yaml
-  #     oas-artifact-name: open-forms-oas
-  #     node-version-file: '.nvmrc'
-  #     spectral-version: '^6.15.0'
-  #     openapi-to-postman-version: '^5.0.0'
-  #     postman-artifact-name: open-forms-postman-collection
-  #     openapi-generator-version: '^2.20.0'
+  oas:
+    name: OAS
+    uses: maykinmedia/open-api-workflows/.github/workflows/oas.yml@cef92d6eec651bca751db7bbc211e10eb1f9c31d # pre-v7.0.0
+    with:
+      python-version: '3.12'
+      apt-packages: 'libxml2 libxmlsec1 libxmlsec1-openssl gdal-bin'
+      django-settings-module: openforms.conf.ci
+      oas-generate-command: ./bin/generate_oas.sh
+      schema-path: src/openapi.yaml
+      oas-artifact-name: open-forms-oas
+      openapi-to-postman-version: '^5.0.0'
+      postman-artifact-name: open-forms-postman-collection
+      openapi-generator-version: '^2.20.0'
+      vacuum-version: '0.30.0'
+      vacuum-version-checksum: '817b6bd71051c2b543891b4e26692404bfab9c79b29393734bdd8c6b9356c2e4'
 
   docker_push:
     needs:
@@ -440,7 +440,7 @@ jobs:
       - e2etests
       - setup
       - docker_build
-      # - oas
+      - oas
 
     name: Push Docker image
     runs-on: ubuntu-latest


### PR DESCRIPTION
instead of spectral-cli

Closes #...

**Changes**

[Describe the changes here]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Checked new model fields are usable in the admin
  - [ ] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [ ] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how

- Documentation

  - [ ] Added documentation which describes the changes
