### PR TITLE
Fix form partial update crash

### DIFF
--- a/src/openforms/forms/api/serializers/form.py
+++ b/src/openforms/forms/api/serializers/form.py
@@ -1,4 +1,4 @@
-from django.db import transaction
+from django.db import models, transaction
 from django.utils.translation import gettext_lazy as _
 
 import structlog
@@ -636,6 +636,8 @@ class FormSerializer(PublicFieldsSerializerMixin, serializers.ModelSerializer):
         auth_backends = get_from_serializer_data_or_instance(
             "auth_backends", attrs, self
         )
+        if isinstance(auth_backends, models.Manager):
+            auth_backends = auth_backends.values()
 
         # If an auto login backend is supplied, it must be present in
         # `auth_backends`

--- a/src/openforms/forms/tests/test_serializers.py
+++ b/src/openforms/forms/tests/test_serializers.py
@@ -1,12 +1,12 @@
 from unittest.mock import patch
 
 from django.contrib.auth.models import AnonymousUser
-from django.test import RequestFactory, TestCase
+from django.test import RequestFactory, TestCase, tag
 
 from hypothesis import given
 from hypothesis.extra.django import TestCase as HypothesisTestCase
 
-from openforms.accounts.tests.factories import UserFactory
+from openforms.accounts.tests.factories import SuperUserFactory, UserFactory
 from openforms.authentication.contrib.digid.constants import DIGID_DEFAULT_LOA
 from openforms.config.models.config import GlobalConfiguration
 from openforms.tests.search_strategies import json_primitives
@@ -383,6 +383,24 @@ class FormSerializerTest(TestCase):
 
         self.assertEqual(len(login_options), 1)
         self.assertTrue(login_options[0]["visible"])
+
+    @tag("sentry-496315")
+    def test_validation_auto_login_backend_with_partial_update(self):
+        # regression detected via Sentry issue 496315
+        form = FormFactory.create(authentication_backend="digid")
+        factory = RequestFactory()
+        request = factory.get("/foo")
+        request.user = SuperUserFactory.create()
+        serializer = FormSerializer(
+            instance=form,
+            data={"auto_login_authentication_backend": "eherkenning"},
+            partial=True,
+            context={"request": request},
+        )
+
+        is_valid = serializer.is_valid()
+
+        self.assertFalse(is_valid)
 
 
 class SynchronizeVariablesActionConfigSerializerTest(TestCase):


### PR DESCRIPTION
[skip: e2e]

Noticed this via Sentry - this does not happen in our own frontend code and was triggered by a third party client consuming the private API.