### PR TITLE
Fixing default value for multiple field

### DIFF
--- a/src/openforms/formio/migration_converters.py
+++ b/src/openforms/formio/migration_converters.py
@@ -343,6 +343,10 @@ def fix_empty_default_value(component: Component) -> bool:
         changed = True
 
     if component.get("multiple", False):
+        if not isinstance(component["defaultValue"], list):
+            component["defaultValue"] = []
+            changed = True
+
         for index, value in enumerate(component["defaultValue"]):
             if value is None:
                 component["defaultValue"][index] = ""
@@ -458,6 +462,7 @@ CONVERTERS: dict[str, dict[str, ComponentConverter]] = {
     },
     "date": {
         "alter_prefill_default_values": alter_prefill_default_values,
+        "fix_empty_default_value": fix_empty_default_value,
         "rename_identifier_role_authorizee": rename_identifier_role_authorizee,
         "remove_empty_conditional_values": remove_empty_conditional_values,
         "replace_empty_datepicker_properties": replace_empty_datepicker_properties,
@@ -465,6 +470,7 @@ CONVERTERS: dict[str, dict[str, ComponentConverter]] = {
     },
     "datetime": {
         "alter_prefill_default_values": alter_prefill_default_values,
+        "fix_empty_default_value": fix_empty_default_value,
         "prevent_datetime_components_from_emptying_invalid_values": prevent_datetime_components_from_emptying_invalid_values,
         "rename_identifier_role_authorizee": rename_identifier_role_authorizee,
         "replace_empty_datepicker_properties": replace_empty_datepicker_properties,

--- a/src/openforms/formio/tests/test_migration_converters.py
+++ b/src/openforms/formio/tests/test_migration_converters.py
@@ -106,6 +106,20 @@ class LicensePlateTests(SimpleTestCase):
         self.assertTrue(changed)
         self.assertEqual(component["defaultValue"], [""])
 
+    def test_multiple_default_value_string_changed(self):
+        component: Component = {
+            "type": "licenseplate",
+            "key": "licensePlate",
+            "label": "Licenseplate",
+            "multiple": True,
+            "defaultValue": "",
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [])
+
     def test_multiple_default_value_with_none_changed(self):
         component: Component = {
             "type": "licenseplate",
@@ -281,6 +295,20 @@ class PostCodeTests(SimpleTestCase):
         self.assertTrue(changed)
         self.assertEqual(component["defaultValue"], [])
 
+    def test_multiple_default_value_string_changed(self):
+        component: Component = {
+            "type": "postcode",
+            "key": "postcode",
+            "label": "postcode",
+            "multiple": True,
+            "defaultValue": "",
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [])
+
     def test_non_empty_errors(self):
         component: Component = {
             "type": "postcode",
@@ -392,6 +420,108 @@ class DatetimeTests(ParametrizedTestCase, SimpleTestCase):
             self.assertFalse(changed)
             self.assertIn(prop, component["openForms"])
             self.assertIn("mode", component["openForms"][prop])
+
+    def test_multiple_noop(self):
+        component: Component = {
+            "type": "datetime",
+            "key": "datetime",
+            "label": "Datetime",
+            "multiple": True,
+            "defaultValue": [],
+        }
+
+        changed = fix_empty_default_value(component)
+        self.assertFalse(changed)
+
+    def test_default_value_noop(self):
+        component: Component = {
+            "type": "datetime",
+            "key": "datetime",
+            "label": "Datetime",
+            "defaultValue": "",
+        }
+
+        changed = fix_empty_default_value(component)
+        self.assertFalse(changed)
+
+    def test_default_value_none_changed(self):
+        component: Component = {
+            "type": "datetime",
+            "key": "datetime",
+            "label": "Datetime",
+            "defaultValue": None,
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], "")
+
+    def test_no_default_value_noop(self):
+        component: Component = {
+            "type": "datetime",
+            "key": "datetime",
+            "label": "Datetime",
+        }
+
+        changed = fix_empty_default_value(component)
+        self.assertFalse(changed)
+
+    def test_multiple_default_value_none_in_array_changed(self):
+        component: Component = {
+            "type": "datetime",
+            "key": "datetime",
+            "label": "Datetime",
+            "defaultValue": [None],
+            "multiple": True,
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [""])
+
+    def test_multiple_default_value_with_none_changed(self):
+        component: Component = {
+            "type": "datetime",
+            "key": "datetime",
+            "label": "Datetime",
+            "defaultValue": ["foo", None, "bar"],
+            "multiple": True,
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], ["foo", "", "bar"])
+
+    def test_multiple_default_value_none_changed(self):
+        component: Component = {
+            "type": "datetime",
+            "key": "datetime",
+            "label": "Datetime",
+            "multiple": True,
+            "defaultValue": None,
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [])
+
+    def test_multiple_default_value_string_changed(self):
+        component: Component = {
+            "type": "datetime",
+            "key": "datetime",
+            "label": "Datetime",
+            "multiple": True,
+            "defaultValue": "",
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [])
 
 
 class SelectTests(SimpleTestCase):
@@ -613,6 +743,20 @@ class TextTests(SimpleTestCase):
         self.assertTrue(changed)
         self.assertEqual(component["defaultValue"], [])
 
+    def test_multiple_default_value_string_changed(self):
+        component: Component = {
+            "key": "textField",
+            "label": "Text Field",
+            "type": "textfield",
+            "multiple": True,
+            "defaultValue": "",
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [])
+
     def test_non_empty_errors(self):
         component: Component = {
             "type": "textfield",
@@ -780,6 +924,20 @@ class EmailTests(SimpleTestCase):
         self.assertTrue(changed)
         self.assertEqual(component["defaultValue"], [""])
 
+    def test_multiple_default_value_string_changed(self):
+        component: Component = {
+            "type": "email",
+            "key": "eMailadres",
+            "label": "Emailadres",
+            "multiple": True,
+            "defaultValue": "",
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [])
+
     def test_multiple_default_value_with_none_changed(self):
         component: Component = {
             "type": "email",
@@ -933,6 +1091,20 @@ class TimeTests(SimpleTestCase):
         self.assertTrue(changed)
         self.assertEqual(component["defaultValue"], [""])
 
+    def test_multiple_default_value_string_changed(self):
+        component: Component = {
+            "type": "time",
+            "key": "time",
+            "label": "Time",
+            "multiple": True,
+            "defaultValue": "",
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [])
+
     def test_multiple_default_value_with_none_changed(self):
         component: Component = {
             "type": "time",
@@ -1011,6 +1183,20 @@ class PhoneNumberTests(SimpleTestCase):
 
         self.assertTrue(changed)
         self.assertEqual(component["defaultValue"], [""])
+
+    def test_multiple_default_value_string_changed(self):
+        component: Component = {
+            "type": "phoneNumber",
+            "key": "telefoonnummer",
+            "label": "Telefoonnummer",
+            "multiple": True,
+            "defaultValue": "",
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [])
 
     def test_multiple_default_value_with_none_changed(self):
         component: Component = {
@@ -1131,6 +1317,20 @@ class TextareaTests(SimpleTestCase):
         self.assertTrue(changed)
         self.assertEqual(component["defaultValue"], [""])
 
+    def test_multiple_default_value_string_changed(self):
+        component: Component = {
+            "type": "textarea",
+            "key": "textArea",
+            "label": "Textarea",
+            "multiple": True,
+            "defaultValue": "",
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [])
+
     def test_multiple_default_value_with_none_changed(self):
         component: Component = {
             "type": "textarea",
@@ -1209,6 +1409,20 @@ class IBANTests(SimpleTestCase):
 
         self.assertTrue(changed)
         self.assertEqual(component["defaultValue"], [""])
+
+    def test_multiple_default_value_string_changed(self):
+        component: Component = {
+            "type": "iban",
+            "key": "iban",
+            "label": "iban",
+            "multiple": True,
+            "defaultValue": "",
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [])
 
     def test_multiple_default_value_with_none_changed(self):
         component: Component = {
@@ -1670,6 +1884,108 @@ class DateTests(ParametrizedTestCase, SimpleTestCase):
             self.assertFalse(changed)
             self.assertIn(prop, component["openForms"])
             self.assertIn("mode", component["openForms"][prop])
+
+    def test_multiple_noop(self):
+        component: Component = {
+            "key": "date",
+            "type": "date",
+            "label": "Date",
+            "multiple": True,
+            "defaultValue": [],
+        }
+
+        changed = fix_empty_default_value(component)
+        self.assertFalse(changed)
+
+    def test_default_value_noop(self):
+        component: Component = {
+            "key": "date",
+            "type": "date",
+            "label": "Date",
+            "defaultValue": "",
+        }
+
+        changed = fix_empty_default_value(component)
+        self.assertFalse(changed)
+
+    def test_default_value_none_changed(self):
+        component: Component = {
+            "key": "date",
+            "type": "date",
+            "label": "Date",
+            "defaultValue": None,
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], "")
+
+    def test_no_default_value_noop(self):
+        component: Component = {
+            "key": "date",
+            "type": "date",
+            "label": "Date",
+        }
+
+        changed = fix_empty_default_value(component)
+        self.assertFalse(changed)
+
+    def test_multiple_default_value_none_in_array_changed(self):
+        component: Component = {
+            "key": "date",
+            "type": "date",
+            "label": "Date",
+            "defaultValue": [None],
+            "multiple": True,
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [""])
+
+    def test_multiple_default_value_with_none_changed(self):
+        component: Component = {
+            "key": "date",
+            "type": "date",
+            "label": "Date",
+            "defaultValue": ["foo", None, "bar"],
+            "multiple": True,
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], ["foo", "", "bar"])
+
+    def test_multiple_default_value_none_changed(self):
+        component: Component = {
+            "key": "date",
+            "type": "date",
+            "label": "Date",
+            "multiple": True,
+            "defaultValue": None,
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [])
+
+    def test_multiple_default_value_string_changed(self):
+        component: Component = {
+            "key": "date",
+            "type": "date",
+            "label": "Date",
+            "multiple": True,
+            "defaultValue": "",
+        }
+
+        changed = fix_empty_default_value(component)
+
+        self.assertTrue(changed)
+        self.assertEqual(component["defaultValue"], [])
 
 
 class SelectBoxTests(SimpleTestCase):

--- a/src/openforms/forms/tests/e2e_tests/test_form_designer.py
+++ b/src/openforms/forms/tests/e2e_tests/test_form_designer.py
@@ -513,6 +513,151 @@ class FormDesignerComponentTranslationTests(E2ETestCase):
 
                 await assertFormValues()
 
+    @tag("gh-6297")
+    async def test_textfields_multiple_default_value_empty_list(self):
+        @sync_to_async
+        def setUpTestData():
+            # set up a form
+            form = FormFactory.create(name="Test textfields default value empty string")
+            return form
+
+        await create_superuser()
+        form = await setUpTestData()
+        admin_url = str(
+            furl(self.live_server_url)
+            / reverse("admin:forms_form_change", args=(form.pk,))
+        )
+        admin_changelist_url = str(
+            furl(self.live_server_url) / reverse("admin:forms_form_changelist")
+        )
+
+        basic_components_with_multiple = (
+            "Tekstveld",
+            "E-mail",
+            "Datum",
+            "Datum & tijd",
+            "Tijd",
+            "Telefoonnummer",
+            "Postcode",
+            "Tekstvlak",
+        )
+
+        special_components_with_multiple = (
+            "BSN",
+            "IBAN",
+            "Kenteken",
+        )
+
+        async with browser_page() as page:
+            await self._admin_login(page)
+            await page.goto(str(admin_url))
+
+            with phase("Populate and save form"):
+                await add_new_step(page)
+                step_name_input = page.get_by_role(
+                    "textbox", name="Step name", exact=True
+                )
+                await step_name_input.click()
+                await step_name_input.fill("Step 1")
+
+                for component in basic_components_with_multiple:
+                    await drag_and_drop_component(page, component, "group-panel-custom")
+                    await page.get_by_label("Label", exact=True).fill(
+                        f"Label {component}"
+                    )
+                    await page.get_by_label("Multiple values", exact=True).check()
+                    # Remove the default first item, making the default value `[]`
+                    await (
+                        page.get_by_test_id("componentEditForm")
+                        .get_by_role("button", name="Remove item")
+                        .click()
+                    )
+                    await close_modal(page, "Save", exact=True)
+
+                # Open the special fields list
+                await page.get_by_role(
+                    "button", name="Speciale velden", exact=True
+                ).click()
+
+                for component in special_components_with_multiple:
+                    await drag_and_drop_component(page, component)
+                    await page.get_by_label("Label", exact=True).fill(
+                        f"Label {component}"
+                    )
+                    await page.get_by_label("Multiple values", exact=True).check()
+                    # Remove the default first item, making the default value `[]`
+                    await (
+                        page.get_by_test_id("componentEditForm")
+                        .get_by_role("button", name="Remove item")
+                        .click()
+                    )
+                    await close_modal(page, "Save", exact=True)
+
+                # Save form
+                await page.get_by_role("button", name="Save", exact=True).click()
+                await page.wait_for_url(admin_changelist_url)
+
+            with phase("Validate default values in database"):
+
+                @sync_to_async
+                def assertFormValues():
+                    for component in form.iter_components():
+                        expected = []
+
+                        self.assertEqual(
+                            component["defaultValue"],
+                            expected,
+                            msg=f"Test failed for component {component['key']}",
+                        )
+
+                await assertFormValues()
+
+            with phase("Validate default values in form designer"):
+                # The 6297 bug happens here, after the component default value is set to
+                # `[]`. The bug appears in the component edit json view, where the
+                # `defaultValue` is shown as an empty string `""`. If the form is then
+                # saved again, the component is broken.
+
+                await page.goto(str(admin_url))
+                await page.get_by_role("tab", name="Steps and fields").click()
+                await page.get_by_role("button", name="Step 1").click()
+
+                # Validate every component
+                for component in basic_components_with_multiple:
+                    await open_component_options_modal(
+                        page, f"Label {component}", exact=True
+                    )
+                    await close_modal(page, "Save", exact=True)
+
+                for component in special_components_with_multiple:
+                    await open_component_options_modal(
+                        page, f"Label {component}", exact=True
+                    )
+                    await close_modal(page, "Save", exact=True)
+
+                # Save form
+                await page.get_by_role("button", name="Save", exact=True).click()
+                await page.wait_for_url(admin_changelist_url)
+
+            with phase("Validate default value after editing"):
+
+                @sync_to_async
+                def assertFormValues():
+                    configuration = (
+                        form.formstep_set.get().form_definition.configuration
+                    )
+
+                    for component in configuration["components"]:
+                        self.assertEqual(
+                            component["defaultValue"],
+                            [],
+                            msg=f"Component of type {component['type']} with "
+                            f"`multiple=True` has a non-array default value after "
+                            f"editing.",
+                        )
+
+                await assertFormValues()
+
     @tag("dh-5104")
     async def test_radio_component_default_value_empty_string(self):
         @sync_to_async

--- a/src/openforms/js/components/form/date.js
+++ b/src/openforms/js/components/form/date.js
@@ -1,6 +1,7 @@
 import {Formio} from 'formiojs';
 
 import {localiseSchema} from './i18n';
+import {patchDefaultValue} from './textfield';
 
 const DateTimeField = Formio.Components.components.datetime;
 
@@ -93,6 +94,7 @@ class DateField extends DateTimeField {
       submissionTimezone: null,
       timezone: '',
     };
+    patchDefaultValue(this);
   }
 }
 

--- a/src/openforms/js/components/form/datetime.js
+++ b/src/openforms/js/components/form/datetime.js
@@ -1,6 +1,7 @@
 import {Formio} from 'formiojs';
 
 import {localiseSchema} from './i18n';
+import {patchDefaultValue} from './textfield';
 
 const DateTimeFormio = Formio.Components.components.datetime;
 
@@ -102,6 +103,7 @@ class DateTimeField extends DateTimeFormio {
       submissionTimezone: null,
       timezone: '',
     };
+    patchDefaultValue(this);
   }
 }
 

--- a/src/openforms/js/components/form/email.js
+++ b/src/openforms/js/components/form/email.js
@@ -1,7 +1,7 @@
 import {Formio} from 'formiojs';
 
 import {localiseSchema} from './i18n';
-import {patchValidateDefaults} from './textfield';
+import {patchDefaultValue, patchValidateDefaults} from './textfield';
 
 const FormioEmail = Formio.Components.components.email;
 
@@ -32,6 +32,7 @@ class EmailField extends FormioEmail {
     super(...args);
 
     patchValidateDefaults(this);
+    patchDefaultValue(this);
   }
 
   get defaultSchema() {

--- a/src/openforms/js/components/form/iban.js
+++ b/src/openforms/js/components/form/iban.js
@@ -1,6 +1,6 @@
 import {Formio} from 'formiojs';
 
-import {patchValidateDefaults} from './textfield';
+import {patchDefaultValue, patchValidateDefaults} from './textfield';
 
 const TextField = Formio.Components.components.textfield;
 
@@ -32,6 +32,7 @@ class IbanField extends TextField {
     super(...args);
 
     patchValidateDefaults(this);
+    patchDefaultValue(this);
   }
 
   get defaultSchema() {

--- a/src/openforms/js/components/form/licenseplate.js
+++ b/src/openforms/js/components/form/licenseplate.js
@@ -1,7 +1,7 @@
 import {Formio} from 'formiojs';
 
 import {localiseSchema} from './i18n';
-import {patchValidateDefaults} from './textfield';
+import {patchDefaultValue, patchValidateDefaults} from './textfield';
 
 const TextField = Formio.Components.components.textfield;
 
@@ -40,6 +40,7 @@ class LicensePlate extends TextField {
     super(...args);
 
     patchValidateDefaults(this);
+    patchDefaultValue(this);
   }
 
   get defaultSchema() {

--- a/src/openforms/js/components/form/phoneNumber.js
+++ b/src/openforms/js/components/form/phoneNumber.js
@@ -1,7 +1,7 @@
 import {Formio} from 'formiojs';
 
 import {localiseSchema} from './i18n';
-import {patchValidateDefaults} from './textfield';
+import {patchDefaultValue, patchValidateDefaults} from './textfield';
 
 const PhoneNumber = Formio.Components.components.phoneNumber;
 
@@ -31,6 +31,7 @@ class PhoneNumberField extends PhoneNumber {
     super(...args);
 
     patchValidateDefaults(this);
+    patchDefaultValue(this);
   }
 
   get defaultSchema() {

--- a/src/openforms/js/components/form/textarea.js
+++ b/src/openforms/js/components/form/textarea.js
@@ -3,7 +3,7 @@ import NativePromise from 'native-promise-only';
 import {Formio} from 'react-formio';
 
 import {localiseSchema} from './i18n';
-import {patchValidateDefaults} from './textfield';
+import {patchDefaultValue, patchValidateDefaults} from './textfield';
 
 const FormioTextarea = Formio.Components.components.textarea;
 
@@ -25,6 +25,7 @@ class TextArea extends FormioTextarea {
     super(...args);
 
     patchValidateDefaults(this);
+    patchDefaultValue(this);
   }
 
   get defaultSchema() {

--- a/src/openforms/js/components/form/textfield.js
+++ b/src/openforms/js/components/form/textfield.js
@@ -27,6 +27,20 @@ export const patchValidateDefaults = instance => {
     delete validate.maxWords;
   }
 };
+export const patchDefaultValue = instance => {
+  // #6297; The Formiojs `Component` base class creates a "modified schema" dict
+  // (https://github.com/formio/formio.js/blob/v4.13.13/src/components/_classes/component/Component.js#L685C3-L715)
+  // which is merged with the default schema to get the component schema. In this
+  // `getModifiedSchema` function, empty list values are dropped and get replaced with
+  // their default schema values. This results in `defaultValue=[]` being replaced with
+  // `defaultValue=""`.
+  //
+  // With this small fix we ensure that the `defaultValue` correctly represents the
+  // `multiple` property.
+  if (instance.component.multiple && !Array.isArray(instance.component.defaultValue)) {
+    instance.component.defaultValue = [];
+  }
+};
 
 class TextField extends FormioTextField {
   static schema(...extend) {
@@ -44,6 +58,7 @@ class TextField extends FormioTextField {
     super(...args);
 
     patchValidateDefaults(this);
+    patchDefaultValue(this);
   }
 
   get defaultSchema() {

--- a/src/openforms/js/components/form/time.js
+++ b/src/openforms/js/components/form/time.js
@@ -1,6 +1,7 @@
 import {Formio} from 'formiojs';
 
 import {localiseSchema} from './i18n';
+import {patchDefaultValue} from './textfield';
 
 const Time = Formio.Components.components.time;
 
@@ -12,6 +13,7 @@ const Time = Formio.Components.components.time;
 class TimeField extends Time {
   constructor(...args) {
     super(...args);
+    patchDefaultValue(this);
   }
 
   static schema(...extend) {


### PR DESCRIPTION
Partly closes #6297

**Changes**

This PR fixes the configuration issue described in #6297.

Short version, Formiojs messes with empty list values in the schema's, replacing them with their default schema values. For textfields (and a bunch of other components) this means that the schema value `defaultValue=[]` gets replaced with `defaultValue=""`.

This fix checks if the component `defaultValue` picked by Formiojs correctly represents the `multiple` property (i.e. if `multiple=true`, then `defaultValue` must be an array value). If the `defaultValue` doesn't match with the `multiple` property, we set the `defaultValue` to an empty array `[]`.

Because this issue is caused by the Formiojs component classes, this won't be a problem when we completely drop Formiojs. So this fix is a temporary one.

### Extra Formiojs context

The Formiojs `Component` base class implements a [`getModifiedSchema`](https://github.com/formio/formio.js/blob/v4.13.13/src/components/_classes/component/Component.js#L685C3-L715) method which returns all the modified schema properties. This is done by checking which component configuration properties are different from the default schema AND, if they are list values, are NOT empty.
The result is: a component with the configuration `{defaultValue: []}` will be returned as `{}` (i greatly simplified the configuration for dramatic effect, but you get the idea)

The missing component properties are later filled-in using the default schema which, in the case of all our components that support `multiple` configuration, uses the configuration of `defaultValue=""`.

Formiojs does contain some code which do correct `multiple` + `defaultValue` + `emptyValue` calculations, but these results are never persisted back to the component schema.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
