### PR TITLE
Ensure customer profile validation errors are attached to the address field

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -4,6 +4,7 @@ from copy import deepcopy
 from datetime import date, datetime
 from typing import Protocol, assert_never
 
+from django.core.exceptions import ValidationError as DjangoValidationError
 from django.core.validators import (
     MaxValueValidator,
     MinValueValidator,
@@ -18,6 +19,7 @@ from django.utils.translation import get_language, gettext as _
 import structlog
 from glom import Path, glom
 from rest_framework import ISO_8601, serializers
+from rest_framework.fields import get_error_detail
 from rest_framework.request import Request
 
 from openforms.api.geojson import (
@@ -1246,18 +1248,27 @@ class DigitalAddressSerializer(serializers.Serializer):
             return attrs
 
         # validate address value depending on its type
-        match type:
-            case "email":
-                validate_email(address)
+        try:
+            match type:
+                case "email":
+                    validate_email(address)
 
-            case "phoneNumber":
-                # replicate client-side validation in formio-renderer (buildPhoneNumberValidationSchema)
-                RegexValidator(
-                    regex="^[+0-9][- 0-9]+$", message=_("Enter a valid phone number.")
-                )(address)
+                case "phoneNumber":
+                    # replicate client-side validation in formio-renderer (buildPhoneNumberValidationSchema)
+                    RegexValidator(
+                        regex="^[+0-9][- 0-9]+$",
+                        message=_("Enter a valid phone number."),
+                    )(address)
 
-            case _:  # pragma: no cover
-                assert_never(type)
+                case _:  # pragma: no cover
+                    assert_never(type)
+        except DjangoValidationError as exc:
+            detail = get_error_detail(exc)
+            raise serializers.ValidationError({"address": detail})
+        # branch below is uncovered because *so far* we only use plain Django validators
+        except serializers.ValidationError as exc:  # pragma: no cover
+            detail = serializers.as_serializer_error(exc)
+            raise serializers.ValidationError({"address": detail})
 
         return attrs
 

--- a/src/openforms/formio/tests/validation/test_profile.py
+++ b/src/openforms/formio/tests/validation/test_profile.py
@@ -152,7 +152,7 @@ class ProfileValidationTests(TestCase):
 
         is_valid, errors = validate_formio_data(component, values, submission)
 
-        error = extract_error(errors["profile"][0], "non_field_errors")
+        error = extract_error(errors["profile"][0], "address")
 
         self.assertFalse(is_valid)
         self.assertEqual(error, _("Enter a valid email address."))
@@ -183,7 +183,7 @@ class ProfileValidationTests(TestCase):
         }
         is_valid, errors = validate_formio_data(component, values, submission)
 
-        error = extract_error(errors["profile"][0], "non_field_errors")
+        error = extract_error(errors["profile"][0], "address")
 
         self.assertFalse(is_valid)
         self.assertEqual(error, _("Enter a valid phone number."))


### PR DESCRIPTION
While the validation is running in the validate method because the type field value is known only then, the proper location for the validation error is the address field as that has the incorrectly shaped value.

Part of #6182 with some customer profile UI rework

**Changes**

Move validation error from `non_field_errors` to the `address` field.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
