### PR TITLE
[#5879] allow falsy values while determining empty conditional values

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -116,6 +116,7 @@ COPY \
     ./bin/report_invalid_form_logic.py \
     ./bin/report_logic_with_deprecated_clear_on_hide_behavior.py \
     ./bin/report_file_component_inconsistent_catalogues.py \
+    ./bin/report_conditional_eq_properties.py \
     ./bin/
 
 # prevent writing to the container layer, which would degrade performance.

--- a/bin/report_conditional_eq_properties.py
+++ b/bin/report_conditional_eq_properties.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python
+#
+# Scans form definitions that might contain unwanted changes after performing
+# migrations. b3c9c17b4b0d024c886301220b4fc0f04c51919f introduced changes that
+# were too strict as it removed `eq` values whenever other conditional properties
+# where falsy, while the intend was that the removal should've only happened
+# whenever the properties values were null or whenever all (known) properties
+# were not present at all.
+#
+# This check is intended to run *after* the data migrations that applied fixes
+# to the component configurations. It cannot be run in a preventive manner as
+# upgrade check because these problems cannot be corrected pre-3.5.
+#
+from __future__ import annotations
+
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import NamedTuple
+
+import django
+from django.db.models import Prefetch
+
+import click
+from tabulate import tabulate
+
+SRC_DIR = Path(__file__).parent.parent / "src"
+sys.path.insert(0, str(SRC_DIR.resolve()))
+
+
+class Row(NamedTuple):
+    form_definition_id: int
+    form_definition_name: str
+    component_keys: set[str]
+    form_steps: set[str]
+    form_admin_name: str
+    form_id: int
+
+
+class Empty:
+    def __bool__(self):
+        return False
+
+
+empty = Empty()
+
+
+def report_configurations() -> bool:
+    """
+    Scans and reports the form definitions that might contain unwanted changes
+    after performing migrations.
+
+    :returns: ``True`` if no possible unwanted configuration mutations are detected,
+    ``False`` if there are issues detected.
+    """
+    from openforms.forms.models import Form, FormDefinition, FormStep
+
+    # fmt:off
+    form_definitions = (
+        FormDefinition.objects.prefetch_related(
+            Prefetch(
+                "formstep_set",
+                queryset=FormStep.objects.select_related("form"),
+            ),
+        )
+        .filter(_num_components__gte=1)
+    )
+    # fmt:on
+
+    rows: list[Row] = []
+    known_conditional_keys = {"when", "show"}
+    for form_definition in form_definitions.iterator(chunk_size=10):
+        component_keys: set[str] = set()
+        for component in form_definition.configuration_wrapper:
+            if not (conditional := component.get("conditional")):
+                continue
+            elif (
+                "eq" in conditional
+            ):  # no changes were made to the conditional property
+                continue
+
+            conditional_values = [
+                conditional.get(key, empty) for key in known_conditional_keys
+            ]
+
+            if all((value == empty) for value in conditional_values) or all(
+                value for value in conditional_values
+            ):
+                continue
+
+            component_keys.add(component["key"])
+
+        if not component_keys:
+            continue
+
+        form_mapping: dict[Form, set[FormStep]] = defaultdict(set[FormStep])
+        for step in form_definition.formstep_set.all():
+            form_mapping[step.form].add(step)
+
+        for form, applicable_steps in form_mapping.items():
+            row = Row(
+                form_definition.pk,
+                form_definition.name,
+                component_keys,
+                {str(step.uuid) for step in applicable_steps},
+                form.admin_name,
+                form.pk,
+            )
+            rows.append(row)
+
+    rows.sort(key=lambda row: (row.form_definition_id, row.form_id))
+
+    if not rows:
+        click.echo(click.style("No applicable form definitions found.", fg="green"))
+        return True
+
+    click.echo(
+        click.style(
+            "Found possible form definition configurations with unwanted changes.",
+            fg="red",
+        )
+    )
+    click.echo("")
+    click.echo(
+        tabulate(
+            rows,
+            headers=(
+                "Form definition ID",
+                "Form definition name",
+                "Component keys",
+                "Form steps",
+                "Form admin name",
+                "Form ID",
+            ),
+        )
+    )
+
+    return False
+
+
+def main(skip_setup=False) -> bool:
+    from openforms.setup import setup_env
+
+    if not skip_setup:
+        setup_env()
+        django.setup()
+
+    return report_configurations()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/openforms/formio/migration_converters.py
+++ b/src/openforms/formio/migration_converters.py
@@ -287,7 +287,7 @@ def remove_empty_conditional_values(component: Component) -> bool:
         if not (known_key in conditional and conditional[known_key] == ""):
             continue
         elif known_key == "eq" and all(
-            conditional.get(key) for key in known_keys - {"eq"}
+            conditional.get(key) is not None for key in known_keys - {"eq"}
         ):
             continue
 

--- a/src/openforms/formio/tests/test_migration_converters.py
+++ b/src/openforms/formio/tests/test_migration_converters.py
@@ -158,6 +158,29 @@ class LicensePlateTests(SimpleTestCase):
                 {"show": True, "when": "textfield", "eq": ""},
             )
 
+        empty_eq_show_component: Component = {
+            "type": "licenseplate",
+            "key": "licensePlate",
+            "label": "Licenseplate",
+            "validate": {
+                "pattern": r"^[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}$"  # type: ignore
+            },
+            "conditional": {
+                "eq": "",
+                "show": False,
+                "when": "textfield",
+            },
+        }
+
+        changed = remove_empty_conditional_values(empty_eq_show_component)
+
+        with self.subTest(component=empty_eq_show_component):
+            self.assertFalse(changed)
+            self.assertEqual(
+                empty_eq_show_component["conditional"],
+                {"show": False, "when": "textfield", "eq": ""},
+            )
+
         empty_show_component: Component = {
             "type": "licenseplate",
             "key": "licensePlate",

--- a/src/openforms/forms/models/form_definition.py
+++ b/src/openforms/forms/models/form_definition.py
@@ -21,6 +21,8 @@ from ..validators import validate_template_expressions
 if TYPE_CHECKING:
     from openforms.formio.service import FormioConfigurationWrapper
 
+    from ..models import FormStep
+
 
 def _get_number_of_components(form_definition: "FormDefinition") -> int:
     """
@@ -67,6 +69,8 @@ class FormDefinition(models.Model):
         default=0,
         help_text=_("The total number of Formio components used in the configuration"),
     )
+
+    formstep_set: models.Manager["FormStep"]
 
     class Meta:
         verbose_name = _("Form definition")

--- a/src/openforms/upgrades/tests/test_conditional_eq_properties.py
+++ b/src/openforms/upgrades/tests/test_conditional_eq_properties.py
@@ -1,0 +1,133 @@
+from django.test import TestCase
+
+from unittest_parametrize import ParametrizedTestCase, parametrize
+
+from openforms.forms.tests.factories import FormDefinitionFactory, FormFactory
+
+from ..script_checks import BinScriptCheck
+from .utils import capture_output
+
+
+class ReportConditionalEQpropertiesTests(ParametrizedTestCase, TestCase):
+    script = BinScriptCheck("report_conditional_eq_properties")
+
+    def test_no_conditional(self):
+        FormFactory.create(generate_minimal_setup=True)
+
+        with capture_output() as stdout:
+            self.assertTrue(self.script.execute())
+            self.assertIn(
+                "No applicable form definitions found.",
+                stdout.getvalue(),
+            )
+
+    @parametrize(
+        "conditional",
+        [
+            {
+                "show": False,
+                "when": "textfield",
+            },
+            {
+                "show": False,
+            },
+            {
+                "when": "textfield",
+            },
+        ],
+    )
+    def test_report_components(self, conditional):
+        configuration = {
+            "components": [
+                {
+                    "type": "licenseplate",
+                    "key": "licensePlate",
+                    "label": "Licenseplate",
+                    "validate": {
+                        "pattern": r"^[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}$"
+                    },
+                    "conditional": conditional,
+                }
+            ],
+        }
+
+        form_definition = FormDefinitionFactory.build(configuration=configuration)
+        form_definition.save()  # call the save method to set the _num_components field
+
+        FormFactory.create(
+            generate_minimal_setup=True,
+            internal_name="conditional form",
+            formstep__form_definition=form_definition,
+        )
+
+        with capture_output() as stdout:
+            self.assertFalse(self.script.execute())
+            self.assertIn(
+                "Found possible form definition configurations with unwanted changes.",
+                stdout.getvalue(),
+            )
+
+    @parametrize(
+        "conditional",
+        [
+            {
+                "show": True,
+                "when": "textfield",
+                "eq": "foobar",
+            },
+            {
+                "show": False,
+                "when": "textfield",
+                "eq": "foobar",
+            },
+            {
+                "show": False,
+                "when": "",
+                "eq": "foobar",
+            },
+            {
+                "show": True,
+                "when": "textfield",
+                "eq": "",
+            },
+            {
+                "show": None,
+                "when": None,
+                "eq": "",
+            },
+            {
+                "eq": "",
+            },
+            {},
+        ],
+    )
+    def test_no_report(self, conditional):
+        configuration = {
+            "components": [
+                {
+                    "type": "licenseplate",
+                    "key": "licensePlate",
+                    "label": "Licenseplate",
+                    "validate": {
+                        "pattern": r"^[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}\-[a-zA-Z0-9]{1,3}$"
+                    },
+                    "conditional": conditional,
+                }
+            ],
+        }
+
+        form_definition = FormDefinitionFactory.build(configuration=configuration)
+        form_definition.save()  # call the save method to set the _num_components field
+
+        FormFactory.create(
+            generate_minimal_setup=True,
+            internal_name="conditional form",
+            formstep__form_definition=form_definition,
+        )
+
+        with capture_output() as stdout:
+            self.assertTrue(self.script.execute())
+            self.assertIn(
+                "No applicable form definitions found.",
+                stdout.getvalue(),
+            )


### PR DESCRIPTION
See Taiga Nijmegen issue 35.

**Changes**

Due to [the strictness of the changes introduced](https://github.com/open-formulieren/open-forms/commit/b3c9c17b4b0d024c886301220b4fc0f04c51919f#diff-33e40f96780ff80984e10a5cbf5a9fbee6ba2989af00b4711d22209cc08721beR290) for [earlier feedback](https://github.com/open-formulieren/open-forms/pull/5895#discussion_r2703820832),  component configuration like so:
```
{
  "show": false,
  "when": "bsnField",
  "eq": ""
}
```

would cause the `eq` property to be removed. These changes allow other values to be falsy (e.g an empty string or `false`) while leaving the `eq` property as is.
**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
