### PR TITLE
[#6453] - pass submission for token exchange

### DIFF
--- a/src/openforms/prefill/contrib/family_members/haal_centraal.py
+++ b/src/openforms/prefill/contrib/family_members/haal_centraal.py
@@ -4,6 +4,7 @@ import structlog
 
 from openforms.contrib.haal_centraal.clients import get_brp_client
 from openforms.contrib.haal_centraal.clients.brp import NaturalPersonDetails
+from openforms.submissions.models import Submission
 
 from .constants import FamilyMembersTypeChoices
 from .filters import filter_members_by_age
@@ -13,9 +14,9 @@ logger = structlog.stdlib.get_logger(__name__)
 
 
 def get_data_from_haal_centraal(
-    bsn: str, options: FamilyMemberOptions
+    bsn: str, options: FamilyMemberOptions, submission: Submission
 ) -> list[NaturalPersonDetails]:
-    with get_brp_client() as client:
+    with get_brp_client(submission=submission) as client:
         match options["type"]:
             case FamilyMembersTypeChoices.partners:
                 return client.get_family_members(

--- a/src/openforms/prefill/contrib/family_members/plugin.py
+++ b/src/openforms/prefill/contrib/family_members/plugin.py
@@ -39,7 +39,10 @@ class HasDictDump(Protocol):
 
 class Handler(Protocol):
     def __call__(
-        self, bsn: str, options: FamilyMemberOptions
+        self,
+        bsn: str,
+        options: FamilyMemberOptions,
+        submission: Submission,
     ) -> Sequence[HasDictDump]: ...
 
 
@@ -82,9 +85,8 @@ class FamilyMembersPrefill(BasePlugin[FamilyMemberOptions]):
 
         handler = get_handler()
         results: Sequence[JSONObject] = [
-            item.model_dump(by_alias=True) for item in handler(bsn, options)
+            item.model_dump(by_alias=True) for item in handler(bsn, options, submission)
         ]
-
         # we need to update both variables (the one that contains the initial data and the
         # prefill configuration and the mutable one) with the data that we have retrieved
         return {

--- a/src/openforms/prefill/contrib/family_members/stuf_bg.py
+++ b/src/openforms/prefill/contrib/family_members/stuf_bg.py
@@ -1,5 +1,6 @@
 from typing import assert_never
 
+from openforms.submissions.models import Submission
 from stuf.stuf_bg.client import get_client as get_stufbg_client
 from stuf.stuf_bg.data import NaturalPersonDetails
 
@@ -9,7 +10,7 @@ from .typing import FamilyMemberOptions
 
 
 def get_data_from_stuf_bg(
-    bsn: str, options: FamilyMemberOptions
+    bsn: str, options: FamilyMemberOptions, submission: Submission
 ) -> list[NaturalPersonDetails]:
     with get_stufbg_client() as client:
         match options["type"]:

--- a/src/openforms/prefill/contrib/family_members/tests/test_plugin.py
+++ b/src/openforms/prefill/contrib/family_members/tests/test_plugin.py
@@ -1,4 +1,4 @@
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from django.test import TestCase
 
@@ -14,6 +14,8 @@ from openforms.contrib.haal_centraal.constants import BRPVersions
 from openforms.contrib.haal_centraal.models import HaalCentraalConfig
 from openforms.forms.tests.factories import FormVariableFactory
 from openforms.logging.tests.utils import disable_timelinelog
+from openforms.pre_requests.base import PreRequestHookBase
+from openforms.pre_requests.registry import Registry
 from openforms.prefill.service import prefill_variables
 from openforms.submissions.tests.factories import SubmissionFactory
 from openforms.utils.tests.vcr import OFVCRMixin
@@ -373,6 +375,49 @@ class FamilyMembersPrefillPluginHCV2Tests(OFVCRMixin, TestCase):
         self.assertEqual(
             state.variables["hc_prefill_children_immutable"].value, expected_data
         )
+
+    def test_pre_request_hooks_called(self):
+        pre_req_register = Registry()
+        mock = MagicMock()
+
+        @pre_req_register("test")
+        class PreRequestHook(PreRequestHookBase):
+            def __call__(self, *args, **kwargs):
+                mock(*args, **kwargs)
+
+        submission = SubmissionFactory.from_components(
+            auth_info__value="999970124",
+            auth_info__attribute=AuthAttribute.bsn,
+            components_list=[
+                {
+                    "key": "hc_prefill_partners_mutable",
+                    "type": "partners",
+                    "label": "Partners",
+                },
+            ],
+        )
+        FormVariableFactory.create(
+            key="hc_prefill_partners_immutable",
+            form=submission.form,
+            user_defined=True,
+            data_type=FormVariableDataTypes.array,
+            prefill_plugin=PLUGIN_IDENTIFIER,
+            prefill_options={
+                "type": "partners",
+                "mutable_data_form_variable": "hc_prefill_partners_mutable",
+            },
+        )
+
+        with patch("openforms.pre_requests.clients.registry", new=pre_req_register):
+            prefill_variables(submission=submission)
+
+        # 2 API calls expected, 1 for logged in person data, 1 for partner data
+        self.assertEqual(mock.call_count, 2)
+
+        # assert that the pre request hooks are called with the
+        # expected context to make sure that token exchange works properly
+        context = mock.call_args.kwargs["context"]
+        self.assertEqual(context, {"submission": submission})
 
 
 @disable_timelinelog()

--- a/src/openforms/prefill/contrib/family_members/tests/vcr_cassettes/test_plugin/FamilyMembersPrefillPluginHCV2Tests/test_pre_request_hooks_called.yaml
+++ b/src/openforms/prefill/contrib/family_members/tests/vcr_cassettes/test_plugin/FamilyMembersPrefillPluginHCV2Tests/test_pre_request_hooks_called.yaml
@@ -1,0 +1,86 @@
+interactions:
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970124"],
+      "fields": ["partners.burgerservicenummer", "partners.naam.voornamen", "partners.naam.voorletters",
+      "partners.naam.voorvoegsel", "partners.naam.geslachtsnaam", "partners.geboorte.datum"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '268'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.33.0
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"partners":[{"burgerservicenummer":"999970136","naam":{"voornamen":"Pia","geslachtsnaam":"Pauw","voorletters":"P."},"geboorte":{"datum":{"type":"Datum","datum":"1989-04-01","langFormaat":"1
+        april 1989"}}}]}]}'
+    headers:
+      Content-Length:
+      - '263'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 12 Aug 2026 21:50:07 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"type": "RaadpleegMetBurgerservicenummer", "burgerservicenummer": ["999970136"],
+      "fields": ["burgerservicenummer", "burgerservicenummer", "overlijden"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br, zstd
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '153'
+      Content-Type:
+      - application/json; charset=utf-8
+      User-Agent:
+      - python-requests/2.33.0
+      x-doelbinding:
+      - ''
+      x-gebruiker:
+      - BurgerZelf
+      x-origin-oin:
+      - ''
+      x-verwerking:
+      - ''
+    method: POST
+    uri: http://localhost:5010/haalcentraal/api/brp/personen
+  response:
+    body:
+      string: '{"type":"RaadpleegMetBurgerservicenummer","personen":[{"burgerservicenummer":"999970136"}]}'
+    headers:
+      Content-Length:
+      - '91'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 12 Aug 2026 21:50:08 GMT
+      Server:
+      - Kestrel
+    status:
+      code: 200
+      message: OK
+version: 1


### PR DESCRIPTION
pass submission to the get_data_from_haal_centraal (which passes it to the get_brp_client) so that the token-exchange will hook these calls accordingly

Closes #6453

**Changes**

[Describe the changes here]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Checked new model fields are usable in the admin
  - [ ] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [ ] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how

- Documentation

  - [ ] Added documentation which describes the changes
