### PR TITLE
Prevent hidden required multiple fields from triggering validation

### DIFF
--- a/src/openforms/formio/serializers.py
+++ b/src/openforms/formio/serializers.py
@@ -97,7 +97,13 @@ class StepDataSerializer(serializers.Serializer):
             case serializers.CharField():
                 field.allow_blank = True
 
-            case serializers.ListField() | EditGridField():
+            case serializers.ListField():
+                field.allow_empty = True
+                field.min_length = None
+                field.max_length = None
+                self._remove_validations_from_field(field.child)
+
+            case EditGridField():
                 field.allow_empty = True
                 field.min_length = None
                 field.max_length = None

--- a/src/openforms/submissions/tests/test_submission_completion.py
+++ b/src/openforms/submissions/tests/test_submission_completion.py
@@ -875,6 +875,52 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
+    @tag("gh-6297")
+    def test_required_hidden_multiple_field_should_not_fail_validation(self):
+        submission = SubmissionFactory.create(
+            form__generate_minimal_setup=True,
+            form__formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "textfieldVisible",
+                        "label": "Textfield visible",
+                        "hidden": False,
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "hiddenField",
+                        "label": "Hidden field",
+                        "validate": {
+                            "required": True,
+                        },
+                        "multiple": True,
+                        "hidden": False,
+                        "clearOnHide": False,
+                        "conditional": {
+                            "show": False,
+                            "when": "textfieldVisible",
+                            "eq": "hide",
+                        },
+                        "defaultValue": [],
+                    },
+                ]
+            },
+        )
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=submission.form.formstep_set.get(),
+            data={
+                "textfieldVisible": "hide",
+                "hiddenField": [""],
+            },
+        )
+        self._add_submission_to_session(submission)
+        endpoint = reverse("api:submission-complete", kwargs={"uuid": submission.uuid})
+
+        response = self.client.post(endpoint, {"privacy_policy_accepted": True})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
 
 @temp_private_root()
 class SetSubmissionPriceOnCompletionTests(SubmissionsMixin, APITestCase):

--- a/src/openforms/tests/e2e/test_fill_in_form.py
+++ b/src/openforms/tests/e2e/test_fill_in_form.py
@@ -70,3 +70,69 @@ class FillInFormTests(E2ETestCase):
                     await expect(
                         page.get_by_text("This is non-nested data")
                     ).to_be_visible()
+
+    async def test_required_hidden_multiple_field(self):
+        @sync_to_async
+        def setUpTestData():
+            # set up a form
+            form = FormFactory.create(
+                name="Form nested data",
+                slug="form-with-nested-data",
+                generate_minimal_setup=True,
+                formstep__form_definition__name="First step",
+                formstep__form_definition__slug="first-step",
+                formstep__form_definition__configuration={
+                    "components": [
+                        {
+                            "type": "textfield",
+                            "key": "textfieldVisible",
+                            "label": "Textfield visible",
+                            "hidden": False,
+                        },
+                        {
+                            "type": "textfield",
+                            "key": "hiddenField",
+                            "label": "Hidden field",
+                            "validate": {
+                                "required": True,
+                            },
+                            "multiple": True,
+                            "hidden": False,
+                            "clearOnHide": False,
+                            "conditional": {
+                                "show": False,
+                                "when": "textfieldVisible",
+                                "eq": "hide",
+                            },
+                            "defaultValue": [],
+                        },
+                    ]
+                },
+                translation_enabled=True,
+                ask_privacy_consent=False,
+                ask_statement_of_truth=False,
+            )
+            return form
+
+        form = await setUpTestData()
+        form_url = str(
+            furl(self.live_server_url)
+            / reverse("forms:form-detail", kwargs={"slug": form.slug})
+        )
+
+        with patch("openforms.utils.validators.allow_redirect_url", return_value=True):
+            async with browser_page() as page:
+                await page.goto(form_url)
+
+                await page.get_by_role("button", name="Begin form").click()
+
+                await page.get_by_label("Textfield visible").fill("hide")
+                expect(page.get_by_label("Hidden field")).not_to_be_visible()
+
+                await page.get_by_role("button", name="Next").click()
+                await page.get_by_role("button", name="Confirm").click()
+                await expect(
+                    page.get_by_text(
+                        "Please hold on while we're processing your submission."
+                    )
+                ).to_be_visible()


### PR DESCRIPTION
Partly closes #6297

**Changes**

This PR fixes the bug where a required hidden `multiple=True` component with `clearOnHide=False` triggers validation with the value `[""]`. The error states that some unknown field (the child of the ListField) is left empty (the blank `""` value).

To prevent hidden fields from triggering validation we apply apply `_remove_validations_from_field` on them, to strip them from their validation rules. This however only strips the direct component/ListField of its validation rules, not its children. By also applying this stripping to the children of hidden `multiple=True` components, we can allow falsy list values like `[""]`.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
