### PR TITLE
:arrow_up: Update to renderer 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@fortawesome/fontawesome-free": "^6.7.2",
         "@open-formulieren/design-tokens": "^1.0.0",
         "@open-formulieren/formio-builder": "^1.3.0",
-        "@open-formulieren/formio-renderer": "^2.0.0",
+        "@open-formulieren/formio-renderer": "^2.0.1",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
         "@tinymce/tinymce-react": "^4.3.2",
         "@trivago/prettier-plugin-sort-imports": "^4.0.0",
@@ -5337,9 +5337,9 @@
       }
     },
     "node_modules/@open-formulieren/formio-renderer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-renderer/-/formio-renderer-2.0.0.tgz",
-      "integrity": "sha512-wODmzQWYPdAg8bzdmE1zb5a7KQZQ4eiPsTsMKzCfLOWPwBqTenh8ZpyDH9cPWcbQEimHYRYadz2qMICrpuVwXQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-renderer/-/formio-renderer-2.0.1.tgz",
+      "integrity": "sha512-257pW4kEaPCG9k6afeHZ//AI+FKzJqczC+aV8D/sFZDz/W4nXPxwvDfus93BVPFwJeitbK+/I19IXWOvg2c+Wg==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@babel/runtime": "^7.29.2",
@@ -26705,9 +26705,9 @@
       }
     },
     "@open-formulieren/formio-renderer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-renderer/-/formio-renderer-2.0.0.tgz",
-      "integrity": "sha512-wODmzQWYPdAg8bzdmE1zb5a7KQZQ4eiPsTsMKzCfLOWPwBqTenh8ZpyDH9cPWcbQEimHYRYadz2qMICrpuVwXQ==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-renderer/-/formio-renderer-2.0.1.tgz",
+      "integrity": "sha512-257pW4kEaPCG9k6afeHZ//AI+FKzJqczC+aV8D/sFZDz/W4nXPxwvDfus93BVPFwJeitbK+/I19IXWOvg2c+Wg==",
       "requires": {
         "@babel/runtime": "^7.29.2",
         "@open-formulieren/types": "^1.4.2",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@fortawesome/fontawesome-free": "^6.7.2",
     "@open-formulieren/design-tokens": "^1.0.0",
     "@open-formulieren/formio-builder": "^1.3.0",
-    "@open-formulieren/formio-renderer": "^2.0.0",
+    "@open-formulieren/formio-renderer": "^2.0.1",
     "@open-formulieren/monaco-json-editor": "^0.2.0",
     "@tinymce/tinymce-react": "^4.3.2",
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",


### PR DESCRIPTION
The patches in 2.0.1 have zero effect on the backend, but it's probably best to keep everything on the latest for simplicity :)