### PR TITLE
DH-899 - allow the logic service-fetch calls to be hooked

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,45 @@ Changelog
         `latest <https://open-forms.readthedocs.io/en/latest/changelog.html>`_ docs
         version.
 
+3.5.7 (2026-08-24)
+===================
+
+Regular bugfix release.
+
+* Fixed some crashes in check scripts for the 4.0 upgrade.
+* [:backend:`6510`] Fixed the default value for booleans (checkbox, selectboxes) in
+  logic triggers not being saved properly.
+* [:backend:`6297`] Fixed hidden fields with ``multiple`` enabled and ``clearOnHide``
+  disabled triggering validation errors.
+* [:backend:`5879`] Fixed detection of empty conditional values accidentally treating a
+  falsy value for ``eq`` as "empty".
+* [:backend:`6292`] Fixed incomplete variable extraction from user templates in
+  components, which could lead to incorrect logic rule dependency graphs.
+* [:backend:`6468`, :backend:`6507`] Fixed logic evaluation having different outcomes
+  for admin and non-admin users.
+* [:backend:`6142`, :backend:`4004`] Fixed layout components with conditional display
+  logic inside ``editgrid`` components not being shown on the submission summary page
+  and/or summary PDF.
+* [:backend:`6524`] Fixed a crash when an empty ``content`` field is present.
+* [:backend:`6235`] Fixed client-side Sentry error monitoring not being activated any
+  longer.
+* Upgraded dependencies to latest available security releases (Django, tablib, sqlparse).
+
+
+3.4.13 (2026-08-24)
+===================
+
+Final bugfix release - 3.4.x is end of life as 4.0 is being released.
+
+* [:backend:`6297`] Fixed hidden fields with ``multiple`` enabled and ``clearOnHide``
+  disabled triggering validation errors.
+* [:backend:`6468`] Fixed logic evaluation having different outcomes for admin and
+  non-admin users.
+* [:backend:`6142`, :backend:`4004`] Fixed layout components with conditional display
+  logic inside ``editgrid`` components not being shown on the submission summary page
+  and/or summary PDF.
+* [:backend:`6524`] Fixed a crash when an empty ``content`` field is present.
+
 4.0.0-beta.0 (2026-08-21)
 =========================
 

--- a/bin/report_component_problems.py
+++ b/bin/report_component_problems.py
@@ -147,9 +147,6 @@ def check_component(component: Component) -> Iterator[str]:
             if dp_max_date == "":
                 yield "datePicker.maxDate is empty string instead of null."
 
-            if date_picker["initDate"] != "":
-                yield "datePicker.initDate is not empty string."
-
         case {"type": "datetime"}:
             validate = component.get("validate", {})
             date_picker = component.get("datePicker", {})
@@ -173,9 +170,6 @@ def check_component(component: Component) -> Iterator[str]:
                 yield "datePicker.maxDate is empty string instead of null."
             if dp_max_date and 11 <= len(dp_max_date) <= 16:
                 yield "datePicker.maxDate is not a valid RFC3339 encoded datetime."
-
-            if date_picker["initDate"] != "":
-                yield "datePicker.initDate is not empty string."
 
         case {"type": "time"}:
             validate = component.get("validate", {})

--- a/src/openforms/forms/templates/forms/sdk_snippet.html
+++ b/src/openforms/forms/templates/forms/sdk_snippet.html
@@ -11,8 +11,8 @@
     data-base-url="{% api_base_url %}"
     data-base-path="{% if base_path %}{{ base_path }}{% else %}{% url 'forms:form-detail' slug=form.slug %}{% endif %}"
     data-csp-nonce="{{ request.csp_nonce }}"
-    {% if sdk_sentry_dsn %}data-sentry-dsn{% endif %}
-    {% if sdk_sentry_env %}data-sentry-env{% endif %}
+    {% if sdk_sentry_dsn %}data-sentry-dsn="{{ sdk_sentry_dsn }}"{% endif %}
+    {% if sdk_sentry_env %}data-sentry-env="{{ sdk_sentry_env }}"{% endif %}
 ></div>
 {# Browsers since 2018 support module, the UMD fallback should not be necessary any longer #}
 <script type="module" src="{% static 'sdk-wrapper.mjs' %}"></script>

--- a/src/openforms/submissions/exports.py
+++ b/src/openforms/submissions/exports.py
@@ -5,6 +5,7 @@ from django.db import models
 from django.http import HttpResponse
 from django.utils.timezone import make_naive
 
+import structlog
 import tablib
 from lxml import etree
 from tablib.formats._json import serialize_objects_handler
@@ -13,6 +14,8 @@ from .models import Submission
 from .rendering.base import Node
 from .rendering.constants import RenderModes
 from .rendering.renderer import Renderer
+
+logger = structlog.stdlib.get_logger(__name__)
 
 
 @dataclasses.dataclass
@@ -49,6 +52,7 @@ def create_submission_export(queryset: models.QuerySet[Submission]) -> tablib.Da
     if not queryset:
         return tablib.Dataset()
 
+    logger.info("submission_export_started")
     first_submission = queryset[0]
     headers = ["Formuliernaam", "Inzendingdatum"]
     if first_submission.form.translation_enabled:
@@ -76,6 +80,7 @@ def create_submission_export(queryset: models.QuerySet[Submission]) -> tablib.Da
             data_node.value for data_node in iter_submission_data_nodes(submission)
         ]
         data.append(submission_data)
+    logger.info("submission_export_done", num_rows=len(data))
     return data
 
 

--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -646,7 +646,7 @@ class ServiceFetchAction(ActionOperation):
     ) -> DataMapping:
         var = self.rule.form.formvariable_set.get(key=self.variable)
         with log_errors({}, self.rule):  # TODO proper error handling
-            result = perform_service_fetch(var, context, str(submission.uuid))
+            result = perform_service_fetch(var, context, submission)
             if result is None:
                 return {}
 

--- a/src/openforms/submissions/logic/service_fetching.py
+++ b/src/openforms/submissions/logic/service_fetching.py
@@ -8,9 +8,14 @@ import jq
 import structlog
 from json_logic import UNDEFINED_VALUE, jsonLogic
 from zgw_consumers.client import build_client
+from zgw_consumers.constants import AuthTypes
+from zgw_consumers.nlx import NLXClient
 
+from openforms.contrib.client import LoggingClient
 from openforms.formio.service import FormioData
 from openforms.forms.models import FormVariable
+from openforms.pre_requests.clients import PreRequestClientContext, PreRequestMixin
+from openforms.submissions.models import Submission
 from openforms.typing import JSONObject, JSONValue
 from openforms.variables.models import DataMappingTypes, ServiceFetchConfiguration
 
@@ -27,9 +32,23 @@ class FetchResult:
     # response_headers: JSONObject
 
 
+class ServiceFetchClient(PreRequestMixin, LoggingClient):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
 def perform_service_fetch(
-    var: FormVariable, context: FormioData, submission_uuid: str = ""
+    var: FormVariable,
+    context: FormioData,
+    submission: Submission | None = None,
 ) -> FetchResult | None:
+    """public method for fetching from service.
+    Checks the vars, gets (builds) the client, and performs the fetch method call with the client.
+
+    This ensures that the token exchange is performed when needed:
+    plugin is installed and the service is configured for the token exchange,
+    if not the fetch is done without the token exchange hook"""
+
     """Fetch a value from a http-service, perform a transformation on it and
     return the result.
 
@@ -43,18 +62,34 @@ def perform_service_fetch(
     The value returned by the request is cached using the submission UUID and the
     arguments to the request (hashed to make a cache key).
     """
-    log = logger.bind(variable=var.key, submission_uuid=str(submission_uuid))
-    log.info("perform_service_fetch_started")
 
     if not var.service_fetch_configuration:
         raise ValueError(
             f"Can't perform service fetch on {var}. "
             "It needs a service_fetch_configuration."
         )
-    fetch_config: ServiceFetchConfiguration = var.service_fetch_configuration
 
-    client = build_client(fetch_config.service)
+    submission_uuid = str(submission.uuid) if submission else None
+    log = logger.bind(variable=var.key, submission_uuid=submission_uuid)
+    log.info("perform_service_fetch_started")
+    fetch_config: ServiceFetchConfiguration = var.service_fetch_configuration
     request_args = fetch_config.request_arguments(context)
+
+    context = (
+        PreRequestClientContext(submission=submission)
+        if submission is not None
+        else None
+    )
+
+    if fetch_config.service.auth_type == AuthTypes.api_key:
+        # default client factory, so we do not overwrite the configured api key
+        client_factory = NLXClient
+    else:
+        client_factory = ServiceFetchClient
+
+    client = build_client(
+        fetch_config.service, client_factory=client_factory, context=context
+    )
 
     def _do_fetch():
         log.info("perform_service_fetch_http_call_started")

--- a/src/openforms/submissions/tests/form_logic/test_endpoint.py
+++ b/src/openforms/submissions/tests/form_logic/test_endpoint.py
@@ -10,6 +10,7 @@ from zgw_consumers.test.factories import ServiceFactory
 
 from openforms.accounts.tests.factories import SuperUserFactory
 from openforms.formio.tests.assertions import FormioMixin
+from openforms.forms.constants import LogicActionTypes
 from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
@@ -1238,7 +1239,7 @@ class CheckLogicEndpointTests(
         "as_admin",
         [param(True, id="admin_true"), param(False, id="admin_false")],
     )
-    @tag("gh-6468")
+    @tag("gh-6468", "gh-6507")
     def test_logic_evaluation_as_admin_same_as_not_logged_in(self, as_admin: bool):
         # it's important that this happens on the second (or later) step, as the
         # permission check will never evaluate form logic if you're on the first step
@@ -1277,6 +1278,11 @@ class CheckLogicEndpointTests(
                         "label": "Textfield with radio value: {{ radio }}",
                         "hidden": False,
                     },
+                    {
+                        "type": "textfield",
+                        "key": "valueSetByLogic",
+                        "label": "Value set by logic",
+                    },
                 ]
             },
         )
@@ -1292,12 +1298,27 @@ class CheckLogicEndpointTests(
             actions=[
                 {
                     "action": {
-                        "type": "property",
+                        "type": LogicActionTypes.property,
                         "property": {"type": "bool", "value": "hidden"},
                         "state": True,
                     },
                     "component": "textfield",
                 },
+            ],
+        )
+        # always set the value of the field, this manifests in the ``step.data``
+        # output of API endpoints as it's not yet persisted in the database
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "action": {
+                        "type": LogicActionTypes.variable,
+                        "value": "kaas",
+                    },
+                    "variable": "valueSetByLogic",
+                }
             ],
         )
         form.apply_logic_analysis()
@@ -1347,3 +1368,15 @@ class CheckLogicEndpointTests(
                     "hidden": False,
                 },
             )
+
+        with self.subTest("value assignment"):
+            endpoint = reverse(
+                "api:submission-steps-detail",
+                kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+            )
+
+            response = self.client.get(endpoint)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            step_data = response.json()["data"]
+            self.assertEqual(step_data["valueSetByLogic"], "kaas")

--- a/src/openforms/submissions/tests/form_logic/test_fetching_form_variable_values_from_services.py
+++ b/src/openforms/submissions/tests/form_logic/test_fetching_form_variable_values_from_services.py
@@ -1,9 +1,10 @@
 from typing import Any
 from unittest import skip
+from unittest.mock import MagicMock, patch
 from urllib.parse import unquote
 
 from django.core.exceptions import SuspiciousOperation
-from django.test import SimpleTestCase, tag
+from django.test import SimpleTestCase, TestCase, tag
 
 import requests_mock
 from furl import furl
@@ -11,8 +12,11 @@ from hypothesis import assume, example, given, strategies as st
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
 
+from openforms.authentication.constants import AuthAttribute
 from openforms.formio.service import FormioData
 from openforms.forms.tests.factories import FormVariableFactory
+from openforms.pre_requests.base import PreRequestHookBase
+from openforms.pre_requests.registry import Registry
 from openforms.utils.tests.nlx import DisableNLXRewritingMixin
 from openforms.variables.constants import DataMappingTypes
 from openforms.variables.models import _convert_to_string
@@ -20,6 +24,7 @@ from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
 from openforms.variables.validators import HeaderValidator, ValidationError
 
 from ...logic.service_fetching import perform_service_fetch
+from ..factories import SubmissionFactory
 
 DEFAULT_REQUEST_HEADERS = {
     "Accept",
@@ -431,3 +436,82 @@ class ServiceFetchConfigVariableBindingTests(DisableNLXRewritingMixin, SimpleTes
 
         with self.assertRaises(ValueError):
             perform_service_fetch(var, FormioData())
+
+
+class ServiceFetchConfigPreRequestTests(DisableNLXRewritingMixin, TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.service = ServiceFactory.build(
+            api_type=APITypes.orc,
+            api_root="https://httpbin.org/",
+            auth_type=AuthTypes.no_auth,
+        )
+
+        cls.pre_req_register = Registry()
+        cls.mock = MagicMock()
+
+        @cls.pre_req_register("test")
+        class PreRequestHook(PreRequestHookBase):
+            def __call__(self, *args, **kwargs):
+                cls.mock(*args, **kwargs)
+
+    @requests_mock.Mocker()
+    def test_pre_request_hooks_called(self, m):
+        m.get("https://httpbin.org/get", json={"url": "https://httpbin.org/get"})
+        self.mock.reset_mock()
+        submission = SubmissionFactory.from_components(
+            auth_info__value="999970124",
+            auth_info__attribute=AuthAttribute.bsn,
+            components_list=[
+                {
+                    "key": "dummy_field",
+                    "type": "textfield",
+                    "label": "Dummy field",
+                },
+            ],
+        )
+
+        var = FormVariableFactory.build(
+            service_fetch_configuration=ServiceFetchConfigurationFactory.build(
+                service=self.service,
+                path="get",
+            )
+        )
+
+        with patch(
+            "openforms.pre_requests.clients.registry", new=self.pre_req_register
+        ):
+            perform_service_fetch(var, FormioData(), submission)
+
+        self.assertEqual(self.mock.call_count, 1)
+
+        # assert that the pre request hooks are called with the
+        # expected context to make sure that token exchange works properly
+        context = self.mock.call_args.kwargs["context"]
+        self.assertEqual(context, {"submission": submission})
+
+    @requests_mock.Mocker()
+    def test_pre_request_hooks_not_called(self, m):
+        m.get("https://httpbin.org/get", json={"url": "https://httpbin.org/get"})
+
+        self.mock.reset_mock()
+
+        var = FormVariableFactory.build(
+            service_fetch_configuration=ServiceFetchConfigurationFactory.build(
+                service=self.service,
+                path="get",
+            )
+        )
+
+        with patch(
+            "openforms.pre_requests.clients.registry", new=self.pre_req_register
+        ):
+            perform_service_fetch(var, FormioData())
+
+        self.assertEqual(self.mock.call_count, 1)
+
+        # assert that the pre request hooks are called without the
+        # context to make sure that token exchange does not interfere with none-submission-loaded calls
+        context = self.mock.call_args.kwargs["context"]
+        self.assertEqual(context, None)


### PR DESCRIPTION
to the token exchange pre-requests.

Because of the explicit service configuration in the token exchange plugin no unnecessary token exchange calls are triggered.

Closes DH-899 and DH-848

**Changes**

Pass the submission in the logic service-fetch calls and perform the call through the client that allows the prerequest to be hooked. Specific use-case: getting data from BRK/WOZ API's that are accessible through Haal Centraal which (in our case) needs the token auth.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Checked new model fields are usable in the admin
  - [ ] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [ ] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how

- Documentation

  - [ ] Added documentation which describes the changes
