### PR TITLE
Fix non admin logic result incorrectly being "cached"

### DIFF
--- a/src/openforms/submissions/api/permissions.py
+++ b/src/openforms/submissions/api/permissions.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from uuid import UUID
 
 from rest_framework import permissions
@@ -114,6 +115,8 @@ class CanNavigateBetweenSubmissionStepsPermission(permissions.BasePermission):
 
         submission = obj.submission
         state = submission.load_execution_state()
+        assert obj.form_step is not None
+        configuration_copy = deepcopy(obj.form_step.form_definition.configuration)
         check_submission_logic(submission)
 
         incomplete_steps = [
@@ -123,6 +126,11 @@ class CanNavigateBetweenSubmissionStepsPermission(permissions.BasePermission):
         ]
 
         submission.clear_execution_state()
+        # restore any possible logic side-effects to the current step configuration.
+        # Some logic rules may trigger that don't for the submission step PUT or logic
+        # check, as we don't take unsaved/dirty data into account here.
+        obj.form_step.form_definition.configuration = configuration_copy
+        del obj.form_step.form_definition.configuration_wrapper
 
         if not incomplete_steps:
             return True

--- a/src/openforms/submissions/form_logic.py
+++ b/src/openforms/submissions/form_logic.py
@@ -288,8 +288,8 @@ def check_submission_logic(
 
     # Note that the total configuration wrapper is a cached property, so we need to
     # reset to ensure we are not operating on outdated configurations later.
-    # XXX: not sure why this is necessary - removing it entirely doesn't seem to break
-    # any tests? Check with Viktor.
+    # XXX: not sure why/if this is necessary - removing it entirely doesn't seem to break
+    # any tests.
     if reset_configuration_wrapper:
         submission._total_configuration_wrapper = None
     submission._form_logic_evaluated = True

--- a/src/openforms/submissions/tests/form_logic/test_endpoint.py
+++ b/src/openforms/submissions/tests/form_logic/test_endpoint.py
@@ -4,10 +4,12 @@ import requests_mock
 from rest_framework import status
 from rest_framework.reverse import reverse
 from rest_framework.test import APIRequestFactory, APITestCase
+from unittest_parametrize import ParametrizedTestCase, param, parametrize
 from zgw_consumers.constants import AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
 
 from openforms.accounts.tests.factories import SuperUserFactory
+from openforms.formio.tests.assertions import FormioMixin
 from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
@@ -18,11 +20,14 @@ from openforms.variables.constants import FormVariableDataTypes
 from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
 
 from ...api.viewsets import SubmissionStepViewSet
+from ...models import Submission
 from ..factories import SubmissionFactory, SubmissionStepFactory
 from ..mixins import SubmissionsMixin
 
 
-class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
+class CheckLogicEndpointTests(
+    FormioMixin, SubmissionsMixin, ParametrizedTestCase, APITestCase
+):
     maxDiff = None
 
     def test_update_not_applicable_steps(self):
@@ -1228,3 +1233,117 @@ class CheckLogicEndpointTests(SubmissionsMixin, APITestCase):
         # not relevant in the context of the check-logic call.
         self.assertIsNone(step_data["defaultConfiguration"])
         self.assertEqual([], step_data["logicRules"])
+
+    @parametrize(
+        "as_admin",
+        [param(True, id="admin_true"), param(False, id="admin_false")],
+    )
+    @tag("gh-6468")
+    def test_logic_evaluation_as_admin_same_as_not_logged_in(self, as_admin: bool):
+        # it's important that this happens on the second (or later) step, as the
+        # permission check will never evaluate form logic if you're on the first step
+        superuser = SuperUserFactory.create()
+        if as_admin:
+            self.client.force_authenticate(user=superuser)
+
+        form = FormFactory.create(
+            generate_minimal_setup=True,
+            formstep__form_definition__configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "dummy",
+                        "label": "Dummy textfield",
+                    },
+                ]
+            },
+        )
+        step = FormStepFactory.create(
+            form=form,
+            form_definition__configuration={
+                "components": [
+                    {
+                        "type": "radio",
+                        "key": "radio",
+                        "label": "radio",
+                        "values": [
+                            {"value": "a", "label": "A"},
+                            {"value": "b", "label": "B"},
+                        ],
+                    },
+                    {
+                        "type": "textfield",
+                        "key": "textfield",
+                        "label": "Textfield with radio value: {{ radio }}",
+                        "hidden": False,
+                    },
+                ]
+            },
+        )
+        # make the textfield hidden if there's no value picked in the radio
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger={
+                "in": [
+                    {"var": ["radio", ""]},
+                    [None, "", "None"],
+                ]
+            },
+            actions=[
+                {
+                    "action": {
+                        "type": "property",
+                        "property": {"type": "bool", "value": "hidden"},
+                        "state": True,
+                    },
+                    "component": "textfield",
+                },
+            ],
+        )
+        form.apply_logic_analysis()
+        submission = SubmissionFactory.create(form=form)
+        assert isinstance(submission, Submission)
+        SubmissionStepFactory.create(
+            submission=submission,
+            form_step=form.formstep_set.all()[0],
+            data={"dummy": ""},
+        )
+        self._add_submission_to_session(submission)
+        logic_check_endpoint = reverse(
+            "api:submission-steps-logic-check",
+            kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+        )
+
+        with self.subTest("without radio choice"):
+            response = self.client.post(
+                logic_check_endpoint,
+                {"data": {"radio": ""}},
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            configuration = response.json()["step"]["configuration"]
+            self.assertFormioComponent(
+                configuration,
+                "textfield",
+                {
+                    "label": "Textfield with radio value: ",
+                    "hidden": True,
+                },
+            )
+
+        with self.subTest("with radio choice"):
+            response = self.client.post(
+                logic_check_endpoint,
+                {"data": {"radio": "b"}},
+            )
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            configuration = response.json()["step"]["configuration"]
+            self.assertFormioComponent(
+                configuration,
+                "textfield",
+                {
+                    "label": "Textfield with radio value: b",
+                    "hidden": False,
+                },
+            )


### PR DESCRIPTION
Closes #6468

**Changes**

* Added regression test with different input scenarios and expected logic outcome
* Incorporated admin/non-admin in the regression test
* Reset the form step configuration after permission check logic executed

This is a bandaid, a structural solution is necessary and tickets for that are on the backlog.

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
