### PR TITLE
Fix failing check scripts

### DIFF
--- a/bin/report_file_component_inconsistent_catalogues.py
+++ b/bin/report_file_component_inconsistent_catalogues.py
@@ -67,14 +67,11 @@ def report_components() -> bool:
     from openforms.registrations.contrib.objects_api.constants import (
         PLUGIN_IDENTIFIER as OBJECTS_API_PLUGIN_IDENTIFIER,
     )
-    from openforms.registrations.contrib.zgw_apis.plugin import (
-        PLUGIN_IDENTIFIER as ZGW_APIS_PLUGIN_IDENTIFIER,
-    )
     from openforms.registrations.contrib.zgw_apis.typing import CatalogueOption
 
     RELEVANT_BACKENDS = {
         OBJECTS_API_PLUGIN_IDENTIFIER,
-        ZGW_APIS_PLUGIN_IDENTIFIER,
+        "zgw-create-zaak",
     }
 
     forms = (

--- a/bin/report_logic_with_deprecated_clear_on_hide_behavior.py
+++ b/bin/report_logic_with_deprecated_clear_on_hide_behavior.py
@@ -14,8 +14,6 @@ from json_logic.meta.expressions import destructure
 from json_logic.typing import JSON
 from tabulate import tabulate
 
-from openforms.forms.constants import LogicActionTypes
-
 SRC_DIR = Path(__file__).parent.parent / "src"
 sys.path.insert(0, str(SRC_DIR.resolve()))
 
@@ -90,6 +88,7 @@ def report_rules() -> bool:
     )
     from openforms.formio.typing import Component
     from openforms.formio.visibility import get_conditional
+    from openforms.forms.constants import LogicActionTypes
     from openforms.forms.models import Form
     from openforms.variables.service import resolve_key
 

--- a/bin/report_logic_with_deprecated_clear_on_hide_behavior.py
+++ b/bin/report_logic_with_deprecated_clear_on_hide_behavior.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import sys
+import traceback
 from pathlib import Path
 
 import django
@@ -81,21 +82,152 @@ def iter_variables_with_compare_value(expression: JSON):
     yield from iter_variables_with_compare_value(argument)
 
 
-def report_rules() -> bool:
+def analyze_rule(
+    *,
+    rule,
+    form,
+    component_map,
+    components_with_affected_visibility,
+    data,
+):
     from openforms.formio.service import (
         get_component_empty_value,
         iter_components,
     )
     from openforms.formio.typing import Component
-    from openforms.formio.visibility import get_conditional
     from openforms.forms.constants import LogicActionTypes
-    from openforms.forms.models import Form
     from openforms.variables.service import resolve_key
+
+    ##############################
+    ### CLEAR ON HIDE BEHAVIOR ###
+    ##############################
+    variable_names = set()
+    for var_name, comp_value in iter_variables_with_compare_value(
+        rule.json_logic_trigger
+    ):
+        if (resolved_key := resolve_key(var_name, component_map)) is None:
+            # Variable cannot be resolved, so we cannot determine anything
+            continue
+
+        component = component_map[resolved_key]
+        if component["type"] == "editgrid" and var_name != resolved_key:
+            # We expect data access "editgrid.x.child_key" here, so discard the
+            # parent key and index. Assuming there are no nested editgrids here
+            # :see_no_evil:
+            _, child_key = var_name.removeprefix(f"{resolved_key}.").split(".", 1)
+
+            children_map: dict[str, Component] = {
+                child["key"]: child
+                for child in iter_components(
+                    component, recursive=True, recurse_into_editgrid=False
+                )
+            }
+            resolved_key = resolve_key(child_key, children_map)
+            assert resolved_key is not None
+            component = children_map[resolved_key]
+
+        # Visibility of component is not affected and/or component does not have
+        # clearOnHide enabled, so it's not relevant
+        if resolved_key not in components_with_affected_visibility or not component.get(
+            "clearOnHide", True
+        ):
+            continue
+
+        empty_value = get_component_empty_value(component)
+        if component["type"] == "selectboxes":
+            # `get_component_empty_value` returns {"option_a": False, "option_b": False, etc...}
+            # for a selectboxes component, which is not a useful in this
+            # context. It is not possible to use a dictionary as a comparison
+            # value in a logic trigger, because it will be interpreted as an
+            # expression itself. This means data access always happens using
+            # "selectboxes.option_a", and we should just default to the
+            # individual empty value.
+            empty_value = False
+
+        # The comparison value `None` will also no longer work, as it's the
+        # current default that is set when a variable is missing from the
+        # context. Note that all form variables should be present in the context
+        # at the moment, but there is no such guarantee for nested data.
+        if comp_value in [empty_value, None, component.get("defaultValue")]:
+            variable_names.add(var_name)
+
+    if variable_names:
+        data.append(
+            (
+                form.admin_name,
+                form.pk,
+                rule.order,
+                ", ".join(variable_names),
+                "clear on hide behavior",
+            )
+        )
+
+    ###################################
+    ### VARIABLES FROM FUTURE STEPS ###
+    ###################################
+    # Steps of the input variables
+    input_steps = {
+        step for key in rule.input_variable_keys if (step := form.get_form_step(key))
+    }
+    # Steps on which the rule will be executed
+    executing_steps = rule.steps
+    if input_steps and executing_steps:
+        # Input steps and/or executing steps can be empty if we are only dealing
+        # with user-defined variables. We don't have to do anything in that
+        # case.
+
+        # If the earliest executing step is before the last step of the input
+        # variables, the input value(s) will not be available yet -> risk of
+        # difference in behavior.
+        if (
+            min(executing_steps, key=lambda step: step.order).order
+            < max(input_steps, key=lambda step: step.order).order
+        ):
+            data.append(
+                (
+                    form.admin_name,
+                    form.pk,
+                    rule.order,
+                    "-",
+                    "variables from future steps",
+                )
+            )
+
+    ###################################
+    ### VARIABLES USED AS DMN INPUT ###
+    ###################################
+    for action in rule.actions:
+        if action["action"]["type"] != LogicActionTypes.evaluate_dmn:
+            continue
+        # raw config lookup so that we can also run this on older versions of
+        # open forms
+        input_variable_keys = {
+            mapping["form_variable"]
+            for mapping in action["action"]["config"]["input_mapping"]
+        }
+        if variable_names := components_with_affected_visibility & input_variable_keys:
+            data.append(
+                (
+                    form.admin_name,
+                    form.pk,
+                    rule.order,
+                    ", ".join(variable_names),
+                    "used in DMN input but may be missing",
+                )
+            )
+
+
+def report_rules() -> bool:
+    from openforms.formio.service import iter_components
+    from openforms.formio.typing import Component
+    from openforms.formio.visibility import get_conditional
+    from openforms.forms.models import Form
 
     forms_to_check = Form.objects.filter(_is_deleted=False).prefetch_related(
         "formlogic_set", "formstep_set"
     )
     data = []
+    errors = []
     for form in forms_to_check.iterator(chunk_size=10):
         components_with_affected_visibility: set[str] = set()
 
@@ -137,131 +269,18 @@ def report_rules() -> bool:
             components_with_affected_visibility.update(children)
 
         for rule in form.formlogic_set.iterator():
-            ##############################
-            ### CLEAR ON HIDE BEHAVIOR ###
-            ##############################
-            variable_names = set()
-            for var_name, comp_value in iter_variables_with_compare_value(
-                rule.json_logic_trigger
-            ):
-                if (resolved_key := resolve_key(var_name, component_map)) is None:
-                    # Variable cannot be resolved, so we cannot determine anything
-                    continue
-
-                component = component_map[resolved_key]
-                if component["type"] == "editgrid" and var_name != resolved_key:
-                    # We expect data access "editgrid.x.child_key" here, so discard the
-                    # parent key and index. Assuming there are no nested editgrids here
-                    # :see_no_evil:
-                    _, child_key = var_name.removeprefix(f"{resolved_key}.").split(
-                        ".", 1
-                    )
-
-                    children_map: dict[str, Component] = {
-                        child["key"]: child
-                        for child in iter_components(
-                            component, recursive=True, recurse_into_editgrid=False
-                        )
-                    }
-                    resolved_key = resolve_key(child_key, children_map)
-                    assert resolved_key is not None
-                    component = children_map[resolved_key]
-
-                # Visibility of component is not affected and/or component does not have
-                # clearOnHide enabled, so it's not relevant
-                if (
-                    resolved_key not in components_with_affected_visibility
-                    or not component.get("clearOnHide", True)
-                ):
-                    continue
-
-                empty_value = get_component_empty_value(component)
-                if component["type"] == "selectboxes":
-                    # `get_component_empty_value` returns {"option_a": False, "option_b": False, etc...}
-                    # for a selectboxes component, which is not a useful in this
-                    # context. It is not possible to use a dictionary as a comparison
-                    # value in a logic trigger, because it will be interpreted as an
-                    # expression itself. This means data access always happens using
-                    # "selectboxes.option_a", and we should just default to the
-                    # individual empty value.
-                    empty_value = False
-
-                # The comparison value `None` will also no longer work, as it's the
-                # current default that is set when a variable is missing from the
-                # context. Note that all form variables should be present in the context
-                # at the moment, but there is no such guarantee for nested data.
-                if comp_value in [empty_value, None, component.get("defaultValue")]:
-                    variable_names.add(var_name)
-
-            if variable_names:
-                data.append(
-                    (
-                        form.admin_name,
-                        form.pk,
-                        rule.order,
-                        ", ".join(variable_names),
-                        "clear on hide behavior",
-                    )
+            try:
+                analyze_rule(
+                    rule=rule,
+                    form=form,
+                    component_map=component_map,
+                    components_with_affected_visibility=components_with_affected_visibility,
+                    data=data,
                 )
-
-            ###################################
-            ### VARIABLES FROM FUTURE STEPS ###
-            ###################################
-            # Steps of the input variables
-            input_steps = {
-                step
-                for key in rule.input_variable_keys
-                if (step := form.get_form_step(key))
-            }
-            # Steps on which the rule will be executed
-            executing_steps = rule.steps
-            if input_steps and executing_steps:
-                # Input steps and/or executing steps can be empty if we are only dealing
-                # with user-defined variables. We don't have to do anything in that
-                # case.
-
-                # If the earliest executing step is before the last step of the input
-                # variables, the input value(s) will not be available yet -> risk of
-                # difference in behavior.
-                if (
-                    min(executing_steps, key=lambda step: step.order).order
-                    < max(input_steps, key=lambda step: step.order).order
-                ):
-                    data.append(
-                        (
-                            form.admin_name,
-                            form.pk,
-                            rule.order,
-                            "-",
-                            "variables from future steps",
-                        )
-                    )
-
-            ###################################
-            ### VARIABLES USED AS DMN INPUT ###
-            ###################################
-            for action in rule.actions:
-                if action["action"]["type"] != LogicActionTypes.evaluate_dmn:
-                    continue
-                # raw config lookup so that we can also run this on older versions of
-                # open forms
-                input_variable_keys = {
-                    mapping["form_variable"]
-                    for mapping in action["action"]["config"]["input_mapping"]
-                }
-                if (
-                    variable_names := components_with_affected_visibility
-                    & input_variable_keys
-                ):
-                    data.append(
-                        (
-                            form.admin_name,
-                            form.pk,
-                            rule.order,
-                            ", ".join(variable_names),
-                            "used in DMN input but may be missing",
-                        )
-                    )
+            except Exception:
+                errors.append(
+                    (form.admin_name, form.pk, rule.order, traceback.format_exc())
+                )
 
     if data:
         click.echo(
@@ -284,6 +303,23 @@ def report_rules() -> bool:
                 ),
             )
         )
+        click.echo("")
+    if errors:
+        click.echo(click.style("Logic rules with errors during analysis", fg="red"))
+        click.echo("")
+        click.echo(
+            tabulate(
+                errors,
+                headers=(
+                    "Form admin name",
+                    "Form ID",
+                    "Logic rule number",
+                    "Error",
+                ),
+            )
+        )
+
+    if errors or data:
         return False
     else:
         click.echo(


### PR DESCRIPTION
Things from `openforms` must be imported in the functions themselves, and the zgw plugin identifier does not exist yet on 3.5.x (that changed was only commited to main for 4.0.0)

[skip: e2e]

**Changes**

 - Fixed two failing imports of the check scripts
 - Ensured the check script for clear on hide does not crash completely when analysis of a single rule fails

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
