### PR TITLE
[#6515] cache certain catalogi client requests

### DIFF
--- a/src/openforms/conf/base.py
+++ b/src/openforms/conf/base.py
@@ -129,6 +129,10 @@ CACHES = {
         "BACKEND": "openforms.utils.cache.RequestProxyCache",
         "LOCATION": "default",
     },
+    "catalogi_client": {
+        "BACKEND": "openforms.utils.cache.RequestProxyCache",
+        "LOCATION": "default",
+    },
 }
 
 #

--- a/src/openforms/conf/ci.py
+++ b/src/openforms/conf/ci.py
@@ -38,6 +38,7 @@ CACHES.update(
         # See: https://github.com/jazzband/django-axes/blob/master/docs/configuration.rst#cache-problems
         "axes": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
         "oidc": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+        "catalogi_client": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
     }
 )
 

--- a/src/openforms/conf/dev.py
+++ b/src/openforms/conf/dev.py
@@ -84,6 +84,7 @@ CACHES.update(
         "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
         "axes": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
         "oidc": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+        "catalogi_client": {"BACKEND": "django.core.cache.backends.dummy.DummyCache"},
     }
 )
 

--- a/src/openforms/contrib/zgw/clients/catalogi.py
+++ b/src/openforms/contrib/zgw/clients/catalogi.py
@@ -4,6 +4,8 @@ from functools import cached_property
 from operator import itemgetter
 from typing import Literal, NotRequired, TypedDict
 
+from django.core.cache import BaseCache, caches
+
 from flags.state import flag_enabled
 from requests import Response
 from zgw_consumers.nlx import NLXClient
@@ -138,16 +140,38 @@ class RoleTypeListParams(TypedDict, total=False):
     page: int
 
 
+CATALOGI_LOOKUP_CACHE_TIMEOUT = 60 * 60 * 12  # 12 hours
+CATALOGI_VERSION_LOOKUP_CACHE_TIMEOUT = 60 * 60 * 12  # 12 hours
+CATALOGI_CASE_TYPE_LOOKUP_CACHE_TIMEOUT = 60 * 60 * 1  # 1 hour
+CATALOGI_IOT_LOOKUP_CACHE_TIMEOUT = 60 * 60 * 1  # 1 hours
+
+
 class CatalogiClient(LoggingMixin, NLXClient):
     _api_version: CatalogiAPIVersion | None = None
 
     @property
+    def cache(self) -> BaseCache:
+        cache = caches["catalogi_client"]
+        assert isinstance(cache, BaseCache)
+        return cache
+
+    @property
     def api_version(self) -> CatalogiAPIVersion:
-        if self._api_version is None:
+        def _lookup_version() -> CatalogiAPIVersion:
             # hit a known endpoint and parse the response headers. VRSN is just a made
             # up domain to limit the result set, hopefully it's even entirely empty.
             response = self.get("catalogussen", params={"domein": "VRSN"})
-            self._api_version = self._determine_api_version(response)
+            return self._determine_api_version(response)
+
+        if self._api_version is None:
+            cache_key = f"ZGW|catalogi|version|{self.base_url}"
+            self._api_version = self.cache.get_or_set(
+                cache_key,
+                default=_lookup_version,
+                timeout=CATALOGI_VERSION_LOOKUP_CACHE_TIMEOUT,
+            )
+
+        assert self._api_version is not None
         return self._api_version
 
     def _determine_api_version(self, response: Response) -> CatalogiAPIVersion:
@@ -190,17 +214,24 @@ class CatalogiClient(LoggingMixin, NLXClient):
 
         If no match is found, ``None`` is returned.
         """
+        cache_key_combination = f"{self.base_url}|{domain}|{rsin}"
+        cache_key = f"ZGW|catalogi|find_catalogus|{cache_key_combination}"
+        if (catalogus := self.cache.get(cache_key)) is not None:
+            return catalogus
+
         response = self.get("catalogussen", params={"domein": domain, "rsin": rsin})
         response.raise_for_status()
         data: PaginatedResponseData[Catalogus] = response.json()
-
         if (num_results := len(data["results"])) > 1:
             raise StandardViolation(
                 "Combination of domain + rsin must be unique according to the standard."
             )
         if num_results == 0:
             return None
-        return data["results"][0]
+
+        catalogus = data["results"][0]
+        self.cache.set(cache_key, catalogus, CATALOGI_LOOKUP_CACHE_TIMEOUT)
+        return catalogus
 
     def get_all_case_types(self, *, catalogus: str) -> Iterator[CaseType]:
         params: CaseTypeListParams = {
@@ -231,6 +262,13 @@ class CatalogiClient(LoggingMixin, NLXClient):
         if self.allow_drafts:
             params["status"] = "alles"
 
+        cache_key_combination = (
+            f"{self.base_url}|{'|'.join(str(param) for param in params.values())}"
+        )
+        cache_key = f"ZGW|catalogi|find_case_types|{cache_key_combination}"
+        if (case_types := self.cache.get(cache_key)) is not None:
+            return case_types
+
         response = self.get("zaaktypen", params=params)  # type: ignore
         response.raise_for_status()
 
@@ -260,6 +298,7 @@ class CatalogiClient(LoggingMixin, NLXClient):
                 f"'{identification}'. Version (date) ranges may not overlap."
             )
 
+        self.cache.set(cache_key, all_versions, CATALOGI_CASE_TYPE_LOOKUP_CACHE_TIMEOUT)
         return all_versions
 
     def get_all_informatieobjecttypen(
@@ -306,6 +345,13 @@ class CatalogiClient(LoggingMixin, NLXClient):
         if self.allow_drafts:
             params["status"] = "alles"
 
+        cache_key_combination = (
+            f"{self.base_url}|{'|'.join(str(param) for param in params.values())}"
+        )
+        cache_key = f"ZGW|catalogi|find_informatieobjecttypen|{cache_key_combination}"
+        if (existing_results := self.cache.get(cache_key)) is not None:
+            return existing_results
+
         response = self.get("informatieobjecttypen", params=params)  # type: ignore
 
         response.raise_for_status()
@@ -348,6 +394,7 @@ class CatalogiClient(LoggingMixin, NLXClient):
                 if version["url"] in case_type_document_types
             ]
 
+        self.cache.set(cache_key, all_versions, CATALOGI_IOT_LOOKUP_CACHE_TIMEOUT)
         return all_versions
 
     def list_statustypen(self, zaaktype: str) -> list[dict]:

--- a/src/openforms/contrib/zgw/tests/test_catalogi_client.py
+++ b/src/openforms/contrib/zgw/tests/test_catalogi_client.py
@@ -11,10 +11,20 @@ These tests make use of requests-mock rather than VCR for two reasons:
 
 from datetime import date
 
-from django.test import TestCase
+from django.conf import settings
+from django.core.cache import caches
+from django.test import TestCase, override_settings
 
 import requests_mock
 from furl import furl
+
+from openforms.contrib.zgw.clients.catalogi import (
+    CaseType,
+    Catalogus,
+    InformatieObjectType,
+)
+from openforms.utils.api_clients import PaginatedResponseData
+from openforms.utils.tests.cache import clear_caches
 
 from ..clients import CatalogiClient
 from ..exceptions import StandardViolation
@@ -384,3 +394,214 @@ class CatalogiClientTests(TestCase):
 
         all_results = list(results)
         self.assertEqual(len(all_results), 3)
+
+
+CACHES = settings.CACHES.copy()
+CACHES["catalogi_client"] = {"BACKEND": "openforms.utils.cache.RequestProxyCache"}
+
+
+@override_settings(CACHES=CACHES)
+@requests_mock.Mocker()
+class CatalogiClientCachingTests(TestCase):
+    def setUp(self) -> None:
+        super().setUp()
+
+        self.addCleanup(clear_caches)
+
+    def test_version_caching(self, mocker: requests_mock.Mocker):
+        client = CatalogiClient(base_url="https://dummy/catalogi/api/v1")
+        mocker.get(
+            "https://dummy/catalogi/api/v1/catalogussen?domein=VRSN",
+            headers={"API-Version": "1.2.3"},
+        )
+
+        api_version = client.api_version
+
+        self.assertEqual(api_version, (1, 2, 3))
+        self.assertEqual(len(mocker.request_history), 1)
+
+        cache = caches["catalogi_client"]
+        cache_key = "ZGW|catalogi|version|https://dummy/catalogi/api/v1"
+        self.assertEqual(cache.get(cache_key), (1, 2, 3))
+
+        # Do another request to a random endpoint, not expecting this to increase the
+        # mocker's request history but using the cached value instead.
+        second_version = client.api_version
+
+        self.assertEqual(second_version, api_version)
+        self.assertEqual(len(mocker.request_history), 1)
+
+    def test_catalogi_caching(self, mocker: requests_mock.Mocker):
+        client = CatalogiClient(base_url="https://dummy/catalogi/api/v1")
+
+        expected_catalogus: Catalogus = {
+            "url": "https://dummy/catalogi/api/v1/catalogussen/7575ec62-a5ed-421f-bfc7-f8837066dd10",
+            "domein": "PARTN",
+            "rsin": "000000000",
+            "naam": "Test partners",
+            "informatieobjecttypen": [
+                "https://dummy/catalogi/api/v1/informatieobjecttypen/d2ea38b1-5215-402f-a3f5-2977d112bf72"
+            ],
+            "zaaktypen": [
+                "https://dummy/catalogi/api/v1/zaaktypen/77543c85-e5cd-4b3e-b7a5-27165e1334b1"
+            ],
+        }
+        catalogi_response_data: PaginatedResponseData = {
+            "count": 1,
+            "results": [expected_catalogus],
+            "previous": "https://dummy/catalogi/api/v1/catalogussen?page=-1",
+            "next": "https://dummy/catalogi/api/v1/catalogussen?page=2",
+        }
+        mocker.get(
+            "https://dummy/catalogi/api/v1/catalogussen",
+            json=catalogi_response_data,
+            headers={"API-Version": "1.2.3"},
+        )
+
+        with client:
+            result = client.find_catalogus(domain="PARTN", rsin="000000000")
+
+        self.assertEqual(result, expected_catalogus)
+        self.assertEqual(len(mocker.request_history), 1)
+
+        cache = caches["catalogi_client"]
+        cache_key = (
+            "ZGW|catalogi|find_catalogus|https://dummy/catalogi/api/v1|PARTN|000000000"
+        )
+        self.assertEqual(cache.get(cache_key), result)
+
+        # Call the find_catalogus method again, not expecting this to increase the
+        # mocker's request history but using the cached value instead.
+        with client:
+            client.find_catalogus(domain="PARTN", rsin="000000000")
+
+        self.assertEqual(len(mocker.request_history), 1)
+
+    def test_case_type_caching(self, mocker: requests_mock.Mocker):
+        client = CatalogiClient(base_url="https://dummy/catalogi/api/v1")
+
+        catalogus = "https://dummy/catalogi/api/v1/catalogussen/7575ec62-a5ed-421f-bfc7-f8837066dd10"
+        case_types: list[CaseType] = [
+            {
+                "url": "https://dummy/catalogi/api/v1/zaaktypen/77543c85-e5cd-4b3e-b7a5-27165e1334b1",
+                "catalogus": catalogus,
+                "identificatie": "ZAAKTYPE-2020-0000000001",
+                "omschrijving": "Case type for partners component",
+                "beginGeldigheid": "2020-06-20",
+                "eindeGeldigheid": None,
+                "productenOfDiensten": [],
+                "informatieobjecttypen": [
+                    "https://dummy/catalogi/api/v1/informatieobjecttypen/d2ea38b1-5215-402f-a3f5-2977d112bf72"
+                ],
+                "roltypen": [
+                    "https://dummy/catalogi/api/v1/roltypen/706464f3-cd55-425c-92ac-76be4ac8a61b",
+                    "https://dummy/catalogi/api/v1/roltypen/eedd2d97-19b1-4d66-821b-307f3f44363e",
+                ],
+            }
+        ]
+        case_type_response_data: PaginatedResponseData[CaseType] = {
+            "count": 1,
+            "results": case_types,
+            "previous": "",
+            "next": "",
+        }
+
+        mocker.get(
+            f"https://dummy/catalogi/api/v1/zaaktypen?catalogus={catalogus}",
+            json=case_type_response_data,
+            headers={"API-Version": "1.2.3"},
+        )
+        # the client will do an API version check to determine if filtering
+        # on the `valid_on` query parameter is supported
+        mocker.get(
+            "https://dummy/catalogi/api/v1/catalogussen?domein=VRSN",
+            json={},
+            headers={"API-Version": "1.2.3"},
+        )
+
+        with client:
+            results = client.find_case_types(
+                catalogus=catalogus,
+                identification="",
+            )
+            assert results is not None
+
+        self.assertEqual(results, case_types)
+        self.assertEqual(len(mocker.request_history), 2)
+
+        cache = caches["catalogi_client"]
+        cache_key = (
+            f"ZGW|catalogi|find_case_types|https://dummy/catalogi/api/v1|{catalogus}|"
+        )
+        self.assertEqual(cache.get(cache_key), case_types)
+
+        # Call the find_case_types method again, not expecting this to increase the
+        # mocker's request history but using the cached value instead.
+        with client:
+            results = client.find_case_types(
+                catalogus=catalogus,
+                identification="",
+            )
+            assert results is not None
+
+        self.assertEqual(len(mocker.request_history), 2)
+
+    def test_informatieobjecttype_caching(self, mocker: requests_mock.Mocker):
+        client = CatalogiClient(base_url="https://dummy/catalogi/api/v1")
+
+        catalogus = "https://dummy/catalogi/api/v1/catalogussen/7575ec62-a5ed-421f-bfc7-f8837066dd10"
+        informatieobjecttypen: list[InformatieObjectType] = [
+            {
+                "url": "http://localhost:8003/catalogi/api/v1/informatieobjecttypen/d2ea38b1-5215-402f-a3f5-2977d112bf72",
+                "catalogus": "http://localhost:8003/catalogi/api/v1/catalogussen/7575ec62-a5ed-421f-bfc7-f8837066dd10",
+                "omschrijving": "Partners PDF Informatieobjecttype",
+                "beginGeldigheid": "2020-06-20",
+                "eindeGeldigheid": None,
+            }
+        ]
+        informatieobjecttypen_response_data: PaginatedResponseData[
+            InformatieObjectType
+        ] = {
+            "count": 1,
+            "results": informatieobjecttypen,
+            "previous": "",
+            "next": "",
+        }
+
+        mocker.get(
+            f"https://dummy/catalogi/api/v1/informatieobjecttypen?catalogus={catalogus}&omschrijving=",
+            json=informatieobjecttypen_response_data,
+            headers={"API-Version": "1.2.3"},
+        )
+        # the client will do an API version check to determine if filtering
+        # on the `valid_on` query parameter is supported
+        mocker.get(
+            "https://dummy/catalogi/api/v1/catalogussen?domein=VRSN",
+            json={},
+            headers={"API-Version": "1.2.3"},
+        )
+
+        with client:
+            results = client.find_informatieobjecttypen(
+                catalogus=catalogus,
+                description="",
+            )
+            assert results is not None
+
+        self.assertEqual(results, informatieobjecttypen)
+        self.assertEqual(len(mocker.request_history), 2)
+
+        cache = caches["catalogi_client"]
+        cache_key = f"ZGW|catalogi|find_informatieobjecttypen|https://dummy/catalogi/api/v1|{catalogus}|"
+        self.assertEqual(cache.get(cache_key), informatieobjecttypen)
+
+        # Call the find_case_types method again, not expecting this to increase the
+        # mocker's request history but using the cached value instead.
+        with client:
+            results = client.find_informatieobjecttypen(
+                catalogus=catalogus,
+                description="",
+            )
+            assert results is not None
+
+        self.assertEqual(len(mocker.request_history), 2)


### PR DESCRIPTION
Closes #6515 

**Changes**

These changes will decrease the amount of (external) recurring requests that can be done when validating ZGW form registration backends through caching. Note that the initial requests can still be slow as the cache needs to be populated.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes

[skip: e2e]