### PR TITLE
Fix variable-from-component sync

### DIFF
--- a/src/openforms/js/components/admin/form_design/form-creation-form.js
+++ b/src/openforms/js/components/admin/form_design/form-creation-form.js
@@ -515,7 +515,7 @@ function reducer(draft, action) {
       }
 
       // Check if the formVariables need updating
-      updateFormVariables(
+      draft.formVariables = updateFormVariables(
         formDefinitionReference,
         builderMutationEvent.type,
         {

--- a/src/openforms/js/components/admin/form_design/variables/utils.js
+++ b/src/openforms/js/components/admin/form_design/variables/utils.js
@@ -29,7 +29,7 @@ const isInEditGrid = (targetComponent, configuration) => {
 
     // Check if any of the components in the editgrid has the same key as the component
     // we're looking for.
-    const flatChildren = flattenComponents([component]);
+    const flatChildren = flattenComponents(component.components);
     if (flatChildren[targetComponent.key] !== undefined) return true;
   }
 
@@ -115,15 +115,13 @@ const updateFormVariables = (
   formDefinition,
   mutationType,
   {component, originalComponent = null},
-  currentFormVariables,
+  formVariables,
   stepConfiguration
 ) => {
   // Not all components are associated with variables
   if (shouldNotUpdateVariables(component, originalComponent, mutationType, stepConfiguration)) {
-    return currentFormVariables;
+    return formVariables;
   }
-
-  let updatedFormVariables = _.cloneDeep(currentFormVariables);
 
   // This is a 'create' or a 'paste' event
   if (mutationType === 'created') {
@@ -133,34 +131,24 @@ const updateFormVariables = (
       for (const {component} of iterComponents([component])) {
         // Layout comopnents don't need variables - they don't hold data/values
         if (isLayoutComponent(component)) continue;
-        updatedFormVariables.push(makeNewVariableFromComponent(component, formDefinition));
+        formVariables.push(makeNewVariableFromComponent(component, formDefinition));
       }
     } else {
-      // When a new component is created, the callback is called multiple times by Formio. So we need to avoid adding
-      // the variable more than once.
-      const existingIds = updatedFormVariables
-        .filter(variable => !!variable._id)
-        .map(variable => variable._id);
-      if (existingIds.includes(component.id)) return updatedFormVariables;
-
-      updatedFormVariables.push(makeNewVariableFromComponent(component, formDefinition));
+      formVariables.push(makeNewVariableFromComponent(component, formDefinition));
     }
   } else if (mutationType === 'updated') {
     let indicesVariablesWithoutIds = [];
     let variableUpdated = false;
 
-    for (let variableIndex = 0; variableIndex < updatedFormVariables.length; variableIndex++) {
-      const variable = updatedFormVariables[variableIndex];
+    for (let variableIndex = 0; variableIndex < formVariables.length; variableIndex++) {
+      const variable = formVariables[variableIndex];
       if (!variable._id) {
         indicesVariablesWithoutIds.push(variableIndex);
         continue;
       }
 
       if (variable._id === originalComponent.id) {
-        updatedFormVariables[variableIndex] = makeNewVariableFromComponent(
-          component,
-          formDefinition
-        );
+        formVariables[variableIndex] = makeNewVariableFromComponent(component, formDefinition);
         variableUpdated = true;
         break;
       }
@@ -169,11 +157,11 @@ const updateFormVariables = (
     if (!variableUpdated) {
       // Variables that don't have an _id have been loaded from the backend (which means they can't have duplicate keys)
       for (const index of indicesVariablesWithoutIds) {
-        const variable = updatedFormVariables[index];
+        const variable = formVariables[index];
         // Case 1: the component key has changed (possibly among other attributes)
         // Case 2: other attributes (not the key) of the component have changed.
         if (variable.key === originalComponent.key) {
-          updatedFormVariables[index] = makeNewVariableFromComponent(component, formDefinition);
+          formVariables[index] = makeNewVariableFromComponent(component, formDefinition);
           break;
         }
       }
@@ -190,7 +178,7 @@ const updateFormVariables = (
       }
     }
 
-    updatedFormVariables = updatedFormVariables.filter(variable => {
+    formVariables = formVariables.filter(variable => {
       const matchKeyToRemove = keysToRemove.includes(variable.key);
 
       // In the case that there are duplicate keys, we need to figure out which of the variables with duplicate keys
@@ -199,7 +187,7 @@ const updateFormVariables = (
     });
   }
 
-  return updatedFormVariables;
+  return formVariables;
 };
 
 const checkForDuplicateKeys = (formVariables, staticVariables, validationErrors) => {


### PR DESCRIPTION
Components in form steps must be backed by a form variable - this apparently broken with the new form builder integration. The new desired form variables state is computed and assigned in the state reducer for the form.

Additionally, on loading of the form steps and processing the configuration into form variables, this didn't work for edit grids because the edit grid component itself was incorrectly marked as being "inside an edit grid". This is now also patched by only considering the edit grid children during processing.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
