### PR TITLE
[#5958] Add support for logic rules in v3 Form serializer

### DIFF
--- a/src/openapi.yaml
+++ b/src/openapi.yaml
@@ -8500,6 +8500,49 @@ components:
       required:
       - actions
       - jsonLogicTrigger
+    FormLogicV3:
+      type: object
+      description: Represent logic rules with their actions as a nested serializer.
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        jsonLogicTrigger:
+          type: object
+          title: JSON logic
+          description: The trigger expression to determine if the actions should execute
+            or not. Note that this must be a valid JsonLogic expression, and the first
+            operand must be a reference to a variable in the form.
+          additionalProperties: true
+          example:
+            ==:
+            - var: checkbox
+            - true
+        description:
+          type: string
+          description: Logic rule description in natural language.
+          maxLength: 100
+        order:
+          type: integer
+          description: Order of the rule relative to the form it belongs to. Logic
+            rules are evaluated in this order. Note that specifying a value for the
+            order here will cause the rules before/after this rule to be re-calculated.
+        actions:
+          type: array
+          items:
+            $ref: '#/components/schemas/LogicComponentActionV3'
+          description: Actions triggered when the trigger expression evaluates to
+            'truthy'.
+        isAdvanced:
+          type: boolean
+          description: Is this an advanced rule (the admin user manually wrote the
+            trigger as JSON)?
+      required:
+      - actions
+      - jsonLogicTrigger
+      - order
+      - uuid
     FormModelTranslations:
       type: object
       description: |-
@@ -8899,6 +8942,10 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/FormStepV3'
+        logicRules:
+          type: array
+          items:
+            $ref: '#/components/schemas/FormLogicV3'
         showProgressIndicator:
           type: boolean
           description: Whether the step progression should be displayed in the UI
@@ -9539,6 +9586,38 @@ components:
           description: De UUID van de formulierstap waarop de actie van invloed is.
             Dit veld is verplicht voor actietypen `disable-next`, `step-applicable`,
             `step-not-applicable` - anders is het optioneel.
+        action:
+          $ref: '#/components/schemas/LogicActionPolymorphic'
+      required:
+      - action
+      - uuid
+    LogicComponentActionV3:
+      type: object
+      properties:
+        uuid:
+          type: string
+          format: uuid
+          readOnly: true
+        component:
+          type: string
+          title: Form.io component key
+          description: 'Sleutel van de Form.io-component waarop de actie van toepassing
+            is. Dit veld is verplicht voor de actietypes `property` - anders is het
+            optioneel. '
+          pattern: ^(\w|\w[\w.\-]*\w)$
+        variable:
+          type: string
+          title: Key of the target variable
+          description: Sleutel van de variabele die aangepast wordt door de actie.
+            Dit veld is verplicht voor de actietypes `variable` - anders is het optioneel.
+          pattern: ^(\w|\w[\w.\-]*\w)$
+        formStepSlug:
+          type: string
+          description: The slug of the form step that will be affected by the action.
+            This field is required for action types `disable-next`, `step-applicable`,
+            `step-not-applicable` - otherwise it's optional. We deliberately use the
+            slug instead of the uuid because the uuid is not fixed, as we create from
+            scratch the form steps dusring form update.
         action:
           $ref: '#/components/schemas/LogicActionPolymorphic'
       required:

--- a/src/openforms/forms/api/v3/serializers/form.py
+++ b/src/openforms/forms/api/v3/serializers/form.py
@@ -1,4 +1,6 @@
 from collections import Counter, defaultdict
+from collections.abc import Collection, Mapping
+from datetime import date
 from uuid import UUID
 
 from django.db import transaction
@@ -6,6 +8,8 @@ from django.utils.text import get_text_list
 from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.utils import extend_schema_serializer
+from glom import glom
+from json_logic.typing import Primitive
 from rest_framework import serializers
 from rest_framework.exceptions import ErrorDetail, ValidationError
 
@@ -17,6 +21,7 @@ from openforms.formio.service import (
     DuplicateKeyError,
     FormioConfigurationWrapper,
     get_branch_representation,
+    holds_submission_data,
 )
 from openforms.formio.typing.base import Component
 from openforms.prefill.contrib.customer_interactions.constants import (
@@ -25,7 +30,7 @@ from openforms.prefill.contrib.customer_interactions.constants import (
 from openforms.products.models import Product
 from openforms.translations.api.serializers import ModelTranslationsSerializer
 from openforms.typing import StrOrPromise
-from openforms.variables.constants import FormVariableSources
+from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
 from openforms.variables.models import ServiceFetchConfiguration
 from openforms.variables.service import get_static_variables
 
@@ -36,18 +41,27 @@ from ....api.serializers.form import (
     HelpDialogSerializer,
     SubmissionsRemovalOptionsSerializer,
 )
-from ....constants import FormTypeChoices
+from ....constants import (
+    LOGIC_ACTION_TYPES_REQUIRING_COMPONENT,
+    LOGIC_ACTION_TYPES_REQUIRING_FORM_STEP_SLUG,
+    LOGIC_ACTION_TYPES_REQUIRING_VARIABLE,
+    FormTypeChoices,
+    LogicActionTypes,
+)
+from ....logic_analysis import CyclesDetected, analyze_rules
 from ....models import (
     Category,
     Form,
     FormDefinition,
+    FormLogic,
     FormRegistrationBackend,
     FormStep,
     FormVariable,
 )
 from ...validators import RequireAppointmentsPlugin
-from ..typing import FormStepData, FormValidatedData, FormVariableData
+from ..typing import FormLogicData, FormStepData, FormValidatedData, FormVariableData
 from .form_step import FormStepSerializer
+from .logic_rules import FormLogicSerializer
 from .payment import FormPaymentSerializer
 from .variables import FormVariableSerializer
 
@@ -77,6 +91,7 @@ class FormSerializer(serializers.ModelSerializer):
     variables = FormVariableSerializer(
         many=True, source="formvariable_set", required=False
     )
+    logic_rules = FormLogicSerializer(many=True, required=False, source="formlogic_set")
 
     payment = FormPaymentSerializer(required=False, source="*")
 
@@ -109,6 +124,7 @@ class FormSerializer(serializers.ModelSerializer):
         "confirmation_email_template",
         "formstep_set",
         "formvariable_set",
+        "formlogic_set",
         "registration_backends",
     )
 
@@ -145,6 +161,7 @@ class FormSerializer(serializers.ModelSerializer):
             "category",
             "theme",
             "steps",
+            "logic_rules",
             "show_progress_indicator",
             "show_summary_progress",
             "maintenance_mode",
@@ -177,12 +194,244 @@ class FormSerializer(serializers.ModelSerializer):
             "type": {"validators": [RequireAppointmentsPlugin()]},
         }
 
+    def _validate_actions(self, form: Form, temp_rules: Mapping[FormLogic, int]):
+        form_variables = {
+            var.key: var for var in FormVariable.objects.filter(form=form)
+        }
+        form_step_slugs = form.formstep_set.values_list("slug", flat=True)
+
+        for rule in temp_rules:
+            for action_index, action in enumerate(rule.actions):
+                action_type = action.get("action", {}).get("type")
+                action_value = action.get("action", {}).get("value")
+                component = action.get("component")
+                form_step_slug = action.get("form_step_slug")
+                variable = action.get("variable")
+
+                # validate component exists in action
+                if (
+                    action_type
+                    and action_type in LOGIC_ACTION_TYPES_REQUIRING_COMPONENT
+                    and not component
+                ):
+                    raise serializers.ValidationError(
+                        {
+                            "logic_rules": {
+                                str(rule.order): {
+                                    "actions": {
+                                        str(action_index): {
+                                            "action": {
+                                                "component": _(
+                                                    "This field may not be blank."
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        code="blank",
+                    )
+
+                if action_type and action_type in LOGIC_ACTION_TYPES_REQUIRING_VARIABLE:
+                    # validate variable exists in action
+                    if not variable:
+                        raise serializers.ValidationError(
+                            {
+                                "logic_rules": {
+                                    str(rule.order): {
+                                        "actions": {
+                                            str(action_index): {
+                                                "action": {
+                                                    "variable": _(
+                                                        "You must specify a variable."
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            code="blank",
+                        )
+                    # validate variable exists in form
+                    if variable not in form_variables:
+                        raise serializers.ValidationError(
+                            {
+                                "logic_rules": {
+                                    str(rule.order): {
+                                        "actions": {
+                                            str(action_index): {
+                                                "action": {
+                                                    "variable": _(
+                                                        "The variable {varname} does not exist."
+                                                    ).format(varname=variable),
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            code="invalid",
+                        )
+
+                # validate format of value for date variable
+                if action_type == LogicActionTypes.variable and isinstance(
+                    action_value, Primitive
+                ):
+                    form_var = form_variables.get(variable)
+                    if form_var and form_var.data_type == FormVariableDataTypes.date:
+                        try:
+                            # type check muted since we handle it at runtime
+                            date.fromisoformat(
+                                action_value  # pyright: ignore[reportArgumentType]
+                            )
+                        except (ValueError, TypeError) as ex:
+                            raise serializers.ValidationError(
+                                {
+                                    "logic_rules": {
+                                        str(rule.order): {
+                                            "actions": {
+                                                str(action_index): {
+                                                    "action": {
+                                                        "value": _(
+                                                            "Value for date variable must be a string in the "
+                                                            "format yyyy-mm-dd (e.g. 2023-07-03)"
+                                                        ),
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            ) from ex
+
+                if action_type in LOGIC_ACTION_TYPES_REQUIRING_FORM_STEP_SLUG:
+                    # validate form step slug exists in action
+                    if not form_step_slug:
+                        raise serializers.ValidationError(
+                            {
+                                "logic_rules": {
+                                    str(rule.order): {
+                                        "actions": {
+                                            str(action_index): {
+                                                "form_step_slug": _(
+                                                    "This field may not be null."
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            code="null",
+                        )
+                    # validate form step slug is valid
+                    if form_step_slug not in form_step_slugs:
+                        raise serializers.ValidationError(
+                            {
+                                "logic_rules": {
+                                    str(rule.order): {
+                                        "actions": {
+                                            str(action_index): {
+                                                "form_step_slug": _(
+                                                    "Invalid form step specified in logic action."
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            code="invalid",
+                        )
+
+                # check that "disabled" property is not changed for layout components
+                if action_type == LogicActionTypes.property:
+                    formio_component: None | Component = None
+                    for form_step in form.formstep_set.select_related(
+                        "form_definition"
+                    ):
+                        if component in (
+                            wrapper := form_step.form_definition.configuration_wrapper
+                        ):
+                            formio_component = wrapper[component]
+                            break
+
+                    if (
+                        formio_component
+                        and not holds_submission_data(formio_component)
+                        and glom(action, "action.property.value") == "disabled"
+                    ):
+                        raise serializers.ValidationError(
+                            {
+                                "logic_rules": {
+                                    str(rule.order): {
+                                        "actions": {
+                                            str(action_index): {
+                                                "action": {
+                                                    "component": _(
+                                                        "'disabled' property can't be used for layout components."
+                                                    )
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            },
+                            code="invalid",
+                        )
+
+    def _validate_and_process_logic_rules(
+        self,
+        form: Form,
+        logic_rules_raw: list[FormLogicData],
+        temp_logic_rules: dict[FormLogic, int],
+    ):
+        first_step: FormStep | None = min(
+            form.form_step_map.values(), key=lambda step: step.order, default=None
+        )
+
+        try:
+            updated_rules_and_steps = analyze_rules(
+                form,
+                rules=list(temp_logic_rules.keys()),
+                first_step=first_step,
+            )
+        except CyclesDetected as exc:
+            msg = _("Rule contains cycles through variable(s): {variables}.")
+            errors: defaultdict[str, list[ErrorDetail]] = defaultdict(list)
+            for cycle in exc.cycles:
+                # Sort to get consistent order in the error message (rules of a cycle do
+                # not have a start or end, so the order in which they are processed is
+                # not always consistent).
+                var_keys = ", ".join(sorted(cycle.variables))
+                for rule in sorted(cycle.rules, key=lambda r: r.order):
+                    errors[f"{rule.order}.json_logic_trigger"].append(
+                        ErrorDetail(
+                            msg.format(variables=var_keys), code="cycles-detected"
+                        )
+                    )
+            raise serializers.ValidationError(errors)
+
+        # Reorder the incoming data according to the determined order.
+        steps: list[Collection[FormStep]] = []
+        reordered_rule_data: list[FormLogicData] = []
+        for rule, rule_steps in updated_rules_and_steps:
+            # Lookup the original rule data by checking our rule-to-index map created
+            # earlier.
+            rule_data_index = temp_logic_rules[rule]
+            reordered_rule_data.append(logic_rules_raw[rule_data_index])
+            steps.append(rule_steps)
+
+        self.context["steps_for_each_rule"] = steps
+        return reordered_rule_data
+
     @transaction.atomic()
     def create(self, validated_data: FormValidatedData) -> Form:
         instance = super().create(
             {k: v for k, v in validated_data.items() if k not in self._nested_fields}
         )
 
+        # 1. confirmation email template
         confirmation_email_template = validated_data.get("confirmation_email_template")
         ConfirmationEmailTemplate.objects.set_for_form(
             form=instance, data=confirmation_email_template
@@ -197,7 +446,10 @@ class FormSerializer(serializers.ModelSerializer):
         )
         # fmt:on
         len(form_definitions)  # Evaluate the queryset to acquire the locks.
+
+        # 2. form definitions/steps
         form_definitions_created: dict[UUID, FormDefinition] = {}
+        form_steps: list[FormStep] = []
         for index, step_data in enumerate(form_step_data):
             form_definition_data = step_data["form_definition"]
             form_definition, _ = form_definitions.update_or_create(
@@ -205,24 +457,32 @@ class FormSerializer(serializers.ModelSerializer):
                 defaults={k: v for k, v in form_definition_data.items() if k != "uuid"},
             )
             form_definitions_created[form_definition_data["uuid"]] = form_definition
-
-            FormStep.objects.create(
-                **{**step_data, "form_definition": form_definition},
-                order=index,
-                form=instance,
+            form_steps.append(
+                FormStep(
+                    **{
+                        **step_data,
+                        "form_definition": form_definition,
+                        "form": instance,
+                        "order": index,
+                    }
+                )
             )
+
+        form_steps = FormStep.objects.bulk_create(form_steps)
 
         # These calls are required to create the corresponding component form variables
         # from the form definitions.
         for form_definition in form_definitions_created.values():
             FormVariable.objects.synchronize_for(form_definition)
 
+        # 3. registration backends
         registration_backends = validated_data.get("registration_backends", [])
         FormRegistrationBackend.objects.bulk_create(
             FormRegistrationBackend(form=instance, **backend)
             for backend in registration_backends
         )
 
+        #  4. form variables
         form_variables_data = validated_data.get("formvariable_set", [])
         form_variables: list[FormVariable] = []
         for variable_data in form_variables_data:
@@ -250,6 +510,36 @@ class FormSerializer(serializers.ModelSerializer):
             form_variables.append(form_variable)
         FormVariable.objects.bulk_create(form_variables)
 
+        # 5. logic rules
+        logic_rules_raw: list[FormLogicData] = validated_data.get("formlogic_set", [])
+
+        if not logic_rules_raw:
+            return instance
+
+        # Note: model instances without a pk are not hashable, which is a requirement to
+        # use them in the analysis graph, so we assign it manually. These rules will just
+        # live in memory and they will be saved below, after they are analyzed.
+        temp_rules_instances: dict[FormLogic, int] = {
+            FormLogic(**logic_rule_data, pk=-index, form=instance): index
+            for index, logic_rule_data in enumerate(logic_rules_raw)
+        }
+
+        # We have to do these steps in the create method instead of the ideal/proper
+        # choice to do that inside the validate method. The form instance is important
+        # to have been created at the time that we do these validations, as the related
+        # nested fields are needed (have to be saved and available to access). Adding
+        # that to the validate method would require a huge refactor as a lot of our
+        # current implementation depends on the (saved) form instance.
+        self._validate_actions(instance, temp_rules_instances)
+        reordered_rules = self._validate_and_process_logic_rules(
+            instance, logic_rules_raw, temp_rules_instances
+        )
+
+        # Save the form logic rules in the correct/updated order
+        FormLogic.objects.bulk_create(
+            [FormLogic(**rule, form=instance) for rule in reordered_rules]
+        )
+
         return instance
 
     @transaction.atomic()
@@ -259,6 +549,7 @@ class FormSerializer(serializers.ModelSerializer):
             {k: v for k, v in validated_data.items() if k not in self._nested_fields},
         )
 
+        # 1. confirmation email template
         confirmation_email_template = validated_data.get(
             "confirmation_email_template", None
         )
@@ -266,6 +557,7 @@ class FormSerializer(serializers.ModelSerializer):
             form=instance, data=confirmation_email_template
         )
 
+        # 2. form definitions/steps
         assigned_steps: list[FormStep] = []
         form_step_data = validated_data["formstep_set"]
         # fmt:off
@@ -292,7 +584,7 @@ class FormSerializer(serializers.ModelSerializer):
             )
             assigned_steps.append(step)
 
-        # Remove the form steps not that are not part of the request along with their
+        # Remove the form steps that are not part of the request along with their
         # form definitions when applicable.
         steps_to_delete = instance.formstep_set.exclude(
             pk__in=(step.pk for step in assigned_steps)
@@ -317,6 +609,7 @@ class FormSerializer(serializers.ModelSerializer):
         for form_definition in form_definitions_created.values():
             FormVariable.objects.synchronize_for(form_definition)
 
+        # 3. registration backends
         registration_backends = validated_data.get("registration_backends", None)
         if registration_backends is not None:
             instance.registration_backends.all().delete()
@@ -325,6 +618,7 @@ class FormSerializer(serializers.ModelSerializer):
                 for backend in registration_backends
             )
 
+        # 4. form variables
         form_variables_data = validated_data.get("formvariable_set", [])
         form_variables: list[FormVariable] = []
         for variable_data in form_variables_data:
@@ -353,6 +647,37 @@ class FormSerializer(serializers.ModelSerializer):
         # Remove the stale variables that were not part of the request.
         instance.formvariable_set.exclude(source=FormVariableSources.component).delete()
         FormVariable.objects.bulk_create(form_variables)
+
+        # 5. logic rules
+        logic_rules_raw = validated_data.get("formlogic_set", [])
+        if not logic_rules_raw:
+            return instance
+
+        # Note: model instances without a pk are not hashable, which is a requirement to
+        # use them in the analysis graph, so we assign it manually. These rules will just
+        # live in memory and they will be saved below, after they are analyzed.
+        temp_rules_instances: dict[FormLogic, int] = {
+            FormLogic(**logic_rule_data, pk=-index, form=instance): index
+            for index, logic_rule_data in enumerate(logic_rules_raw)
+        }
+
+        # We have to do these steps in the create method instead of the ideal/proper
+        # choice to do that inside the validate method. The form instance is important
+        # to have been created at the time that we do these validations, as the related
+        # nested fields are needed (have to be saved and available to access). Adding
+        # that to the validate method would require a huge refactor as a lot of our
+        # current implementation depends on the (saved) form instance.
+        self._validate_actions(instance, temp_rules_instances)
+        reordered_rules = self._validate_and_process_logic_rules(
+            instance, logic_rules_raw, temp_rules_instances
+        )
+
+        # Remove the existing logic rules.
+        instance.formlogic_set.all().delete()
+        # Save the form logic rules in the correct/updated order.
+        FormLogic.objects.bulk_create(
+            [FormLogic(**rule, form=instance) for rule in reordered_rules]
+        )
 
         return instance
 

--- a/src/openforms/forms/api/v3/serializers/form.py
+++ b/src/openforms/forms/api/v3/serializers/form.py
@@ -1,6 +1,6 @@
 from collections import Counter, defaultdict
-from collections.abc import Collection, Mapping
-from datetime import date
+from collections.abc import Collection, Mapping, MutableMapping, Sequence
+from typing import TypedDict
 from uuid import UUID
 
 from django.db import transaction
@@ -8,8 +8,6 @@ from django.utils.text import get_text_list
 from django.utils.translation import gettext_lazy as _
 
 from drf_spectacular.utils import extend_schema_serializer
-from glom import glom
-from json_logic.typing import Primitive
 from rest_framework import serializers
 from rest_framework.exceptions import ErrorDetail, ValidationError
 
@@ -21,16 +19,15 @@ from openforms.formio.service import (
     DuplicateKeyError,
     FormioConfigurationWrapper,
     get_branch_representation,
-    holds_submission_data,
 )
-from openforms.formio.typing.base import Component
+from openforms.formio.typing import Component
 from openforms.prefill.contrib.customer_interactions.constants import (
     PLUGIN_IDENTIFIER as COMMUNICATION_PREFERENCES_PLUGIN_IDENTIFIER,
 )
 from openforms.products.models import Product
 from openforms.translations.api.serializers import ModelTranslationsSerializer
 from openforms.typing import StrOrPromise
-from openforms.variables.constants import FormVariableDataTypes, FormVariableSources
+from openforms.variables.constants import FormVariableSources
 from openforms.variables.models import ServiceFetchConfiguration
 from openforms.variables.service import get_static_variables
 
@@ -41,13 +38,7 @@ from ....api.serializers.form import (
     HelpDialogSerializer,
     SubmissionsRemovalOptionsSerializer,
 )
-from ....constants import (
-    LOGIC_ACTION_TYPES_REQUIRING_COMPONENT,
-    LOGIC_ACTION_TYPES_REQUIRING_FORM_STEP_SLUG,
-    LOGIC_ACTION_TYPES_REQUIRING_VARIABLE,
-    FormTypeChoices,
-    LogicActionTypes,
-)
+from ....constants import FormTypeChoices
 from ....logic_analysis import CyclesDetected, analyze_rules
 from ....models import (
     Category,
@@ -59,11 +50,32 @@ from ....models import (
     FormVariable,
 )
 from ...validators import RequireAppointmentsPlugin
-from ..typing import FormLogicData, FormStepData, FormValidatedData, FormVariableData
+from ..typing import (
+    FormLogicActionData,
+    FormLogicData,
+    FormStepData,
+    FormValidatedData,
+    FormVariableData,
+)
+from ..validation import ActionsErrors, validate_logic_actions
 from .form_step import FormStepSerializer
 from .logic_rules import FormLogicSerializer
 from .payment import FormPaymentSerializer
 from .variables import FormVariableSerializer
+
+
+class RuleErrors(TypedDict):
+    """
+    Validation errors for a single logic rule.
+    """
+
+    actions: ActionsErrors
+
+
+type RulesErrors = MutableMapping[int, RuleErrors]
+"""
+Mapping of rule errors for the collection of rules, keyed by rule index.
+"""
 
 
 @extend_schema_serializer(component_name="FormV3Serializer")
@@ -198,187 +210,46 @@ class FormSerializer(serializers.ModelSerializer):
         form_variables = {
             var.key: var for var in FormVariable.objects.filter(form=form)
         }
-        form_step_slugs = form.formstep_set.values_list("slug", flat=True)
+        form_step_slugs = set(form.formstep_set.values_list("slug", flat=True))
+        rule_errors: RulesErrors = {}
 
-        for rule in temp_rules:
-            for action_index, action in enumerate(rule.actions):
-                action_type = action.get("action", {}).get("type")
-                action_value = action.get("action", {}).get("value")
-                component = action.get("component")
-                form_step_slug = action.get("form_step_slug")
-                variable = action.get("variable")
+        _total_configuration_wrapper: FormioConfigurationWrapper | None = None
 
-                # validate component exists in action
-                if (
-                    action_type
-                    and action_type in LOGIC_ACTION_TYPES_REQUIRING_COMPONENT
-                    and not component
-                ):
-                    raise serializers.ValidationError(
-                        {
-                            "logic_rules": {
-                                str(rule.order): {
-                                    "actions": {
-                                        str(action_index): {
-                                            "action": {
-                                                "component": _(
-                                                    "This field may not be blank."
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        },
-                        code="blank",
+        def _find_component(key: str) -> Component | None:
+            """
+            Find the component with key ``key`` in any of the form steps.
+            """
+            nonlocal _total_configuration_wrapper
+
+            if _total_configuration_wrapper is None:
+                _total_configuration_wrapper = FormioConfigurationWrapper(
+                    {"components": []}
+                )
+                for form_step in form.formstep_set.select_related("form_definition"):
+                    assert isinstance(form_step.form_definition, FormDefinition)
+                    _total_configuration_wrapper += (
+                        form_step.form_definition.configuration_wrapper
                     )
 
-                if action_type and action_type in LOGIC_ACTION_TYPES_REQUIRING_VARIABLE:
-                    # validate variable exists in action
-                    if not variable:
-                        raise serializers.ValidationError(
-                            {
-                                "logic_rules": {
-                                    str(rule.order): {
-                                        "actions": {
-                                            str(action_index): {
-                                                "action": {
-                                                    "variable": _(
-                                                        "You must specify a variable."
-                                                    )
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            code="blank",
-                        )
-                    # validate variable exists in form
-                    if variable not in form_variables:
-                        raise serializers.ValidationError(
-                            {
-                                "logic_rules": {
-                                    str(rule.order): {
-                                        "actions": {
-                                            str(action_index): {
-                                                "action": {
-                                                    "variable": _(
-                                                        "The variable {varname} does not exist."
-                                                    ).format(varname=variable),
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            code="invalid",
-                        )
+            if key in _total_configuration_wrapper:
+                return _total_configuration_wrapper[key]
 
-                # validate format of value for date variable
-                if action_type == LogicActionTypes.variable and isinstance(
-                    action_value, Primitive
-                ):
-                    form_var = form_variables.get(variable)
-                    if form_var and form_var.data_type == FormVariableDataTypes.date:
-                        try:
-                            # type check muted since we handle it at runtime
-                            date.fromisoformat(
-                                action_value  # pyright: ignore[reportArgumentType]
-                            )
-                        except (ValueError, TypeError) as ex:
-                            raise serializers.ValidationError(
-                                {
-                                    "logic_rules": {
-                                        str(rule.order): {
-                                            "actions": {
-                                                str(action_index): {
-                                                    "action": {
-                                                        "value": _(
-                                                            "Value for date variable must be a string in the "
-                                                            "format yyyy-mm-dd (e.g. 2023-07-03)"
-                                                        ),
-                                                    }
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            ) from ex
+            return None
 
-                if action_type in LOGIC_ACTION_TYPES_REQUIRING_FORM_STEP_SLUG:
-                    # validate form step slug exists in action
-                    if not form_step_slug:
-                        raise serializers.ValidationError(
-                            {
-                                "logic_rules": {
-                                    str(rule.order): {
-                                        "actions": {
-                                            str(action_index): {
-                                                "form_step_slug": _(
-                                                    "This field may not be null."
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            code="null",
-                        )
-                    # validate form step slug is valid
-                    if form_step_slug not in form_step_slugs:
-                        raise serializers.ValidationError(
-                            {
-                                "logic_rules": {
-                                    str(rule.order): {
-                                        "actions": {
-                                            str(action_index): {
-                                                "form_step_slug": _(
-                                                    "Invalid form step specified in logic action."
-                                                )
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            code="invalid",
-                        )
+        for index, rule in enumerate(temp_rules):
+            # at this point, the shape of the actions has been validated, but their semantic
+            # meaning hasn't yet
+            actions: Sequence[FormLogicActionData] = rule.actions
+            if rule_action_errors := validate_logic_actions(
+                actions,
+                find_component=_find_component,
+                form_variables=form_variables,
+                form_step_slugs=form_step_slugs,
+            ):
+                rule_errors[index] = {"actions": rule_action_errors}
 
-                # check that "disabled" property is not changed for layout components
-                if action_type == LogicActionTypes.property:
-                    formio_component: None | Component = None
-                    for form_step in form.formstep_set.select_related(
-                        "form_definition"
-                    ):
-                        if component in (
-                            wrapper := form_step.form_definition.configuration_wrapper
-                        ):
-                            formio_component = wrapper[component]
-                            break
-
-                    if (
-                        formio_component
-                        and not holds_submission_data(formio_component)
-                        and glom(action, "action.property.value") == "disabled"
-                    ):
-                        raise serializers.ValidationError(
-                            {
-                                "logic_rules": {
-                                    str(rule.order): {
-                                        "actions": {
-                                            str(action_index): {
-                                                "action": {
-                                                    "component": _(
-                                                        "'disabled' property can't be used for layout components."
-                                                    )
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            },
-                            code="invalid",
-                        )
+        if rule_errors:
+            raise ValidationError({"logic_rules": rule_errors})  # pyright:ignore[reportArgumentType]
 
     def _validate_and_process_logic_rules(
         self,

--- a/src/openforms/forms/api/v3/serializers/logic_rules.py
+++ b/src/openforms/forms/api/v3/serializers/logic_rules.py
@@ -1,0 +1,135 @@
+import uuid
+
+from django.utils.translation import gettext_lazy as _
+
+from drf_spectacular.utils import extend_schema_field, extend_schema_serializer
+from ordered_model.serializers import OrderedModelSerializer
+from rest_framework import serializers
+
+from openforms.formio.api.fields import FormioVariableKeyField
+
+from ....constants import (
+    LOGIC_ACTION_TYPES_REQUIRING_COMPONENT,
+    LOGIC_ACTION_TYPES_REQUIRING_FORM_STEP_SLUG,
+    LOGIC_ACTION_TYPES_REQUIRING_VARIABLE,
+)
+from ....models import FormLogic
+from ...serializers.logic.action_serializers import (
+    LogicActionPolymorphicSerializer,
+    _join_action_types,
+)
+from ...validators import (
+    JsonLogicTriggerValidator,
+    JsonLogicValidator,
+)
+
+
+@extend_schema_field(
+    {
+        "type": "object",
+        "title": "JSON logic",
+        "description": "The trigger expression to determine if the actions should "
+        "execute or not. Note that this must be a valid JsonLogic expression, and the "
+        "first operand must be a reference to a variable in the form.",
+        "additionalProperties": True,
+        "example": {
+            "==": [
+                {"var": "checkbox"},
+                True,
+            ]
+        },
+    }
+)
+class JsonLogicField(serializers.JSONField):
+    pass
+
+
+@extend_schema_serializer(component_name="LogicComponentActionV3Serializer")
+class LogicComponentActionSerializer(serializers.Serializer):
+    uuid = serializers.UUIDField(
+        read_only=True,
+        default=uuid.uuid4,
+        label=_("UUID"),
+    )
+    component = FormioVariableKeyField(
+        required=False,
+        allow_blank=True,
+        label=_("Form.io component key"),
+        help_text=_(
+            "Key of the Form.io component that the action applies to. This field is "
+            "required for the action types {action_types} - otherwise it's optional."
+        ).format(
+            action_types=_join_action_types(LOGIC_ACTION_TYPES_REQUIRING_COMPONENT)
+        ),
+    )
+    variable = FormioVariableKeyField(
+        required=False,
+        allow_blank=True,
+        label=_("Key of the target variable"),
+        help_text=_(
+            "Key of the target variable whose value will be changed. This field is "
+            "required for the action types {action_types} - otherwise it's optional."
+        ).format(
+            action_types=_join_action_types(LOGIC_ACTION_TYPES_REQUIRING_VARIABLE)
+        ),
+    )
+    form_step_slug = serializers.CharField(
+        allow_blank=True,
+        required=False,
+        label=_("form step slug"),
+        help_text=_(
+            "The slug of the form step that will be affected by the action. This field "
+            "is required for action types {action_types} - otherwise it's optional. We "
+            "deliberately use the slug instead of the uuid because the uuid is not fixed, "
+            "as we create from scratch the form steps dusring form update."
+        ).format(
+            action_types=_join_action_types(LOGIC_ACTION_TYPES_REQUIRING_FORM_STEP_SLUG)
+        ),
+    )
+    action = LogicActionPolymorphicSerializer()
+
+
+@extend_schema_serializer(component_name="FormLogicV3Serializer")
+class FormLogicSerializer(OrderedModelSerializer):
+    """Represent logic rules with their actions as a nested serializer."""
+
+    actions = LogicComponentActionSerializer(
+        many=True,
+        label=_("actions"),
+        help_text=_(
+            "Actions triggered when the trigger expression evaluates to 'truthy'."
+        ),
+    )
+    json_logic_trigger = JsonLogicField()
+
+    class Meta:  # pyright: ignore[reportIncompatibleVariableOverride]
+        model = FormLogic
+        fields = (
+            "uuid",
+            "json_logic_trigger",
+            "description",
+            "order",
+            "actions",
+            "is_advanced",
+        )
+        extra_kwargs = {
+            "uuid": {"read_only": True},
+            "json_logic_trigger": {
+                "help_text": _(
+                    "The trigger expression to determine if the actions should execute "
+                    "or not. Note that this must be a valid JsonLogic expression, and "
+                    "the first operand must be a reference to a variable in the form."
+                ),
+                "validators": [JsonLogicValidator()],
+            },
+            "order": {
+                "read_only": False,
+                "help_text": _(
+                    "Order of the rule relative to the form it belongs to. Logic rules "
+                    "are evaluated in this order. Note that specifying a value for the "
+                    "order here will cause the rules before/after this rule to be "
+                    "re-calculated."
+                ),
+            },
+        }
+        validators = [JsonLogicTriggerValidator("json_logic_trigger")]

--- a/src/openforms/forms/api/v3/typing.py
+++ b/src/openforms/forms/api/v3/typing.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import NotRequired, TypedDict
+from typing import Literal, NotRequired, TypedDict
 from uuid import UUID
 
 from openforms.appointments.base import Product
@@ -8,6 +8,7 @@ from openforms.data_removal.constants import RemovalMethods
 from openforms.emails.typing import ConfirmationEmailTemplateTranslatedData
 from openforms.formio.typing import FormioConfiguration
 from openforms.prefill.constants import IdentifierRoles
+from openforms.typing import JSONObject, JSONValue
 from openforms.variables.constants import (
     DataMappingTypes,
     FormVariableDataTypes,
@@ -15,7 +16,12 @@ from openforms.variables.constants import (
     ServiceFetchMethods,
 )
 
-from ...constants import FormTypeChoices, StatementCheckboxChoices
+from ...constants import (
+    FormTypeChoices,
+    LogicActionTypes,
+    PropertyTypes,
+    StatementCheckboxChoices,
+)
 from ...models import Category
 
 
@@ -140,6 +146,102 @@ class FormVariableData(TypedDict):
     service_fetch_configuration: NotRequired[ServiceFetchConfigurationData | None]
 
 
+class LogicActionServiceData(TypedDict):
+    type: Literal[LogicActionTypes.fetch_from_service]
+    value: JSONValue
+
+
+class LogicActionDummyData(TypedDict):
+    type: Literal[
+        LogicActionTypes.disable_next,
+        LogicActionTypes.step_not_applicable,
+        LogicActionTypes.step_applicable,
+    ]
+
+
+class PropertyData(TypedDict):
+    type: PropertyTypes
+    value: str
+
+
+class LogicActionPropertyData(TypedDict):
+    type: Literal[LogicActionTypes.property]
+    property: PropertyData
+    state: JSONValue
+
+
+class LogicValueData(TypedDict):
+    type: Literal[LogicActionTypes.variable]
+    value: JSONValue
+
+
+class VariableMappingData(TypedDict):
+    form_variable: str
+    dmn_variable: str
+
+
+class LogicActionDMNEvaluateConfigData(TypedDict):
+    plugin_id: str
+    decision_definition_id: str
+    decision_definition_version: NotRequired[str]
+    input_mapping: list[VariableMappingData]
+    output_mapping: list[VariableMappingData]
+
+
+class LogicActionDMNEvaluateData(TypedDict):
+    type: Literal[LogicActionTypes.evaluate_dmn]
+    config: LogicActionDMNEvaluateConfigData
+
+
+class LogicActionRegistrationBackendData(TypedDict):
+    type: Literal[LogicActionTypes.set_registration_backend]
+    value: str
+
+
+class SynchronizeDataMappingData(TypedDict):
+    property: str
+    component_key: str
+
+
+class SynchronizeVariableConfigData(TypedDict):
+    identifier_variable: str
+    source_variable: str
+    destination_variable: str
+    data_mappings: list[SynchronizeDataMappingData]
+
+
+class LogicActionSynchronizeVariableData(TypedDict):
+    type: Literal[LogicActionTypes.synchronize_variables]
+    config: SynchronizeVariableConfigData
+
+
+type LogicActionTypeData = (
+    LogicActionDummyData
+    | LogicActionPropertyData
+    | LogicActionServiceData
+    | LogicValueData
+    | LogicActionDMNEvaluateData
+    | LogicActionRegistrationBackendData
+    | LogicActionSynchronizeVariableData
+)
+
+
+class FormLogicActionData(TypedDict):
+    component: NotRequired[str]
+    variable: NotRequired[str]
+    form_step_slug: NotRequired[str]
+    action: LogicActionTypeData
+    config: NotRequired[LogicActionDMNEvaluateConfigData]
+
+
+class FormLogicData(TypedDict):
+    json_logic_trigger: JSONObject
+    description: NotRequired[str]
+    order: int
+    actions: list[FormLogicActionData]
+    is_advanced: NotRequired[bool]
+
+
 class FormValidatedData(TypedDict):
     uuid: UUID
     name: str
@@ -157,6 +259,7 @@ class FormValidatedData(TypedDict):
     payment: NotRequired[PaymentData]
 
     formvariable_set: list[FormVariableData]
+    formlogic_set: list[FormLogicData]
 
     show_progress_indicator: NotRequired[bool]
     show_summary_progress: NotRequired[bool]

--- a/src/openforms/forms/api/v3/validation.py
+++ b/src/openforms/forms/api/v3/validation.py
@@ -1,0 +1,176 @@
+from collections import defaultdict
+from collections.abc import Callable, Collection, Mapping, Sequence
+from datetime import date
+from typing import assert_never
+
+from django.utils.translation import gettext as _
+
+from json_logic.typing import Primitive
+from rest_framework.exceptions import ErrorDetail
+
+from openforms.formio.service import holds_submission_data
+from openforms.formio.typing import Component
+from openforms.variables.constants import FormVariableDataTypes
+
+from ...constants import LogicActionTypes
+from ...models import FormVariable
+from .typing import FormLogicActionData
+
+type ActionsErrors = defaultdict[int, defaultdict[str, list[ErrorDetail]]]
+"""
+A mapping of action indices to field errors.
+
+The field errors themselves are a mapping of field name to a collection of errors for
+that field. The field names are the keys of a logic action struct (polymorphic).
+"""
+
+
+def validate_logic_actions(
+    actions: Sequence[FormLogicActionData],
+    *,
+    find_component: Callable[[str], Component | None],
+    form_variables: Mapping[str, FormVariable],
+    form_step_slugs: Collection[str],
+) -> ActionsErrors:
+    """
+    Validate a collection of logic rule actions.
+
+    :param actions: The (ordered) collection of actions to verify against the form
+      configuration.
+    :param find_component: An (optimized) callback to to resolve a component key against
+      a Formio component in any of the form steps.
+    :param form_variables: A mapping of all known form variable keys to their form
+      variable instance, including both component and user defined variables.
+    :param form_step_slugs: A collection of all the form step slugs used in the form.
+    """
+    errors: ActionsErrors = defaultdict(lambda: defaultdict(list))
+
+    for action_index, action in enumerate(actions):
+        # the enum helps enforce the value, and we expect input validation to
+        # validate that the action key & type key are present already
+        action_type = LogicActionTypes(action["action"]["type"])
+
+        # actions are polymorphic, so their configuration needs to be validated based on
+        # the discriminator key. Pattern matching works well for this.
+
+        match action_type:
+            # LOGIC_ACTION_TYPES_REQUIRING_COMPONENT
+            case LogicActionTypes.property:
+                # check that a component is provided
+                component_key = action.get("component") or ""
+                if not component_key:
+                    errors[action_index]["component"].append(
+                        ErrorDetail(_("This field may not be blank."), code="blank")
+                    )
+                    continue
+
+                # now that we know a component is provided, check that it exists
+                component = find_component(component_key)
+                if component is None:
+                    errors[action_index]["component"].append(
+                        ErrorDetail(
+                            _("Could not find the component with key '{key}'.").format(
+                                key=component_key
+                            ),
+                            code="invalid",
+                        )
+                    )
+                    continue
+
+                # check that "disabled" property is not changed for layout components
+                match action["action"]:
+                    case {"property": {"value": "disabled"}} if (
+                        not holds_submission_data(component)
+                    ):
+                        errors[action_index]["component"].append(
+                            ErrorDetail(
+                                _(
+                                    "You cannot used the 'disabled' property "
+                                    "on layout components'."
+                                ),
+                                code="invalid",
+                            )
+                        )
+                    case _:
+                        pass
+
+            # LOGIC_ACTION_TYPES_REQUIRING_VARIABLE
+            case LogicActionTypes.variable:
+                # check that a variable is specified
+                variable_key = action.get("variable") or ""
+                if not variable_key:
+                    errors[action_index]["variable"].append(
+                        ErrorDetail(_("You must specify a variable."), code="blank")
+                    )
+                    continue
+
+                # check that the variable exists
+                form_var = form_variables.get(variable_key)
+                if form_var is None:
+                    errors[action_index]["variable"].append(
+                        ErrorDetail(
+                            _("Could not find the variable with key '{key}'.").format(
+                                key=variable_key
+                            ),
+                            code="invalid",
+                        )
+                    )
+                    continue
+
+                # validate format of value for date variable
+                assert "value" in action["action"]
+                action_value = action["action"]["value"]
+                if (
+                    isinstance(action_value, Primitive)
+                    and form_var.data_type == FormVariableDataTypes.date
+                ):
+                    try:
+                        # type check muted since we handle it at runtime
+                        date.fromisoformat(action_value)  # pyright: ignore[reportArgumentType]
+                    except (ValueError, TypeError):
+                        errors[action_index]["action.value"].append(
+                            ErrorDetail(
+                                _(
+                                    "The value for a date variable must be a string in "
+                                    "the format yyyy-mm-dd (e.g. 2023-07-03)"
+                                ),
+                                code="invalid",
+                            )
+                        )
+
+            case (
+                LogicActionTypes.step_applicable
+                | LogicActionTypes.step_not_applicable
+                | LogicActionTypes.disable_next
+            ):
+                # validate form step slug exists in action
+                form_step_slug = action.get("form_step_slug") or ""
+                if not form_step_slug:
+                    errors[action_index]["formStepSlug"].append(
+                        ErrorDetail(_("This field may not be blank."), code="blank")
+                    )
+                    continue
+
+                # validate form step slug is valid
+                if form_step_slug not in form_step_slugs:
+                    errors[action_index]["formStepSlug"].append(
+                        ErrorDetail(
+                            _("Could not find a step with the slug '{slug}'.").format(
+                                slug=form_step_slug
+                            ),
+                            code="invalid",
+                        )
+                    )
+                    continue
+
+            case (
+                LogicActionTypes.fetch_from_service
+                | LogicActionTypes.set_registration_backend
+                | LogicActionTypes.evaluate_dmn
+                | LogicActionTypes.synchronize_variables
+            ):
+                pass
+            case _:  # pragma: no cover
+                assert_never(action_type)
+
+    return errors

--- a/src/openforms/forms/constants.py
+++ b/src/openforms/forms/constants.py
@@ -39,6 +39,12 @@ LOGIC_ACTION_TYPES_REQUIRING_FORM_STEP_UUID: Set[str] = {
     LogicActionTypes.disable_next.value,
 }
 
+# TODO
+# Clean this up when the above is not needed (during v2 removal)
+LOGIC_ACTION_TYPES_REQUIRING_FORM_STEP_SLUG = (
+    LOGIC_ACTION_TYPES_REQUIRING_FORM_STEP_UUID
+)
+
 
 class PropertyTypes(models.TextChoices):
     bool = "bool", _("Boolean")

--- a/src/openforms/forms/constants.py
+++ b/src/openforms/forms/constants.py
@@ -1,5 +1,3 @@
-from collections.abc import Set
-
 from django.db import models
 from django.utils.translation import gettext_lazy as _
 
@@ -31,9 +29,9 @@ class LogicActionTypes(models.TextChoices):
         return dict(cls.choices)[value]
 
 
-LOGIC_ACTION_TYPES_REQUIRING_COMPONENT: Set[str] = {LogicActionTypes.property.value}
-LOGIC_ACTION_TYPES_REQUIRING_VARIABLE: Set[str] = {LogicActionTypes.variable.value}
-LOGIC_ACTION_TYPES_REQUIRING_FORM_STEP_UUID: Set[str] = {
+LOGIC_ACTION_TYPES_REQUIRING_COMPONENT: set[str] = {LogicActionTypes.property.value}
+LOGIC_ACTION_TYPES_REQUIRING_VARIABLE: set[str] = {LogicActionTypes.variable.value}
+LOGIC_ACTION_TYPES_REQUIRING_FORM_STEP_UUID: set[str] = {
     LogicActionTypes.step_applicable.value,
     LogicActionTypes.step_not_applicable.value,
     LogicActionTypes.disable_next.value,

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -4,6 +4,7 @@ from datetime import timedelta
 from uuid import UUID, uuid4
 
 from django.db import connections
+from django.test import override_settings
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.text import get_text_list
@@ -43,11 +44,12 @@ from ...constants import (
     StatementCheckboxChoices,
     SubmissionAllowedChoices,
 )
-from ...models import Form, FormDefinition, FormRegistrationBackend
+from ...models import Form, FormDefinition, FormLogic, FormRegistrationBackend
 from ...tests.factories import (
     CategoryFactory,
     FormDefinitionFactory,
     FormFactory,
+    FormLogicFactory,
     FormStepFactory,
 )
 
@@ -304,6 +306,23 @@ class FormEndpointTests(APITestCase):
                     b"\xf6\x178U\x00\x00\x00\x00IEND\xaeB`\x82"
                 ).decode("ascii"),
             },
+            "logic_rules": [
+                {
+                    "order": 0,
+                    "jsonLogicTrigger": {"==": [{"var": "component1"}, "foo"]},
+                    "actions": [
+                        {
+                            "component": "component2",
+                            "action": {
+                                "type": "property",
+                                "property": {"type": "bool", "value": "hidden"},
+                                "value": "",
+                                "state": True,
+                            },
+                        }
+                    ],
+                },
+            ],
         }
         response = self.client.put(url, data=data)
 
@@ -523,6 +542,9 @@ class FormEndpointTests(APITestCase):
             form.explanation_template_nl, "Wees klaar om voor koekjes te vragen"
         )
         self.assertEqual(form.help_dialog_content_nl, "hulpinformatie")
+
+        # logic rules
+        self.assertEqual(form.formlogic_set.count(), 1)
 
     def test_create_reuse_existing_definition(self):
         form_definition = FormDefinitionFactory.create(
@@ -3318,6 +3340,864 @@ class FormEndpointVariableTests(APITestCase):
         self.assertEqual(
             error_message["reason"],
             "Unknown component key 'foobar' specified for profile form variable",
+        )
+
+
+@override_settings(LANGUAGE_CODE="en")
+class FormEndpointLogicRulesTests(APITestCase):
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+
+        cls.admin_user = UserFactory.create(
+            is_staff=True, user_permissions=("forms.change_form",)
+        )
+
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.client.force_authenticate(user=self.admin_user)
+
+    def test_create_form_with_logic_rules(self):
+        form_definition_uuid = uuid4()
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "slug": "create-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "textField",
+                                    "label": "TextField",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                                {
+                                    "type": "checkbox",
+                                    "key": "checkbox",
+                                    "label": "Checkbox",
+                                    "hidden": False,
+                                    "clearOnHide": False,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration",
+                                "internalName": "Form configuration",
+                            },
+                            "nl": {
+                                "name": "Form configuratie",
+                                "internalName": "Form configuratie",
+                            },
+                        },
+                    },
+                },
+            ],
+            "variables": [
+                {
+                    "name": "Extra_var",
+                    "key": "extra_var",
+                    "source": FormVariableSources.user_defined,
+                    "formDefinition": None,
+                    "dataType": FormVariableDataTypes.string,
+                },
+            ],
+            "logic_rules": [
+                {
+                    "order": 0,
+                    "jsonLogicTrigger": {"==": [{"var": "checkbox"}, True]},
+                    "actions": [
+                        {
+                            "component": "textField",
+                            "action": {
+                                "type": "property",
+                                "property": {"type": "bool", "value": "hidden"},
+                                "value": "",
+                                "state": True,
+                            },
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Form.objects.count(), 1)
+        form = Form.objects.get()
+
+        self.assertEqual(form.formlogic_set.count(), 1)
+
+    def test_update_form_with_logic_rules(self):
+        form = FormFactory.create(generate_minimal_setup=True)
+        form_definition = form.formstep_set.get().form_definition
+        FormLogicFactory.create(form=form)
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition.uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "test-key",
+                                    "label": "TextField",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                                {
+                                    "type": "checkbox",
+                                    "key": "checkbox",
+                                    "label": "Checkbox",
+                                    "hidden": False,
+                                    "clearOnHide": False,
+                                },
+                            ],
+                        },
+                        "translations": {
+                            "en": {
+                                "name": "Form configuration",
+                                "internalName": "Form configuration",
+                            },
+                            "nl": {
+                                "name": "Form configuratie",
+                                "internalName": "Form configuratie",
+                            },
+                        },
+                    },
+                },
+            ],
+            "logic_rules": [
+                {
+                    "order": 0,
+                    "jsonLogicTrigger": {"==": [{"var": "checkbox"}, True]},
+                    "actions": [
+                        {
+                            "component": "test-key",
+                            "action": {
+                                "type": "property",
+                                "property": {"type": "bool", "value": "hidden"},
+                                "value": "",
+                                "state": True,
+                            },
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(Form.objects.count(), 1)
+        form.refresh_from_db()
+
+        logic_rule = FormLogic.objects.get()
+        self.assertEqual(form.formlogic_set.get(), logic_rule)
+        self.assertEqual(
+            logic_rule.actions,
+            [
+                {
+                    "action": {
+                        "type": "property",
+                        "state": True,
+                        "property": {"type": "bool", "value": "hidden"},
+                    },
+                    "component": "test-key",
+                }
+            ],
+        )
+
+    def test_component_missing_from_action_and_present_in_form(self):
+        form = FormFactory.create()
+        form_step = FormStepFactory.create(form=form, slug="step-1")
+        form_definition = form_step.form_definition
+        FormLogicFactory.create(form=form)
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition.uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "textField",
+                                    "label": "TextField",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            "logic_rules": [
+                {
+                    "order": 0,
+                    "jsonLogicTrigger": False,
+                    "is_advanced": True,
+                    "actions": [
+                        {
+                            "formStepSlug": form_step.slug,
+                            "action": {"type": "disable-next"},
+                        }
+                    ],
+                },
+                {
+                    "order": 1,
+                    "jsonLogicTrigger": True,
+                    "is_advanced": True,
+                    "actions": [
+                        {
+                            "component": "",
+                            "action": {
+                                "type": "property",
+                                "property": {"type": "bool", "value": "hidden"},
+                                "value": "",
+                                "state": True,
+                            },
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response_data["code"], "invalid")
+        self.assertEqual(
+            response_data["invalidParams"][0],
+            {
+                "name": "logicRules.1.actions.0.component",
+                "code": "blank",
+                "reason": "This field may not be blank.",
+            },
+        )
+
+    def test_variable_missing_from_action_and_present_in_form(self):
+        form = FormFactory.create()
+        form_step = FormStepFactory.create(form=form, slug="step-1")
+        form_definition = form_step.form_definition
+        FormLogicFactory.create(form=form)
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition.uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "textField",
+                                    "label": "TextField",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            "logic_rules": [
+                {
+                    "order": 0,
+                    "jsonLogicTrigger": True,
+                    "is_advanced": True,
+                    "actions": [
+                        {
+                            "action": {
+                                "type": "variable",
+                                "property": {"type": "", "value": ""},
+                                "value": "foo",
+                                "state": "",
+                            },
+                            "variable": "",
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response_data["code"], "invalid")
+        self.assertEqual(
+            response_data["invalidParams"][0],
+            {
+                "name": "logicRules.0.actions.0.variable",
+                "code": "blank",
+                "reason": "You must specify a variable.",
+            },
+        )
+
+    def test_wrong_variable_provided_in_variable_action(self):
+        form = FormFactory.create()
+        form_step = FormStepFactory.create(form=form, slug="step-1")
+        form_definition = form_step.form_definition
+        FormLogicFactory.create(form=form)
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition.uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "textField",
+                                    "label": "TextField",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            "logic_rules": [
+                {
+                    "order": 0,
+                    "jsonLogicTrigger": True,
+                    "is_advanced": True,
+                    "actions": [
+                        {
+                            "action": {
+                                "type": "variable",
+                                "property": {"type": "", "value": ""},
+                                "value": "foo",
+                                "state": "",
+                            },
+                            "variable": "wrong",
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response_data["code"], "invalid")
+        self.assertEqual(
+            response_data["invalidParams"][0],
+            {
+                "name": "logicRules.0.actions.0.variable",
+                "code": "invalid",
+                "reason": "The variable wrong does not exist.",
+            },
+        )
+
+    def test_wrong_date_format_in_variable_action(self):
+        form = FormFactory.create()
+        form_step = FormStepFactory.create(form=form, slug="step-1")
+        form_definition = form_step.form_definition
+        FormLogicFactory.create(form=form)
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition.uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "date",
+                                    "key": "date",
+                                    "label": "Date",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            "logic_rules": [
+                {
+                    "order": 0,
+                    "jsonLogicTrigger": True,
+                    "is_advanced": True,
+                    "actions": [
+                        {
+                            "action": {
+                                "type": "variable",
+                                "property": {"type": "", "value": ""},
+                                "value": "foo",
+                                "state": "",
+                            },
+                            "variable": "date",
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response_data["code"], "invalid")
+        self.assertEqual(
+            response_data["invalidParams"][0],
+            {
+                "name": "logicRules.0.actions.0.value",
+                "code": "invalid",
+                "reason": "Value for date variable must be a string in the format yyyy-mm-dd (e.g. 2023-07-03)",
+            },
+        )
+
+    def test_layout_components_and_disabled(self):
+        form = FormFactory.create()
+        form_step = FormStepFactory.create(form=form, slug="step-1")
+        form_definition = form_step.form_definition
+        FormLogicFactory.create(form=form)
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition.uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "fieldset",
+                                    "key": "fieldset",
+                                    "label": "Fieldset",
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            "logic_rules": [
+                {
+                    "order": 0,
+                    "jsonLogicTrigger": True,
+                    "is_advanced": True,
+                    "actions": [
+                        {
+                            "component": "fieldset",
+                            "action": {
+                                "type": "property",
+                                "property": {
+                                    "type": "bool",
+                                    "value": "disabled",
+                                },
+                                "value": "",
+                                "state": True,
+                            },
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response_data["code"], "invalid")
+        self.assertEqual(
+            response_data["invalidParams"][0],
+            {
+                "name": "logicRules.0.actions.0.component",
+                "code": "invalid",
+                "reason": "'disabled' property can't be used for layout components.",
+            },
+        )
+
+    def test_missing_form_step_slug_from_action(self):
+        form = FormFactory.create()
+        form_step = FormStepFactory.create(form=form, slug="step-1")
+        form_definition = form_step.form_definition
+        FormLogicFactory.create(form=form)
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition.uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "fieldset",
+                                    "key": "fieldset",
+                                    "label": "Fieldset",
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            "logic_rules": [
+                {
+                    "order": 0,
+                    "jsonLogicTrigger": True,
+                    "is_advanced": True,
+                    "actions": [
+                        {
+                            "component": "",
+                            "formStepSlug": None,
+                            "action": {
+                                "type": "disable-next",
+                                "property": {"type": "", "value": ""},
+                                "value": "",
+                                "state": "",
+                            },
+                        },
+                    ],
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response_data["code"], "invalid")
+        self.assertEqual(
+            response_data["invalidParams"][0],
+            {
+                "name": "logicRules.0.actions.0.formStepSlug",
+                "code": "null",
+                "reason": "This field may not be null.",
+            },
+        )
+
+    def test_invalid_form_step_slug_in_action(self):
+        form = FormFactory.create()
+        form_step = FormStepFactory.create(form=form, slug="step-1")
+        form_definition = form_step.form_definition
+        FormLogicFactory.create(form=form)
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition.uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "fieldset",
+                                    "key": "fieldset",
+                                    "label": "Fieldset",
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            "logic_rules": [
+                {
+                    "order": 0,
+                    "jsonLogicTrigger": True,
+                    "is_advanced": True,
+                    "actions": [
+                        {
+                            "component": "",
+                            "formStepSlug": "wrong",
+                            "action": {
+                                "type": "disable-next",
+                                "property": {"type": "", "value": ""},
+                                "value": "",
+                                "state": "",
+                            },
+                        },
+                    ],
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response_data["code"], "invalid")
+        self.assertEqual(
+            response_data["invalidParams"][0],
+            {
+                "name": "logicRules.0.actions.0.formStepSlug",
+                "code": "invalid",
+                "reason": "Invalid form step specified in logic action.",
+            },
+        )
+
+    def test_logic_rules_with_cycles_detected(self):
+        form = FormFactory.create(generate_minimal_setup=True)
+        form_step = FormStepFactory.create(form=form, slug="step-1")
+        form_definition = form_step.form_definition
+        FormLogicFactory.create(form=form)
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition.uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "key": "foo",
+                                    "type": "textfield",
+                                    "label": "Foo",
+                                },
+                                {
+                                    "key": "bar",
+                                    "type": "textfield",
+                                    "label": "Bar",
+                                },
+                                {
+                                    "key": "baz",
+                                    "type": "textfield",
+                                    "label": "Baz",
+                                },
+                                {
+                                    "key": "self",
+                                    "type": "textfield",
+                                    "label": "Self",
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            "logic_rules": [
+                {
+                    "jsonLogicTrigger": {"==": [{"var": "self"}, ""]},
+                    "description": "Set self",
+                    "order": 0,
+                    "actions": [
+                        {
+                            "variable": "self",
+                            "action": {"type": "variable", "value": "self"},
+                        }
+                    ],
+                },
+                {
+                    "jsonLogicTrigger": {"==": [{"var": "foo"}, ""]},
+                    "description": "Set bar",
+                    "order": 1,
+                    "actions": [
+                        {
+                            "variable": "bar",
+                            "action": {"type": "variable", "value": "bar"},
+                        }
+                    ],
+                },
+                {
+                    "jsonLogicTrigger": {"==": [{"var": "bar"}, ""]},
+                    "description": "Set baz",
+                    "order": 2,
+                    "actions": [
+                        {
+                            "variable": "baz",
+                            "action": {"type": "variable", "value": "baz"},
+                        }
+                    ],
+                },
+                {
+                    "jsonLogicTrigger": {"==": [{"var": "baz"}, ""]},
+                    "description": "Set foo",
+                    "order": 3,
+                    "actions": [
+                        {
+                            "variable": "foo",
+                            "action": {"type": "variable", "value": "foo"},
+                        }
+                    ],
+                },
+            ],
+        }
+
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(status.HTTP_400_BAD_REQUEST, response.status_code)
+
+        expected_error = [
+            {
+                "name": "0.jsonLogicTrigger",
+                "code": "cycles-detected",
+                "reason": _(
+                    "Rule contains cycles through variable(s): {variables}."
+                ).format(variables="self"),
+            },
+            {
+                "name": "1.jsonLogicTrigger",
+                "code": "cycles-detected",
+                "reason": _(
+                    "Rule contains cycles through variable(s): {variables}."
+                ).format(variables="bar, baz, foo"),
+            },
+            {
+                "name": "2.jsonLogicTrigger",
+                "code": "cycles-detected",
+                "reason": _(
+                    "Rule contains cycles through variable(s): {variables}."
+                ).format(variables="bar, baz, foo"),
+            },
+            {
+                "name": "3.jsonLogicTrigger",
+                "code": "cycles-detected",
+                "reason": _(
+                    "Rule contains cycles through variable(s): {variables}."
+                ).format(variables="bar, baz, foo"),
+            },
+        ]
+        self.assertEqual(response.json()["invalidParams"], expected_error)
+
+    def test_validation_reports_multiple_errors(self):
+        form = FormFactory.create()
+        form_step = FormStepFactory.create(form=form, slug="step-1")
+        form_definition = form_step.form_definition
+        FormLogicFactory.create(form=form)
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition.uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "fieldset",
+                                    "key": "fieldset",
+                                    "label": "Fieldset",
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            "logic_rules": [
+                {
+                    "order": 0,
+                    "jsonLogicTrigger": True,
+                    "is_advanced": True,
+                    "actions": [
+                        {
+                            "component": "",
+                            "formStepSlug": "",
+                            "action": {
+                                "type": "disable-next",
+                                "property": {"type": "", "value": ""},
+                                "value": "",
+                                "state": "",
+                            },
+                        },
+                        {
+                            "variable": "",
+                            "action": {
+                                "type": "variable",
+                                "value": 42,
+                            },
+                        },
+                    ],
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response_data["code"], "invalid")
+        self.assertEqual(
+            response_data["invalidParams"][0],
+            {
+                "name": "logicRules.0.actions.0.formStepSlug",
+                "code": "blank",
+                "reason": "This field may not be blank.",
+            },
+        )
+        self.assertEqual(
+            response_data["invalidParams"][1],
+            {
+                "name": "logicRules.0.actions.1.variable",
+                "code": "blank",
+                "reason": "This field may not be blank.",
+            },
         )
 
 

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -3412,6 +3412,16 @@ class FormEndpointLogicRulesTests(APITestCase):
                     "dataType": FormVariableDataTypes.string,
                 },
             ],
+            "registrationBackends": [
+                {
+                    "name": "Email registration",
+                    "key": "email-fu",
+                    "backend": "email",
+                    "options": {
+                        "to_emails": ["foo@example.com"],
+                    },
+                }
+            ],
             "logic_rules": [
                 {
                     "order": 0,
@@ -3425,7 +3435,13 @@ class FormEndpointLogicRulesTests(APITestCase):
                                 "value": "",
                                 "state": True,
                             },
-                        }
+                        },
+                        {
+                            "action": {
+                                "type": "set-registration-backend",
+                                "value": "email-fu",
+                            },
+                        },
                     ],
                 },
             ],
@@ -3602,6 +3618,63 @@ class FormEndpointLogicRulesTests(APITestCase):
             },
         )
 
+    def test_invalid_component_reference_is_caught_during_validation(self):
+        url = reverse("api:v3:form-detail", kwargs={"uuid": uuid4()})
+        data = {
+            "name": "Create form",
+            "slug": "create-form",
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": str(uuid4()),
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "textField",
+                                    "label": "TextField",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            "logic_rules": [
+                {
+                    "order": 0,
+                    "jsonLogicTrigger": True,
+                    "is_advanced": True,
+                    "actions": [
+                        {
+                            "component": "badReference",
+                            "action": {
+                                "type": "property",
+                                "property": {"type": "bool", "value": "hidden"},
+                                "value": "",
+                                "state": True,
+                            },
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        response_data = response.json()
+        self.assertEqual(response_data["code"], "invalid")
+        self.assertEqual(
+            response_data["invalidParams"][0],
+            {
+                "name": "logicRules.0.actions.0.component",
+                "code": "invalid",
+                "reason": "Could not find the component with key 'badReference'.",
+            },
+        )
+
     def test_variable_missing_from_action_and_present_in_form(self):
         form = FormFactory.create()
         form_step = FormStepFactory.create(form=form, slug="step-1")
@@ -3728,7 +3801,7 @@ class FormEndpointLogicRulesTests(APITestCase):
             {
                 "name": "logicRules.0.actions.0.variable",
                 "code": "invalid",
-                "reason": "The variable wrong does not exist.",
+                "reason": "Could not find the variable with key 'wrong'.",
             },
         )
 
@@ -3791,9 +3864,12 @@ class FormEndpointLogicRulesTests(APITestCase):
         self.assertEqual(
             response_data["invalidParams"][0],
             {
-                "name": "logicRules.0.actions.0.value",
+                "name": "logicRules.0.actions.0.action.value",
                 "code": "invalid",
-                "reason": "Value for date variable must be a string in the format yyyy-mm-dd (e.g. 2023-07-03)",
+                "reason": (
+                    "The value for a date variable must be a string in the format "
+                    "yyyy-mm-dd (e.g. 2023-07-03)"
+                ),
             },
         )
 
@@ -3859,7 +3935,7 @@ class FormEndpointLogicRulesTests(APITestCase):
             {
                 "name": "logicRules.0.actions.0.component",
                 "code": "invalid",
-                "reason": "'disabled' property can't be used for layout components.",
+                "reason": "You cannot used the 'disabled' property on layout components'.",
             },
         )
 
@@ -3987,7 +4063,7 @@ class FormEndpointLogicRulesTests(APITestCase):
             {
                 "name": "logicRules.0.actions.0.formStepSlug",
                 "code": "invalid",
-                "reason": "Invalid form step specified in logic action.",
+                "reason": "Could not find a step with the slug 'wrong'.",
             },
         )
 
@@ -4196,7 +4272,7 @@ class FormEndpointLogicRulesTests(APITestCase):
             {
                 "name": "logicRules.0.actions.1.variable",
                 "code": "blank",
-                "reason": "This field may not be blank.",
+                "reason": "You must specify a variable.",
             },
         )
 


### PR DESCRIPTION
Closes #5958

**Changes**

- Add new field `logic_rules` to the new v3 form endpoint
- Add validation concerning the logic rules and actions
- Add tests

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
