### PR TITLE
Fix stale cache issue in logic evaluation / permission checks

### DIFF
--- a/src/openforms/formio/dynamic_config/dynamic_options.py
+++ b/src/openforms/formio/dynamic_config/dynamic_options.py
@@ -116,10 +116,13 @@ def add_options_to_config(
                 raise ServiceUnavailable(
                     _("Could not retrieve options from Referentielijsten API."),
                 )
+            del component["openForms"]["service"]
+            del component["openForms"]["code"]
         case DataSrcOptions.variable:
             items_array = get_options_from_variable(component, data, submission)
             if items_array is None:
                 return
+            del component["openForms"]["itemsExpression"]
         case _:
             return
 
@@ -133,3 +136,5 @@ def add_options_to_config(
         ],
         missing=dict,
     )
+    # ensure the new renderer assertions are met
+    assign(component, "openForms.dataSrc", "manual")

--- a/src/openforms/submissions/api/permissions.py
+++ b/src/openforms/submissions/api/permissions.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from uuid import UUID
 
 from rest_framework import permissions
@@ -114,7 +115,9 @@ class CanNavigateBetweenSubmissionStepsPermission(permissions.BasePermission):
 
         submission = obj.submission
         state = submission.load_execution_state()
-        check_submission_logic(submission)
+        assert obj.form_step is not None
+        configuration_copy = deepcopy(obj.form_step.form_definition.configuration)
+        check_submission_logic(submission, reset_configuration_wrapper=True)
 
         incomplete_steps = [
             submission_step
@@ -123,6 +126,8 @@ class CanNavigateBetweenSubmissionStepsPermission(permissions.BasePermission):
         ]
 
         submission.clear_execution_state()
+        obj.form_step.form_definition.configuration = configuration_copy
+        del obj.form_step.form_definition.configuration_wrapper
 
         if not incomplete_steps:
             return True

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -311,8 +311,12 @@ def check_submission_logic(
 
     # Note that the total configuration wrapper is a cached property, so we need to
     # reset to ensure we are not operating on outdated configurations later.
-    # XXX: not sure why this is necessary - removing it entirely doesn't seem to break
-    # any tests? Check with Viktor.
+    # We also need to reset the configuration itself, as demonstrated (again) in #6468,
+    # because mutations to the configuration wrapper result in dict mutations shared in
+    # the formstep configuration, which can lead to the wrong begin-state for the actual
+    # logic evaluation/check because this function does *not* receive the dirty input
+    # data that may result in a rule trigger *not* hitting, but by then the damage is
+    # already done from the permission check logic evaluation (for example).
     if reset_configuration_wrapper:
         submission._total_configuration_wrapper = None
     submission._form_logic_evaluated = True

--- a/src/openforms/submissions/tests/form_logic/test_submission_logic.py
+++ b/src/openforms/submissions/tests/form_logic/test_submission_logic.py
@@ -10,12 +10,14 @@ from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APITestCase
 
+from openforms.accounts.tests.factories import SuperUserFactory
 from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
     FormStepFactory,
     FormVariableFactory,
 )
+from openforms.submissions.models import Submission
 from openforms.typing import JSONValue
 from openforms.utils.json_logic.api.validators import JsonLogicValidator
 from openforms.variables.constants import FormVariableDataTypes
@@ -1369,6 +1371,229 @@ class CheckLogicSubmissionTest(SubmissionsMixin, APITestCase):
             ]
             self.assertTrue(textfield["hidden"])
             self.assertTrue(editgrid["hidden"])
+
+    @tag("gh-6468")
+    def test_logic_evaluation_as_admin_same_as_not_logged_in(self):
+        def _run_test(as_admin: bool):
+            form = FormFactory.create(
+                generate_minimal_setup=True,
+                formstep__form_definition__configuration={
+                    "components": [
+                        {
+                            "type": "selectboxes",
+                            "key": "inputOptions",
+                            "label": "Options",
+                            "values": [
+                                {"value": "a", "label": "A"},
+                                {"value": "b", "label": "B"},
+                                {"value": "c", "label": "C"},
+                            ],
+                        },
+                    ]
+                },
+            )
+            step1 = form.formstep_set.get()
+            step2 = FormStepFactory.create(
+                form=form,
+                form_definition__configuration={
+                    "components": [
+                        {
+                            "type": "radio",
+                            "key": "choice",
+                            "label": "Preference",
+                            "values": [],
+                            "openForms": {
+                                "dataSrc": "variable",
+                                "itemsExpression": {"var": "preferenceOptions"},
+                            },
+                            "hidden": False,
+                        },
+                        {
+                            "type": "selectboxes",
+                            "key": "derived",
+                            "label": "Label using {{choice}}",
+                            "values": [
+                                {"value": "1", "label": "1"},
+                                {"value": "2", "label": "2"},
+                            ],
+                            "hidden": False,
+                        },
+                    ],
+                },
+            )
+            FormVariableFactory.create(
+                form=form,
+                user_defined=True,
+                key="preferenceOptions",
+                data_type=FormVariableDataTypes.array,
+                data_subtype="",
+                initial_value=[],
+            )
+            FormLogicFactory.create(
+                form=form,
+                json_logic_trigger={
+                    "or": [
+                        {"var": "inputOptions.a"},
+                        {"var": "inputOptions.b"},
+                        {"var": "inputOptions.c"},
+                    ]
+                },
+                actions=[
+                    {
+                        "action": {
+                            "type": "variable",
+                            "value": {
+                                "reduce": [
+                                    [
+                                        {"if": [{"var": "inputOptions.a"}, ["a", "A"]]},
+                                        {"if": [{"var": "inputOptions.b"}, ["b", "B"]]},
+                                        {"if": [{"var": "inputOptions.c"}, ["c", "C"]]},
+                                    ],
+                                    {
+                                        "if": [
+                                            {"var": "current"},
+                                            {
+                                                "merge": [
+                                                    {"var": "accumulator"},
+                                                    [{"var": "current"}],
+                                                ]
+                                            },
+                                            {"var": "accumulator"},
+                                        ]
+                                    },
+                                    [],
+                                ],
+                            },
+                        },
+                        "variable": "preferenceOptions",
+                    }
+                ],
+            )
+            FormLogicFactory.create(
+                form=form,
+                json_logic_trigger={
+                    "or": [
+                        {"==": [{"var": "choice"}, None]},
+                        {"==": [{"var": "choice"}, ""]},
+                        {"==": [{"var": "choice"}, "None"]},
+                    ]
+                },
+                actions=[
+                    {
+                        "action": {
+                            "type": "property",
+                            "property": {"type": "bool", "value": "hidden"},
+                            "state": True,
+                        },
+                        "component": "derived",
+                    },
+                ],
+            )
+            # form.apply_logic_analysis()
+            submission = SubmissionFactory.create(form=form)
+            assert isinstance(submission, Submission)
+            self._add_submission_to_session(submission)
+            # simulating submitting the first step
+            endpoint = reverse(
+                "api:submission-steps-detail",
+                kwargs={"submission_uuid": submission.uuid, "step_uuid": step1.uuid},
+            )
+            response = self.client.put(
+                endpoint,
+                data={"data": {"inputOptions": {"a": False, "b": True, "c": True}}},
+            )
+            assert response.status_code == status.HTTP_201_CREATED
+            submission.refresh_from_db()
+            state = submission.load_submission_value_variables_state()
+            assert state.get_data()["preferenceOptions"]
+
+            logic_check_endpoint = reverse(
+                "api:submission-steps-logic-check",
+                kwargs={
+                    "submission_uuid": submission.uuid,
+                    "step_uuid": step2.uuid,
+                },
+            )
+
+            with self.subTest("without radio choice", as_admin=as_admin):
+                response = self.client.post(
+                    logic_check_endpoint,
+                    {"data": {"choice": ""}},
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                step_components = response.json()["step"]["formStep"]["configuration"][
+                    "components"
+                ]
+                self.assertEqual(
+                    step_components,
+                    [
+                        {
+                            "type": "radio",
+                            "key": "choice",
+                            "label": "Preference",
+                            "hidden": False,
+                            "openForms": {"dataSrc": "manual"},
+                            "values": [
+                                {"value": "b", "label": "B"},
+                                {"value": "c", "label": "C"},
+                            ],
+                        },
+                        {
+                            "type": "selectboxes",
+                            "key": "derived",
+                            "label": "Label using ",
+                            "values": [
+                                {"label": "1", "value": "1"},
+                                {"label": "2", "value": "2"},
+                            ],
+                            "hidden": True,
+                        },
+                    ],
+                )
+
+            with self.subTest("with radio choice", as_admin=as_admin):
+                response = self.client.post(
+                    logic_check_endpoint,
+                    {"data": {"choice": "b"}},
+                )
+
+                self.assertEqual(response.status_code, status.HTTP_200_OK)
+                step_components = response.json()["step"]["formStep"]["configuration"][
+                    "components"
+                ]
+                self.assertEqual(
+                    step_components,
+                    [
+                        {
+                            "type": "radio",
+                            "key": "choice",
+                            "label": "Preference",
+                            "hidden": False,
+                            "openForms": {"dataSrc": "manual"},
+                            "values": [
+                                {"value": "b", "label": "B"},
+                                {"value": "c", "label": "C"},
+                            ],
+                        },
+                        {
+                            "type": "selectboxes",
+                            "key": "derived",
+                            "label": "Label using b",
+                            "values": [
+                                {"label": "1", "value": "1"},
+                                {"label": "2", "value": "2"},
+                            ],
+                            "hidden": False,
+                        },
+                    ],
+                )
+
+        _run_test(as_admin=False)
+
+        user = SuperUserFactory.create()
+        self.client.force_authenticate(user=user)
+        _run_test(as_admin=True)
 
 
 @tag("gh-6005")


### PR DESCRIPTION
Closes #6468
[skip: e2e]

**Changes**

...

**TODO**

- [ ] Check if this also happens on 3.5, both new and old logic evaluation
- [ ] Fortward port the dynamic options patch (all versions)
- [ ] Add (updated) regression test to main to ensure this problem doesn't happen (first attempts to reproduce there didn't hint at it, but that may be because of the missing default value in logic)
- [ ] Drop data src commit, the renderer does not assert anything