### PR TITLE
Fix incorrect validation for `addressNL` that's optional

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -592,6 +592,20 @@ class AddressValueSerializer(serializers.Serializer):
         self.component = kwargs.pop("component", None)
         super().__init__(**kwargs)
 
+    def get_fields(self):
+        fields = super().get_fields()
+
+        # if the field as a whole is not required, postcode & house number become
+        # optional
+        postcode = fields["postcode"]
+        assert isinstance(postcode, serializers.RegexField)
+        postcode.allow_blank = not self.required
+
+        house_number = fields["houseNumber"]
+        assert isinstance(house_number, serializers.RegexField)
+        house_number.allow_blank = not self.required
+        return fields
+
     def validate_city(self, value: str) -> str:
         if city_regex := glom(
             self.component, "openForms.components.city.validate.pattern", default=""

--- a/src/openforms/formio/tests/validation/test_addressnl.py
+++ b/src/openforms/formio/tests/validation/test_addressnl.py
@@ -1,11 +1,13 @@
-from django.test import SimpleTestCase, override_settings
+from django.test import SimpleTestCase, override_settings, tag
 from django.utils.crypto import salted_hmac
 
 from rest_framework import serializers
+from unittest_parametrize import ParametrizedTestCase, parametrize
 
 from openforms.contrib.brk.constants import AddressValue
 from openforms.contrib.brk.validators import ValueSerializer
 from openforms.submissions.models import Submission
+from openforms.typing import JSONObject
 from openforms.validations.base import BasePlugin
 
 from ...components.utils import salt_location_message
@@ -22,7 +24,7 @@ class PostcodeValidator(BasePlugin[AddressValue]):
 
 
 @override_settings(LANGUAGE_CODE="en")
-class AddressNLValidationTests(SimpleTestCase):
+class AddressNLValidationTests(ParametrizedTestCase, SimpleTestCase):
     def test_addressNL_field_required_validation(self):
         component: AddressNLComponent = {
             "key": "addressNl",
@@ -46,7 +48,26 @@ class AddressNLValidationTests(SimpleTestCase):
                 error = extract_error(errors, component["key"])
                 self.assertEqual(error.code, error_code)
 
-    def test_addressNL_field_non_required_validation(self):
+    @parametrize(
+        "value",
+        [
+            {},
+            {
+                "addressNl": {
+                    "autoPopulated": False,
+                    "postcode": "",
+                    "houseNumber": "",
+                    "houseLetter": "",
+                    "houseNumberAddition": "",
+                    "streetName": "",
+                    "city": "",
+                    "secretStreetCity": "",
+                },
+            },
+        ],
+    )
+    @tag("gh-6581")
+    def test_addressNL_field_non_required_validation(self, value: JSONObject):
         component: AddressNLComponent = {
             "key": "addressNl",
             "type": "addressNL",
@@ -54,7 +75,7 @@ class AddressNLValidationTests(SimpleTestCase):
             "deriveAddress": False,
         }
 
-        is_valid, _ = validate_formio_data(component, {})
+        is_valid, _ = validate_formio_data(component, value)
 
         self.assertTrue(is_valid)
 


### PR DESCRIPTION
Closes #6581

**Changes**

* Added regression test
* Fixed setting the subfield required/blank state based on the parent field

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
