### PR TITLE
Do not crash on empty content field

### DIFF
--- a/src/openforms/emails/tests/test_utils.py
+++ b/src/openforms/emails/tests/test_utils.py
@@ -4,6 +4,11 @@ from ..utils import strip_tags_plus
 
 
 class StripTagsPlusTests(SimpleTestCase):
+    def test_empty_content(self):
+        output = strip_tags_plus("")
+
+        self.assertEqual(output, "")
+
     def test_strip_tags_no_keep_leading_whitespace(self):
         markup = """
         <p>Some paragraph</p>

--- a/src/openforms/emails/utils.py
+++ b/src/openforms/emails/utils.py
@@ -8,7 +8,7 @@ from django.template.loader import get_template
 
 from mail_cleaner.mail import send_mail_plus
 from mail_cleaner.sanitizer import sanitize_content as _sanitize_content
-from mail_cleaner.text import strip_tags_plus
+from mail_cleaner.text import strip_tags_plus as _strip_tags_plus
 
 from openforms.config.models import GlobalConfiguration, Theme
 from openforms.template import openforms_backend, render_from_string
@@ -19,6 +19,13 @@ from .context import get_wrapper_context
 MESSAGE_SIZE_LIMIT = 2 * 1024 * 1024
 
 RE_NON_WHITESPACE = re.compile(r"\S")
+
+
+def strip_tags_plus(text: str, keep_leading_whitespace: bool = False) -> str:
+    if not text:
+        return ""
+
+    return _strip_tags_plus(text, keep_leading_whitespace=keep_leading_whitespace)
 
 
 def get_system_netloc_allowlist() -> list[str]:


### PR DESCRIPTION
Closes #6524

**Changes**

This change makes sure the summary page does not crash when there is an empty content field in there.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
