### PR TITLE
Let form preview labels take up 100% of the inline size

### DIFF
--- a/src/openforms/scss/components/builder/_builder.scss
+++ b/src/openforms/scss/components/builder/_builder.scss
@@ -58,6 +58,7 @@ body:has(.offb-modal) {
     text-overflow: ellipsis;
     overflow: hidden;
     white-space: nowrap;
+    inline-size: 100%;
     max-inline-size: 100%;
   }
 }


### PR DESCRIPTION
Closes #6550

**Changes**

Don't cut of labels at 160px (Django admin styles).

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
