### PR TITLE
[#6236] Fix flaky test in Objects API prefill

### DIFF
--- a/src/openforms/prefill/contrib/objects_api/tests/test_prefill.py
+++ b/src/openforms/prefill/contrib/objects_api/tests/test_prefill.py
@@ -196,14 +196,15 @@ class ObjectsAPIPrefillPluginTests(OFVCRMixin, SubmissionsMixin, APITestCase):
         data = state.get_data(include_unsaved=True)
 
         self.assertEqual(TimelineLogProxy.objects.count(), 2)
-        ownership_check_log, prefill_log = TimelineLogProxy.objects.order_by("pk")
 
-        self.assertEqual(
-            ownership_check_log.extra_data["log_event"],
-            "object_ownership_check_success",
+        ownership_check_log = TimelineLogProxy.objects.get(
+            extra_data__log_event="object_ownership_check_success"
         )
+        prefill_log = TimelineLogProxy.objects.get(
+            extra_data__log_event="prefill_retrieve_empty"
+        )
+
         self.assertEqual(ownership_check_log.extra_data["plugin_id"], "objects_api")
-        self.assertEqual(prefill_log.extra_data["log_event"], "prefill_retrieve_empty")
         self.assertEqual(prefill_log.extra_data["plugin_id"], "objects_api")
         self.assertEqual(data["lastName"], "")
         self.assertEqual(data["age"], "")

--- a/src/openforms/prefill/contrib/objects_api/tests/vcr_cassettes/test_prefill/ObjectsAPIPrefillPluginTests/test_prefill_values_when_reference_returns_empty_values.yaml
+++ b/src/openforms/prefill/contrib/objects_api/tests/vcr_cassettes/test_prefill/ObjectsAPIPrefillPluginTests/test_prefill_values_when_reference_returns_empty_values.yaml
@@ -1,7 +1,7 @@
 interactions:
 - request:
     body: '{"type": "http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48",
-      "record": {"typeVersion": 3, "data": {"bsn": "111222333"}, "startAt": "2026-08-17"}}'
+      "record": {"typeVersion": 3, "data": {"bsn": "111222333"}, "startAt": "2026-08-25"}}'
     headers:
       Accept:
       - '*/*'
@@ -21,7 +21,7 @@ interactions:
     uri: http://localhost:8001/api/v2/objects
   response:
     body:
-      string: '{"url":"http://localhost:8001/api/v2/objects/e78d3ff2-8326-4386-9a49-21748a62d296","uuid":"e78d3ff2-8326-4386-9a49-21748a62d296","type":"http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"bsn":"111222333"},"geometry":null,"references":[],"startAt":"2026-08-17","endAt":null,"registrationAt":"2026-08-17","correctionFor":null,"correctedBy":null}}'
+      string: '{"url":"http://localhost:8001/api/v2/objects/36012b14-e408-47b8-83df-2ad4242c92a8","uuid":"36012b14-e408-47b8-83df-2ad4242c92a8","type":"http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"bsn":"111222333"},"geometry":null,"references":[],"startAt":"2026-08-25","endAt":null,"registrationAt":"2026-08-25","correctionFor":null,"correctedBy":null}}'
     headers:
       API-version:
       - 2.7.0
@@ -32,17 +32,17 @@ interactions:
       Content-Length:
       - '418'
       Content-Security-Policy:
-      - 'style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src ''self''
-        fonts.gstatic.com; object-src ''none''; default-src ''self''; base-uri ''self'';
-        img-src ''self'' data: cdn.redoc.ly; frame-ancestors ''none''; frame-src ''self'';
-        script-src ''self'' ''unsafe-inline''; form-action ''self''; worker-src ''self''
+      - 'style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; script-src ''self''
+        ''unsafe-inline''; frame-ancestors ''none''; img-src ''self'' data: cdn.redoc.ly;
+        font-src ''self'' fonts.gstatic.com; form-action ''self''; frame-src ''self'';
+        base-uri ''self''; default-src ''self''; object-src ''none''; worker-src ''self''
         blob:'
       Content-Type:
       - application/json
       Cross-Origin-Opener-Policy:
       - same-origin
       Location:
-      - http://localhost:8001/api/v2/objects/e78d3ff2-8326-4386-9a49-21748a62d296
+      - http://localhost:8001/api/v2/objects/36012b14-e408-47b8-83df-2ad4242c92a8
       Referrer-Policy:
       - same-origin
       Vary:
@@ -68,10 +68,10 @@ interactions:
       User-Agent:
       - python-requests/2.33.0
     method: GET
-    uri: http://localhost:8001/api/v2/objects/e78d3ff2-8326-4386-9a49-21748a62d296
+    uri: http://localhost:8001/api/v2/objects/36012b14-e408-47b8-83df-2ad4242c92a8
   response:
     body:
-      string: '{"url":"http://localhost:8001/api/v2/objects/e78d3ff2-8326-4386-9a49-21748a62d296","uuid":"e78d3ff2-8326-4386-9a49-21748a62d296","type":"http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"bsn":"111222333"},"geometry":null,"references":[],"startAt":"2026-08-17","endAt":null,"registrationAt":"2026-08-17","correctionFor":null,"correctedBy":null}}'
+      string: '{"url":"http://localhost:8001/api/v2/objects/36012b14-e408-47b8-83df-2ad4242c92a8","uuid":"36012b14-e408-47b8-83df-2ad4242c92a8","type":"http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"bsn":"111222333"},"geometry":null,"references":[],"startAt":"2026-08-25","endAt":null,"registrationAt":"2026-08-25","correctionFor":null,"correctedBy":null}}'
     headers:
       API-version:
       - 2.7.0
@@ -82,10 +82,10 @@ interactions:
       Content-Length:
       - '418'
       Content-Security-Policy:
-      - 'style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src ''self''
-        fonts.gstatic.com; object-src ''none''; default-src ''self''; base-uri ''self'';
-        img-src ''self'' data: cdn.redoc.ly; frame-ancestors ''none''; frame-src ''self'';
-        script-src ''self'' ''unsafe-inline''; form-action ''self''; worker-src ''self''
+      - 'style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; script-src ''self''
+        ''unsafe-inline''; frame-ancestors ''none''; img-src ''self'' data: cdn.redoc.ly;
+        font-src ''self'' fonts.gstatic.com; form-action ''self''; frame-src ''self'';
+        base-uri ''self''; default-src ''self''; object-src ''none''; worker-src ''self''
         blob:'
       Content-Type:
       - application/json
@@ -116,10 +116,10 @@ interactions:
       User-Agent:
       - python-requests/2.33.0
     method: GET
-    uri: http://localhost:8001/api/v2/objects/e78d3ff2-8326-4386-9a49-21748a62d296
+    uri: http://localhost:8001/api/v2/objects/36012b14-e408-47b8-83df-2ad4242c92a8
   response:
     body:
-      string: '{"url":"http://localhost:8001/api/v2/objects/e78d3ff2-8326-4386-9a49-21748a62d296","uuid":"e78d3ff2-8326-4386-9a49-21748a62d296","type":"http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"bsn":"111222333"},"geometry":null,"references":[],"startAt":"2026-08-17","endAt":null,"registrationAt":"2026-08-17","correctionFor":null,"correctedBy":null}}'
+      string: '{"url":"http://localhost:8001/api/v2/objects/36012b14-e408-47b8-83df-2ad4242c92a8","uuid":"36012b14-e408-47b8-83df-2ad4242c92a8","type":"http://localhost:8001/api/v2/objecttypes/8e46e0a5-b1b4-449b-b9e9-fa3cea655f48","record":{"index":1,"typeVersion":3,"data":{"bsn":"111222333"},"geometry":null,"references":[],"startAt":"2026-08-25","endAt":null,"registrationAt":"2026-08-25","correctionFor":null,"correctedBy":null}}'
     headers:
       API-version:
       - 2.7.0
@@ -130,10 +130,10 @@ interactions:
       Content-Length:
       - '418'
       Content-Security-Policy:
-      - 'style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; font-src ''self''
-        fonts.gstatic.com; object-src ''none''; default-src ''self''; base-uri ''self'';
-        img-src ''self'' data: cdn.redoc.ly; frame-ancestors ''none''; frame-src ''self'';
-        script-src ''self'' ''unsafe-inline''; form-action ''self''; worker-src ''self''
+      - 'style-src ''self'' ''unsafe-inline'' fonts.googleapis.com; script-src ''self''
+        ''unsafe-inline''; frame-ancestors ''none''; img-src ''self'' data: cdn.redoc.ly;
+        font-src ''self'' fonts.gstatic.com; form-action ''self''; frame-src ''self'';
+        base-uri ''self''; default-src ''self''; object-src ''none''; worker-src ''self''
         blob:'
       Content-Type:
       - application/json


### PR DESCRIPTION
Closes #6236

**Changes**

This seems to be a problem regarding the order of saving the logs. The order should be first the log about the ownership and then about the prefill values. According to the code we first check the ownership and then we prefill the values (if there are any).

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
