### PR TITLE
Ensure global validate.required default configuration is not ignored

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@formatjs/cli": "^6.6.1",
         "@fortawesome/fontawesome-free": "^6.7.2",
         "@open-formulieren/design-tokens": "^1.0.0",
-        "@open-formulieren/formio-builder": "^1.3.0",
+        "@open-formulieren/formio-builder": "^1.4.0",
         "@open-formulieren/formio-renderer": "^2.0.1",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
         "@tinymce/tinymce-react": "^4.3.2",
@@ -5278,14 +5278,19 @@
       "license": "EUPL-1.2"
     },
     "node_modules/@open-formulieren/formio-builder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-1.3.0.tgz",
-      "integrity": "sha512-afTMwkuwflP1nCM+vkjZzBXL/c/68SqFgwcfnngmSlgzBBZkfJgGBifQo4J9gQhB73AYTmUF+tWt6tZM6YNMcw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-1.4.0.tgz",
+      "integrity": "sha512-4+QogOjgVE1E0Jb96lF3w7NEHf63ecnUgPuwDEvLK9gb2OTnnWtnOZP+FDq4oosFdGWa11Stgx70/P5fcfTJ8g==",
       "license": "EUPL-1.2",
       "dependencies": {
         "@ckeditor/ckeditor5-react": "^11.0.1",
+        "@dnd-kit/abstract": "^0.4.0",
+        "@dnd-kit/collision": "^0.4.0",
+        "@dnd-kit/dom": "^0.4.0",
+        "@dnd-kit/geometry": "^0.4.0",
         "@dnd-kit/helpers": "^0.4.0",
         "@dnd-kit/react": "^0.4.0",
+        "@dnd-kit/state": "^0.4.0",
         "@floating-ui/react": "^0.27.5",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
@@ -5304,7 +5309,7 @@
         "react-leaflet-draw": "^0.20.6",
         "react-modal": "^3.16.1",
         "react-select": "^5.8.0",
-        "react-signature-canvas": "^1.0.6",
+        "react-signature-canvas": "1.1.0-alpha.2",
         "react-use": "^17.4.0",
         "zod": "^3.25.76",
         "zod-formik-adapter": "^1.2.0"
@@ -5334,6 +5339,36 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/immer"
+      }
+    },
+    "node_modules/@open-formulieren/formio-builder/node_modules/react-signature-canvas": {
+      "version": "1.1.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/react-signature-canvas/-/react-signature-canvas-1.1.0-alpha.2.tgz",
+      "integrity": "sha512-tKUNk3Gmh04Ug4K8p5g8Is08BFUKvbXxi0PyetQ/f8OgCBzcx4vqNf9+OArY/TdNdfHtswXQNRwZD6tyELjkjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@babel/runtime": "^7.17.9",
+        "@types/signature_pad": "^2.3.0",
+        "signature_pad": "^2.3.2",
+        "trim-canvas": "^0.1.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/agilgur5"
+      },
+      "peerDependencies": {
+        "@types/prop-types": "^15.7.3",
+        "@types/react": "0.14 - 19",
+        "prop-types": "^15.5.8",
+        "react": "0.14 - 19",
+        "react-dom": "0.14 - 19"
+      },
+      "peerDependenciesMeta": {
+        "@types/prop-types": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@open-formulieren/formio-renderer": {
@@ -8558,6 +8593,12 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
       "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/signature_pad": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@types/signature_pad/-/signature_pad-2.3.6.tgz",
+      "integrity": "sha512-v3j92gCQJoxomHhd+yaG4Vsf8tRS/XbzWKqDv85UsqjMGy4zhokuwKe4b6vhbgncKkh+thF+gpz6+fypTtnFqQ==",
       "license": "MIT"
     },
     "node_modules/@types/stack-utils": {
@@ -26661,13 +26702,18 @@
       "integrity": "sha512-WiTuUbL2F/tpLzHdy3c8yLYMDVc1hw+ZpLFkbdHVg+6+gv1sC3UaYStXCF9O6IWIcHlF5gXnLMuJBnHZjFClnA=="
     },
     "@open-formulieren/formio-builder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-1.3.0.tgz",
-      "integrity": "sha512-afTMwkuwflP1nCM+vkjZzBXL/c/68SqFgwcfnngmSlgzBBZkfJgGBifQo4J9gQhB73AYTmUF+tWt6tZM6YNMcw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/formio-builder/-/formio-builder-1.4.0.tgz",
+      "integrity": "sha512-4+QogOjgVE1E0Jb96lF3w7NEHf63ecnUgPuwDEvLK9gb2OTnnWtnOZP+FDq4oosFdGWa11Stgx70/P5fcfTJ8g==",
       "requires": {
         "@ckeditor/ckeditor5-react": "^11.0.1",
+        "@dnd-kit/abstract": "^0.4.0",
+        "@dnd-kit/collision": "^0.4.0",
+        "@dnd-kit/dom": "^0.4.0",
+        "@dnd-kit/geometry": "^0.4.0",
         "@dnd-kit/helpers": "^0.4.0",
         "@dnd-kit/react": "^0.4.0",
+        "@dnd-kit/state": "^0.4.0",
         "@floating-ui/react": "^0.27.5",
         "@open-formulieren/leaflet-tools": "^1.0.0",
         "@open-formulieren/monaco-json-editor": "^0.2.0",
@@ -26686,7 +26732,7 @@
         "react-leaflet-draw": "^0.20.6",
         "react-modal": "^3.16.1",
         "react-select": "^5.8.0",
-        "react-signature-canvas": "^1.0.6",
+        "react-signature-canvas": "1.1.0-alpha.2",
         "react-use": "^17.4.0",
         "zod": "^3.25.76",
         "zod-formik-adapter": "^1.2.0"
@@ -26701,6 +26747,17 @@
           "version": "11.1.16",
           "resolved": "https://registry.npmjs.org/immer/-/immer-11.1.16.tgz",
           "integrity": "sha512-Xs7H9rBc+kti1J6RueUvbEBkmOz7jqj11XYgf+YMXAYzu8EeE7hwZ9poLXdVfVnGmJu7QAf41T7H2KuF6QoK6Q=="
+        },
+        "react-signature-canvas": {
+          "version": "1.1.0-alpha.2",
+          "resolved": "https://registry.npmjs.org/react-signature-canvas/-/react-signature-canvas-1.1.0-alpha.2.tgz",
+          "integrity": "sha512-tKUNk3Gmh04Ug4K8p5g8Is08BFUKvbXxi0PyetQ/f8OgCBzcx4vqNf9+OArY/TdNdfHtswXQNRwZD6tyELjkjQ==",
+          "requires": {
+            "@babel/runtime": "^7.17.9",
+            "@types/signature_pad": "^2.3.0",
+            "signature_pad": "^2.3.2",
+            "trim-canvas": "^0.1.0"
+          }
         }
       }
     },
@@ -28762,6 +28819,11 @@
       "resolved": "https://registry.npmjs.org/@types/semver/-/semver-7.8.0.tgz",
       "integrity": "sha512-1mAINjtQCXXeLkJ9ehXkwOcBpqtLxiVtKhpUf83DdRNdQKV0iXZpaHYqRr7nj+wvxuJzoAmAwXI+sCNMv1CzLQ==",
       "dev": true
+    },
+    "@types/signature_pad": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/@types/signature_pad/-/signature_pad-2.3.6.tgz",
+      "integrity": "sha512-v3j92gCQJoxomHhd+yaG4Vsf8tRS/XbzWKqDv85UsqjMGy4zhokuwKe4b6vhbgncKkh+thF+gpz6+fypTtnFqQ=="
     },
     "@types/stack-utils": {
       "version": "2.0.3",

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "@formatjs/cli": "^6.6.1",
     "@fortawesome/fontawesome-free": "^6.7.2",
     "@open-formulieren/design-tokens": "^1.0.0",
-    "@open-formulieren/formio-builder": "^1.3.0",
+    "@open-formulieren/formio-builder": "^1.4.0",
     "@open-formulieren/formio-renderer": "^2.0.1",
     "@open-formulieren/monaco-json-editor": "^0.2.0",
     "@tinymce/tinymce-react": "^4.3.2",

--- a/src/openforms/appointments/contrib/jcc_rest/admin.py
+++ b/src/openforms/appointments/contrib/jcc_rest/admin.py
@@ -10,3 +10,23 @@ from .models import JccRestConfig
 class JccRestConfigAdmin(SingletonModelAdmin):
     form = JccRestConfigForm
     change_form_template = "admin/jcc_rest/jccrestconfig/change_form.html"
+
+    def render_change_form(
+        self, request, context, add=False, change=False, form_url="", obj=None
+    ):
+        # Can't use `openforms.forms.admin.FormioConfigMixin` because the appointment
+        # configuration has different semantics - `required_default` is controlled by
+        # the upstream API, while file uploads/map components are irrelevant.
+        context.update(
+            {
+                "required_default": False,
+                "rich_text_colors": [],
+                "map_tile_layers": [],
+                "wms_layers": [],
+                "upload_filetypes": [],
+                "feature_flags": {},
+                "confidentiality_levels": [],
+                "component_empty_values": [],
+            }
+        )
+        return super().render_change_form(request, context, add, change, form_url, obj)

--- a/src/openforms/js/components/admin/form_design/FormBuilder.js
+++ b/src/openforms/js/components/admin/form_design/FormBuilder.js
@@ -27,6 +27,7 @@ const RICH_TEXT_COLORS = jsonScriptToVar('config-RICH_TEXT_COLORS', {default: []
 const MAP_TILE_LAYERS = jsonScriptToVar('config-MAP_TILE_LAYERS', {default: []});
 const MAP_WMS_LAYERS = jsonScriptToVar('config-MAP_WMS_LAYERS', {default: []});
 const MAP_WFS_LAYERS = [];
+const VALIDATE_REQUIRED_DEFAULT = jsonScriptToVar('config-REQUIRED_DEFAULT', {default: false});
 
 const getMapOverlayTileLayers = async () => {
   const layers = [
@@ -123,6 +124,7 @@ const FormBuilder = ({
         }
       }}
       // Context binding
+      validateRequiredDefault={VALIDATE_REQUIRED_DEFAULT}
       formType={formType}
       uniquifyKey={key => getUniqueKey(toCamelCase(key), usedComponentKeys)}
       supportedLanguageCodes={LANGUAGES}


### PR DESCRIPTION
Closes #6570 - depends on https://github.com/open-formulieren/formio-builder/pull/325 being merged and released

**Changes**

* Forward global configuration option as `FormioBuilder` prop
* Fix missing/empty context in appointmentconfig, which would break the JSON boolean parsing for this parameter

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
