### PR TITLE
Fix values only being set after interaction

### DIFF
--- a/src/openforms/submissions/api/permissions.py
+++ b/src/openforms/submissions/api/permissions.py
@@ -131,6 +131,7 @@ class CanNavigateBetweenSubmissionStepsPermission(permissions.BasePermission):
         # check, as we don't take unsaved/dirty data into account here.
         obj.form_step.form_definition.configuration = configuration_copy
         del obj.form_step.form_definition.configuration_wrapper
+        del submission.variables_state
 
         if not incomplete_steps:
             return True

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -535,6 +535,11 @@ class Submission(models.Model):
     def variables_state(self) -> SubmissionValueVariablesState:
         return self.load_submission_value_variables_state()
 
+    @variables_state.deleter
+    def variables_state(self) -> None:
+        if hasattr(self, "_variables_state"):
+            del self._variables_state
+
     @transaction.atomic()
     def remove_sensitive_data(self):
         from .submission_files import SubmissionFileAttachment

--- a/src/openforms/submissions/tests/form_logic/test_endpoint.py
+++ b/src/openforms/submissions/tests/form_logic/test_endpoint.py
@@ -10,6 +10,7 @@ from zgw_consumers.test.factories import ServiceFactory
 
 from openforms.accounts.tests.factories import SuperUserFactory
 from openforms.formio.tests.assertions import FormioMixin
+from openforms.forms.constants import LogicActionTypes
 from openforms.forms.tests.factories import (
     FormFactory,
     FormLogicFactory,
@@ -1340,7 +1341,7 @@ class CheckLogicEndpointTests(
         "as_admin",
         [param(True, id="admin_true"), param(False, id="admin_false")],
     )
-    @tag("gh-6468")
+    @tag("gh-6468", "gh-6507")
     def test_logic_evaluation_as_admin_same_as_not_logged_in(self, as_admin: bool):
         # it's important that this happens on the second (or later) step, as the
         # permission check will never evaluate form logic if you're on the first step
@@ -1379,6 +1380,11 @@ class CheckLogicEndpointTests(
                         "label": "Textfield with radio value: {{ radio }}",
                         "hidden": False,
                     },
+                    {
+                        "type": "textfield",
+                        "key": "valueSetByLogic",
+                        "label": "Value set by logic",
+                    },
                 ]
             },
         )
@@ -1394,12 +1400,27 @@ class CheckLogicEndpointTests(
             actions=[
                 {
                     "action": {
-                        "type": "property",
+                        "type": LogicActionTypes.property,
                         "property": {"type": "bool", "value": "hidden"},
                         "state": True,
                     },
                     "component": "textfield",
                 },
+            ],
+        )
+        # always set the value of the field, this manifests in the ``step.data``
+        # output of API endpoints as it's not yet persisted in the database
+        FormLogicFactory.create(
+            form=form,
+            json_logic_trigger=True,
+            actions=[
+                {
+                    "action": {
+                        "type": LogicActionTypes.variable,
+                        "value": "kaas",
+                    },
+                    "variable": "valueSetByLogic",
+                }
             ],
         )
         form.apply_logic_analysis()
@@ -1449,3 +1470,15 @@ class CheckLogicEndpointTests(
                     "hidden": False,
                 },
             )
+
+        with self.subTest("value assignment"):
+            endpoint = reverse(
+                "api:submission-steps-detail",
+                kwargs={"submission_uuid": submission.uuid, "step_uuid": step.uuid},
+            )
+
+            response = self.client.get(endpoint)
+
+            self.assertEqual(response.status_code, status.HTTP_200_OK)
+            step_data = response.json()["data"]
+            self.assertEqual(step_data, {"valueSetByLogic": "kaas"})


### PR DESCRIPTION
Closes #6507

**Changes**

The described problem is merely a side effect of the underlying root cause where some stale cached datastructures resulted in a data updated not being returned in the logic outcome of the submission step detail endpoint, leading to not-initially populated form fields. This didn't happen for admin users, because the logic check is skipped there in the permission backend.

It works in the interaction later on because it fires a check logic call with explicit `field: ""` data in the input, which *does* lead to a data update eventually, but it requires an interaction.

The regression test passes on main as-is, see 778d470969efe1b7c7dfedf181832fc2b3c41b22

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
