### PR TITLE
DH-899 - use the prerequest for service fetch configuration.

### DIFF
--- a/src/openforms/submissions/logic/actions.py
+++ b/src/openforms/submissions/logic/actions.py
@@ -646,7 +646,7 @@ class ServiceFetchAction(ActionOperation):
     ) -> DataMapping:
         var = self.rule.form.formvariable_set.get(key=self.variable)
         with log_errors({}, self.rule):  # TODO proper error handling
-            result = perform_service_fetch(var, context, str(submission.uuid))
+            result = perform_service_fetch(var, context, submission)
             if result is None:
                 return {}
 

--- a/src/openforms/submissions/logic/service_fetching.py
+++ b/src/openforms/submissions/logic/service_fetching.py
@@ -8,9 +8,13 @@ import jq
 import structlog
 from json_logic import UNDEFINED_VALUE, jsonLogic
 from zgw_consumers.client import build_client
+from zgw_consumers.constants import AuthTypes
 
+from openforms.contrib.client import LoggingClient
 from openforms.formio.service import FormioData
 from openforms.forms.models import FormVariable
+from openforms.pre_requests.clients import PreRequestClientContext, PreRequestMixin
+from openforms.submissions.models import Submission
 from openforms.typing import JSONObject, JSONValue
 from openforms.variables.models import DataMappingTypes, ServiceFetchConfiguration
 
@@ -27,8 +31,21 @@ class FetchResult:
     # response_headers: JSONObject
 
 
+class ServiceFetchClient(PreRequestMixin, LoggingClient):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # overwrite binding contextvars, as the "client=self" in the loggingMixin
+        # causes errors in this case with submissions
+        structlog.contextvars.bind_contextvars(
+            base_url=self.base_url,
+            client=type(self).__qualname__,
+        )
+
+
 def perform_service_fetch(
-    var: FormVariable, context: FormioData, submission_uuid: str = ""
+    var: FormVariable,
+    context: FormioData,
+    submission: Submission | None = None,
 ) -> FetchResult | None:
     """Fetch a value from a http-service, perform a transformation on it and
     return the result.
@@ -43,7 +60,8 @@ def perform_service_fetch(
     The value returned by the request is cached using the submission UUID and the
     arguments to the request (hashed to make a cache key).
     """
-    log = logger.bind(variable=var.key, submission_uuid=str(submission_uuid))
+    submission_uuid = str(submission.uuid) if submission else None
+    log = logger.bind(variable=var.key, submission_uuid=submission_uuid)
     log.info("perform_service_fetch_started")
 
     if not var.service_fetch_configuration:
@@ -51,10 +69,23 @@ def perform_service_fetch(
             f"Can't perform service fetch on {var}. "
             "It needs a service_fetch_configuration."
         )
-    fetch_config: ServiceFetchConfiguration = var.service_fetch_configuration
 
-    client = build_client(fetch_config.service)
+    fetch_config: ServiceFetchConfiguration = var.service_fetch_configuration
     request_args = fetch_config.request_arguments(context)
+
+    context = (
+        PreRequestClientContext(submission=submission)
+        if submission is not None
+        else None
+    )
+
+    if fetch_config.service.auth_type == AuthTypes.no_auth:
+        client = build_client(
+            fetch_config.service, client_factory=ServiceFetchClient, context=context
+        )
+    else:
+        # default client factory, so we do not overwrite the configured auth
+        client = build_client(fetch_config.service)
 
     def _do_fetch():
         log.info("perform_service_fetch_http_call_started")

--- a/src/openforms/submissions/tests/form_logic/test_fetching_form_variable_values_from_services.py
+++ b/src/openforms/submissions/tests/form_logic/test_fetching_form_variable_values_from_services.py
@@ -1,9 +1,10 @@
 from typing import Any
 from unittest import skip
+from unittest.mock import MagicMock, patch
 from urllib.parse import unquote
 
 from django.core.exceptions import SuspiciousOperation
-from django.test import SimpleTestCase, tag
+from django.test import SimpleTestCase, TestCase, tag
 
 import requests_mock
 from furl import furl
@@ -11,8 +12,11 @@ from hypothesis import assume, example, given, strategies as st
 from zgw_consumers.constants import APITypes, AuthTypes
 from zgw_consumers.test.factories import ServiceFactory
 
+from openforms.authentication.constants import AuthAttribute
 from openforms.formio.service import FormioData
 from openforms.forms.tests.factories import FormVariableFactory
+from openforms.pre_requests.base import PreRequestHookBase
+from openforms.pre_requests.registry import Registry
 from openforms.utils.tests.nlx import DisableNLXRewritingMixin
 from openforms.variables.constants import DataMappingTypes
 from openforms.variables.models import _convert_to_string
@@ -20,6 +24,7 @@ from openforms.variables.tests.factories import ServiceFetchConfigurationFactory
 from openforms.variables.validators import HeaderValidator, ValidationError
 
 from ...logic.service_fetching import perform_service_fetch
+from ..factories import SubmissionFactory
 
 DEFAULT_REQUEST_HEADERS = {
     "Accept",
@@ -431,3 +436,133 @@ class ServiceFetchConfigVariableBindingTests(DisableNLXRewritingMixin, SimpleTes
 
         with self.assertRaises(ValueError):
             perform_service_fetch(var, FormioData())
+
+
+class ServiceFetchConfigPreRequestTests(DisableNLXRewritingMixin, TestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.service = ServiceFactory.build(
+            api_type=APITypes.orc,
+            api_root="https://httpbin.org/",
+            auth_type=AuthTypes.no_auth,
+        )
+
+        cls.pre_req_register = Registry()
+        cls.mock = MagicMock()
+
+        @cls.pre_req_register("test")
+        class PreRequestHook(PreRequestHookBase):
+            def __call__(self, *args, **kwargs):
+                cls.mock(*args, **kwargs)
+
+    @requests_mock.Mocker()
+    def test_pre_request_hooks_called(self, m):
+        m.get("https://httpbin.org/get", json={"url": "https://httpbin.org/get"})
+        self.mock.reset_mock()
+        submission = SubmissionFactory.from_components(
+            auth_info__value="999970124",
+            auth_info__attribute=AuthAttribute.bsn,
+            components_list=[
+                {
+                    "key": "dummy_field",
+                    "type": "textfield",
+                    "label": "Dummy field",
+                },
+            ],
+        )
+
+        var = FormVariableFactory.build(
+            service_fetch_configuration=ServiceFetchConfigurationFactory.build(
+                service=self.service,
+                path="get",
+            )
+        )
+
+        with patch(
+            "openforms.pre_requests.clients.registry", new=self.pre_req_register
+        ):
+            perform_service_fetch(var, FormioData(), submission)
+
+        self.assertEqual(self.mock.call_count, 1)
+
+        # assert that the pre request hooks are called with the
+        # expected context to make sure that token exchange works properly
+        context = self.mock.call_args.kwargs["context"]
+        self.assertEqual(context, {"submission": submission})
+
+    @requests_mock.Mocker()
+    def test_pre_request_hooks_not_called(self, m):
+        m.get("https://httpbin.org/get", json={"url": "https://httpbin.org/get"})
+
+        self.mock.reset_mock()
+
+        var = FormVariableFactory.build(
+            service_fetch_configuration=ServiceFetchConfigurationFactory.build(
+                service=self.service,
+                path="get",
+            )
+        )
+
+        with patch(
+            "openforms.pre_requests.clients.registry", new=self.pre_req_register
+        ):
+            perform_service_fetch(var, FormioData())
+
+        self.assertEqual(self.mock.call_count, 1)
+
+        # assert that the pre request hooks are called without the
+        # context to make sure that token exchange does not interfere with none-submission-loaded calls
+        context = self.mock.call_args.kwargs["context"]
+        self.assertEqual(context, None)
+
+    @requests_mock.Mocker()
+    def test_pre_request_client_factory_used(self, m):
+        m.get("https://httpbin.org/get", json={"url": "https://httpbin.org/get"})
+
+        self.mock.reset_mock()
+
+        var = FormVariableFactory.build(
+            service_fetch_configuration=ServiceFetchConfigurationFactory.build(
+                service=ServiceFactory.build(
+                    api_type=APITypes.orc,
+                    api_root="https://httpbin.org/",
+                    auth_type=AuthTypes.no_auth,
+                ),
+                path="get",
+            )
+        )
+
+        with patch(
+            "openforms.pre_requests.clients.registry", new=self.pre_req_register
+        ):
+            perform_service_fetch(var, FormioData())
+
+        self.assertEqual(self.mock.call_count, 1)
+
+    @requests_mock.Mocker()
+    def test_default_client_factory_used(self, m):
+        m.get("https://httpbin.org/get", json={"url": "https://httpbin.org/get"})
+        self.mock.reset_mock()
+
+        var = FormVariableFactory.build(
+            service_fetch_configuration=ServiceFetchConfigurationFactory.build(
+                service=ServiceFactory.build(
+                    api_type=APITypes.orc,
+                    api_root="https://httpbin.org/",
+                    auth_type=AuthTypes.api_key,
+                ),
+                path="get",
+            )
+        )
+
+        with patch(
+            "openforms.pre_requests.clients.registry", new=self.pre_req_register
+        ):
+            perform_service_fetch(var, FormioData())
+
+        result = perform_service_fetch(var, FormioData())
+        value = result.value
+
+        self.assertEqual(value["url"], "https://httpbin.org/get")
+        self.assertEqual(self.mock.call_count, 0)


### PR DESCRIPTION
Allow the logic service-fetch calls to be hooked to the token exchange pre-requests.

Because of the explicit service configuration in the token exchange plugin no unnecessary token exchange calls are triggered.

Closes DH-899 and DH-848


**Changes**

Pass the submission in the logic service-fetch calls and perform the call through the client that allows the prerequest to be hooked. Specific use-case: getting data from BRK/WOZ API's that are accessible through Haal Centraal which (in our case) needs the token auth.
If a service is configured with the api-key auth type, do not do the pre-request, as that overwrites this header (even when because of the plugin configuration the pre-request is not done, the header is emptied)

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Checked new model fields are usable in the admin
  - [ ] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [ ] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how

- Documentation

  - [ ] Added documentation which describes the changes
