### PR TITLE
Fix editgrid summary visibility bug

### DIFF
--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
 from typing import Any, Literal, NotRequired, TypedDict
@@ -14,6 +15,7 @@ from furl import furl
 
 from openforms.emails.utils import strip_tags_plus  # TODO: put somewhere else
 from openforms.formio.typing import Component
+from openforms.submissions.rendering.base import Node
 from openforms.submissions.rendering.constants import RenderModes
 from openforms.submissions.rendering.renderer import Renderer
 from openforms.utils.urls import build_absolute_uri
@@ -31,8 +33,10 @@ class ContainerMixin:
 
     renderer: Renderer
     step_data: FormioData
+    path: str = ""  # Path in the data (#TODO rename to data_path?)
     component: Component
     mode: RenderModes
+    parent_node: Node | None = None
 
     @property
     def is_visible(self) -> bool:
@@ -46,11 +50,31 @@ class ContainerMixin:
         if self.mode in visible_modes:
             return True
 
-        # We only pass the step data, since frontend logic only has access to the current step data.
-        if is_hidden(
+        formio_config_wrapper = self.renderer.submission.total_configuration_wrapper
+
+        # We only pass the step data, since frontend logic only has access to the
+        # current step data.
+        if isinstance(self.parent_node, EditGridGroupNode):
+            # Frontend logic for repeating group does not specify the index of the
+            # iteration. So we need to look at the data for a specific iteration to
+            # figure out if a field within the iteration is visible
+            artificial_repeating_group_data = copy.deepcopy(self.step_data)
+            current_iteration_data = self.step_data.get(self.path, None)
+            artificial_repeating_group_data[self.parent_node.path] = (
+                current_iteration_data
+            )
+            if is_hidden(
+                self.component,
+                artificial_repeating_group_data,
+                # we can pass the root config wrapper because all editgrid item component
+                # keys are already exposed in the config wrapper with their prefixed paths
+                configuration=formio_config_wrapper,
+            ):
+                return False
+        elif is_hidden(
             self.component,
             self.step_data,
-            configuration=self.renderer.submission.total_configuration_wrapper,
+            configuration=formio_config_wrapper,
         ):
             return False
 

--- a/src/openforms/formio/rendering/default.py
+++ b/src/openforms/formio/rendering/default.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
-import copy
 from collections.abc import Callable, Iterator
 from dataclasses import dataclass
-from typing import Any, Literal, NotRequired, TypedDict
+from typing import TYPE_CHECKING, Any, Literal, NotRequired, TypedDict
 
 from django.conf import settings
 from django.urls import reverse
@@ -14,6 +13,7 @@ from django.utils.translation import gettext, gettext_lazy as _
 from furl import furl
 
 from openforms.emails.utils import strip_tags_plus  # TODO: put somewhere else
+from openforms.formio.service import FormioConfigurationWrapper
 from openforms.formio.typing import Component
 from openforms.submissions.rendering.base import Node
 from openforms.submissions.rendering.constants import RenderModes
@@ -38,6 +38,12 @@ class ContainerMixin:
     mode: RenderModes
     parent_node: Node | None = None
 
+    if TYPE_CHECKING:
+
+        def _is_visible_in_editgrid_item(
+            self, formio_config_wrapper: FormioConfigurationWrapper
+        ) -> bool: ...
+
     @property
     def is_visible(self) -> bool:
         # fieldset/editgrid components do not support the showInFoo properties, so we don't use the super
@@ -55,21 +61,7 @@ class ContainerMixin:
         # We only pass the step data, since frontend logic only has access to the
         # current step data.
         if isinstance(self.parent_node, EditGridGroupNode):
-            # Frontend logic for repeating group does not specify the index of the
-            # iteration. So we need to look at the data for a specific iteration to
-            # figure out if a field within the iteration is visible
-            artificial_repeating_group_data = copy.deepcopy(self.step_data)
-            current_iteration_data = self.step_data.get(self.path, None)
-            artificial_repeating_group_data[self.parent_node.path] = (
-                current_iteration_data
-            )
-            if is_hidden(
-                self.component,
-                artificial_repeating_group_data,
-                # we can pass the root config wrapper because all editgrid item component
-                # keys are already exposed in the config wrapper with their prefixed paths
-                configuration=formio_config_wrapper,
-            ):
+            if not self._is_visible_in_editgrid_item(formio_config_wrapper):
                 return False
         elif is_hidden(
             self.component,

--- a/src/openforms/formio/rendering/nodes.py
+++ b/src/openforms/formio/rendering/nodes.py
@@ -11,7 +11,7 @@ from openforms.submissions.models import SubmissionStep
 from openforms.submissions.rendering.base import Node
 from openforms.submissions.rendering.constants import RenderModes
 
-from ..datastructures import FormioData
+from ..datastructures import FormioConfigurationWrapper, FormioData
 from ..service import format_value, get_component_empty_value, holds_submission_data
 from ..typing import Component
 from ..utils import iter_components
@@ -123,21 +123,7 @@ class ComponentNode(Node):
         # We only pass the step data, since frontend logic only has access to the
         # current step data.
         if isinstance(self.parent_node, EditGridGroupNode):
-            # Frontend logic for repeating group does not specify the index of the
-            # iteration. So we need to look at the data for a specific iteration to
-            # figure out if a field within the iteration is visible
-            artificial_repeating_group_data = copy.deepcopy(self.step_data)
-            current_iteration_data = self.step_data.get(self.path, None)
-            artificial_repeating_group_data[self.parent_node.path] = (
-                current_iteration_data
-            )
-            if is_hidden(
-                self.component,
-                artificial_repeating_group_data,
-                # we can pass the root config wrapper because all editgrid item component
-                # keys are already exposed in the config wrapper with their prefixed paths
-                configuration=formio_config_wrapper,
-            ):
+            if not self._is_visible_in_editgrid_item(formio_config_wrapper):
                 return False
         elif is_hidden(
             self.component,
@@ -158,6 +144,26 @@ class ComponentNode(Node):
             render_configuration.key, render_configuration.default
         )
         return should_render
+
+    def _is_visible_in_editgrid_item(
+        self, formio_config_wrapper: FormioConfigurationWrapper
+    ) -> bool:
+        from .default import EditGridGroupNode
+
+        assert isinstance(self.parent_node, EditGridGroupNode)
+        # Frontend logic for repeating group does not specify the index of the
+        # iteration. So we need to look at the data for a specific iteration to
+        # figure out if a field within the iteration is visible
+        artificial_repeating_group_data = copy.deepcopy(self.step_data)
+        current_iteration_data = self.step_data.get(self.path, None)
+        artificial_repeating_group_data[self.parent_node.path] = current_iteration_data
+        return not is_hidden(
+            self.component,
+            artificial_repeating_group_data,
+            # we can pass the root config wrapper because all editgrid item component
+            # keys are already exposed in the config wrapper with their prefixed paths
+            configuration=formio_config_wrapper,
+        )
 
     @property
     def key(self):

--- a/src/openforms/submissions/tests/renderer/test_submission_summary.py
+++ b/src/openforms/submissions/tests/renderer/test_submission_summary.py
@@ -1,6 +1,7 @@
 from django.test import TestCase, tag
 from django.urls import reverse
 
+from privates.test import temp_private_root
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -620,3 +621,112 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
         response = self.client.get(url)
 
         self.assertEqual(status.HTTP_200_OK, response.status_code)
+
+    @temp_private_root()
+    @tag("gh-6142")
+    def test_summary_with_editgrid_items_that_have_conditional_visibility(self):
+        submission = SubmissionFactory.from_components(
+            [
+                {
+                    "type": "fieldset",
+                    "key": "fieldset",
+                    "label": "fieldset",
+                    "components": [
+                        {"type": "textfield", "key": "textfield", "label": "textfield"}
+                    ],
+                },
+                {
+                    "type": "editgrid",
+                    "key": "herhalendeGroep",
+                    "label": "editgrid",
+                    "groupLabel": "Item",
+                    "components": [
+                        {
+                            "type": "textfield",
+                            "key": "tekstveld0",
+                            "label": "Tekstveld0",
+                        },
+                        {
+                            "type": "textfield",
+                            "key": "tekstveld1",
+                            "label": "Tekstveld1",
+                        },
+                        {
+                            "type": "checkbox",
+                            "key": "selectievakje",
+                            "label": "Selectievakje",
+                        },
+                        {
+                            "type": "fieldset",
+                            "key": "veldengroep",
+                            "label": "Veldengroep",
+                            "conditional": {
+                                "eq": True,
+                                "show": True,
+                                "when": "herhalendeGroep.selectievakje",
+                            },
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "tekstveld2",
+                                    "label": "Tekstveld2",
+                                },
+                                {
+                                    "type": "textfield",
+                                    "key": "tekstveld3",
+                                    "label": "Tekstveld3",
+                                },
+                            ],
+                        },
+                    ],
+                },
+            ],
+            submitted_data={
+                "textfield": "zzz",
+                "herhalendeGroep": [
+                    {
+                        "tekstveld0": "a",
+                        "tekstveld1": "b",
+                        "selectievakje": True,
+                        "tekstveld2": "c",
+                        "tekstveld3": "d",
+                    }
+                ],
+            },
+            with_report=True,
+        )
+        self._add_submission_to_session(submission)
+
+        with self.subTest("summary endpoint data"):
+            url = reverse("api:submission-summary", kwargs={"uuid": submission.uuid})
+
+            response = self.client.get(url)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            summary_data = response.json()[0]["data"]
+
+            expected = [
+                ("fieldset", None),
+                ("textfield", "zzz"),
+                ("editgrid", None),
+                ("Item 1", None),
+                ("Tekstveld0", "a"),
+                ("Tekstveld1", "b"),
+                ("Selectievakje", True),
+                ("Veldengroep", None),
+                ("Tekstveld2", "c"),
+                ("Tekstveld3", "d"),
+            ]
+            for index, (name, value) in enumerate(expected):
+                with self.subTest(label=name, expected_value=value):
+                    summary_item = summary_data[index]
+                    self.assertEqual(summary_item["name"], name)
+                    self.assertEqual(summary_item["value"], value)
+
+        with self.subTest("summary pdf generation"):
+            html = submission.report.generate_submission_report_pdf()
+
+            self.assertIn("Tekstveld0", html)
+            self.assertIn("Tekstveld1", html)
+            self.assertIn("Tekstveld2", html)
+            self.assertIn("Tekstveld3", html)

--- a/src/openforms/submissions/tests/renderer/test_submission_summary.py
+++ b/src/openforms/submissions/tests/renderer/test_submission_summary.py
@@ -690,7 +690,12 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                         "selectievakje": True,
                         "tekstveld2": "c",
                         "tekstveld3": "d",
-                    }
+                    },
+                    {
+                        "tekstveld0": "e",
+                        "tekstveld1": "f",
+                        "selectievakje": False,
+                    },
                 ],
             },
             with_report=True,
@@ -716,7 +721,12 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
                 ("Veldengroep", None),
                 ("Tekstveld2", "c"),
                 ("Tekstveld3", "d"),
+                ("Item 2", None),
+                ("Tekstveld0", "e"),
+                ("Tekstveld1", "f"),
+                ("Selectievakje", False),
             ]
+            self.assertEqual(len(summary_data), len(expected))
             for index, (name, value) in enumerate(expected):
                 with self.subTest(label=name, expected_value=value):
                     summary_item = summary_data[index]


### PR DESCRIPTION
Closes #6142
Closes #4004

**Changes**

Implement editgrid item handling in the layout container mixin `is_visible` method.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
