### PR TITLE
[#6604] check component prop during rendering of registration variables

### DIFF
--- a/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummaryList.js
+++ b/src/openforms/js/components/admin/form_design/variables/registration/RegistrationsSummaryList.js
@@ -43,7 +43,7 @@ const RegistrationSummary = ({
   // always pick the right index of the backend from the updated context
   const backendIndex = formContext.registrationBackends.findIndex(item => item.key === backend.key);
 
-  const isForDifferentComponent = component?.key !== variable.key;
+  const isForDifferentComponent = component && component?.key !== variable.key;
 
   return (
     <>


### PR DESCRIPTION
Closes #6604 

**Changes**

Previously no check was present that checked if the component property was passed through when the check was performed whether a variable was for another component or not. See 36a20f09ca08cd6cf580ab8343780bf651752a1c for more information.

This caused all user defined and registration related variables to not show up as the `component` property was not passed through for these variables.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
