### PR TITLE
[#6210] Add missing validations for single step forms

### DIFF
--- a/src/openforms/forms/api/v3/serializers/form.py
+++ b/src/openforms/forms/api/v3/serializers/form.py
@@ -39,7 +39,7 @@ from ....api.serializers.form import (
     HelpDialogSerializer,
     SubmissionsRemovalOptionsSerializer,
 )
-from ....constants import FormTypeChoices
+from ....constants import FormTypeChoices, SubmissionAllowedChoices
 from ....logic_analysis import CyclesDetected, analyze_rules
 from ....models import (
     Category,
@@ -253,6 +253,7 @@ class FormSerializer(serializers.ModelSerializer):
             actions: Sequence[FormLogicActionData] = rule.actions
             if rule_action_errors := validate_logic_actions(
                 actions,
+                form_type=form.type,
                 find_component=_find_component,
                 form_variables=form_variables,
                 form_step_slugs=form_step_slugs,
@@ -821,11 +822,38 @@ class FormSerializer(serializers.ModelSerializer):
                 }
             )
 
+    def validate_single_step_form_type(self, attrs: FormValidatedData) -> None:
+        steps = attrs.get("formstep_set", [])
+
+        # login required
+        for step in steps:
+            if (
+                login_required := step["form_definition"].get("login_required")
+            ) and login_required is True:
+                raise serializers.ValidationError(
+                    _("Single step forms do not support authentication.")
+                )
+
+        # submission allowance
+        if (
+            submission_allowed := attrs.get("submission_allowed")
+        ) and submission_allowed != SubmissionAllowedChoices.yes:
+            raise serializers.ValidationError(
+                _("Submission is always allowed in single step forms.")
+            )
+
     def validate(self, attrs: FormValidatedData) -> FormValidatedData:
         self.validate_amount_of_steps(attrs)
         # validate variables after validation of the form definitions were ran
         self.validate_variable_data(attrs)
         self.validate_auto_login_backend(attrs)
+
+        # single step form type validations
+        if (
+            form_type := attrs.get("type")
+        ) and form_type == FormTypeChoices.single_step:
+            self.validate_single_step_form_type(attrs)
+
         return attrs
 
     def save(self, **kwargs):

--- a/src/openforms/forms/api/v3/serializers/form.py
+++ b/src/openforms/forms/api/v3/serializers/form.py
@@ -824,15 +824,14 @@ class FormSerializer(serializers.ModelSerializer):
 
     def validate_single_step_form_type(self, attrs: FormValidatedData) -> None:
         steps = attrs.get("formstep_set", [])
+        authentication_error_msg = _("Single step forms do not support authentication.")
 
-        # login required
+        # login required inside step
         for step in steps:
             if (
                 login_required := step["form_definition"].get("login_required")
             ) and login_required is True:
-                raise serializers.ValidationError(
-                    _("Single step forms do not support authentication.")
-                )
+                raise serializers.ValidationError(authentication_error_msg)
 
         # submission allowance
         if (
@@ -841,6 +840,10 @@ class FormSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError(
                 _("Submission is always allowed in single step forms.")
             )
+
+        # authentication backends
+        if attrs.get("auth_backends"):
+            raise serializers.ValidationError(authentication_error_msg)
 
     def validate(self, attrs: FormValidatedData) -> FormValidatedData:
         self.validate_amount_of_steps(attrs)

--- a/src/openforms/forms/api/v3/serializers/form.py
+++ b/src/openforms/forms/api/v3/serializers/form.py
@@ -253,7 +253,7 @@ class FormSerializer(serializers.ModelSerializer):
             actions: Sequence[FormLogicActionData] = rule.actions
             if rule_action_errors := validate_logic_actions(
                 actions,
-                form_type=form.type,
+                form_type=FormTypeChoices(form.type),
                 find_component=_find_component,
                 form_variables=form_variables,
                 form_step_slugs=form_step_slugs,
@@ -823,15 +823,16 @@ class FormSerializer(serializers.ModelSerializer):
             )
 
     def validate_single_step_form_type(self, attrs: FormValidatedData) -> None:
-        steps = attrs.get("formstep_set", [])
+        # at this point we already know that the form type is that of a single step and
+        # validate_amount_of_steps validated that there is only one form step present
+        form_step = attrs["formstep_set"][0]
         authentication_error_msg = _("Single step forms do not support authentication.")
 
         # login required inside step
-        for step in steps:
-            if (
-                login_required := step["form_definition"].get("login_required")
-            ) and login_required is True:
-                raise serializers.ValidationError(authentication_error_msg)
+        if (
+            login_required := form_step["form_definition"].get("login_required")
+        ) and login_required is True:
+            raise serializers.ValidationError(authentication_error_msg)
 
         # submission allowance
         if (

--- a/src/openforms/forms/api/v3/serializers/form.py
+++ b/src/openforms/forms/api/v3/serializers/form.py
@@ -829,17 +829,13 @@ class FormSerializer(serializers.ModelSerializer):
         authentication_error_msg = _("Single step forms do not support authentication.")
 
         # login required inside step
-        if (
-            login_required := form_step["form_definition"].get("login_required")
-        ) and login_required is True:
+        if form_step["form_definition"].get("login_required"):
             raise serializers.ValidationError(authentication_error_msg)
 
         # submission allowance
-        if (
-            submission_allowed := attrs.get("submission_allowed")
-        ) and submission_allowed != SubmissionAllowedChoices.yes:
+        if attrs.get("submission_allowed") != SubmissionAllowedChoices.yes:
             raise serializers.ValidationError(
-                _("Submission is always allowed in single step forms.")
+                _("Submission must always be allowed in single step forms.")
             )
 
         # authentication backends

--- a/src/openforms/forms/api/v3/validation.py
+++ b/src/openforms/forms/api/v3/validation.py
@@ -12,7 +12,11 @@ from openforms.formio.service import holds_submission_data
 from openforms.formio.typing import Component
 from openforms.variables.constants import FormVariableDataTypes
 
-from ...constants import LogicActionTypes
+from ...constants import (
+    SINGLE_STEP_FORM_ACTION_TYPES,
+    FormTypeChoices,
+    LogicActionTypes,
+)
 from ...models import FormVariable
 from .typing import FormLogicActionData
 
@@ -28,6 +32,7 @@ that field. The field names are the keys of a logic action struct (polymorphic).
 def validate_logic_actions(
     actions: Sequence[FormLogicActionData],
     *,
+    form_type: str,
     find_component: Callable[[str], Component | None],
     form_variables: Mapping[str, FormVariable],
     form_step_slugs: Collection[str],
@@ -37,7 +42,8 @@ def validate_logic_actions(
 
     :param actions: The (ordered) collection of actions to verify against the form
       configuration.
-    :param find_component: An (optimized) callback to to resolve a component key against
+    :param form_type: The type of the form.
+    :param find_component: An (optimized) callback to resolve a component key against
       a Formio component in any of the form steps.
     :param form_variables: A mapping of all known form variable keys to their form
       variable instance, including both component and user defined variables.
@@ -49,6 +55,19 @@ def validate_logic_actions(
         # the enum helps enforce the value, and we expect input validation to
         # validate that the action key & type key are present already
         action_type = LogicActionTypes(action["action"]["type"])
+
+        if (
+            form_type == FormTypeChoices.single_step
+            and action_type not in SINGLE_STEP_FORM_ACTION_TYPES
+        ):
+            errors[action_index]["type"].append(
+                ErrorDetail(
+                    _(
+                        "Logic action {action_type} is not allowed in single step forms."
+                    ).format(action_type=action_type),
+                    code="invalid",
+                )
+            )
 
         # actions are polymorphic, so their configuration needs to be validated based on
         # the discriminator key. Pattern matching works well for this.
@@ -85,7 +104,7 @@ def validate_logic_actions(
                         errors[action_index]["component"].append(
                             ErrorDetail(
                                 _(
-                                    "You cannot used the 'disabled' property "
+                                    "You cannot use the 'disabled' property "
                                     "on layout components'."
                                 ),
                                 code="invalid",

--- a/src/openforms/forms/api/v3/validation.py
+++ b/src/openforms/forms/api/v3/validation.py
@@ -32,7 +32,7 @@ that field. The field names are the keys of a logic action struct (polymorphic).
 def validate_logic_actions(
     actions: Sequence[FormLogicActionData],
     *,
-    form_type: str,
+    form_type: FormTypeChoices,
     find_component: Callable[[str], Component | None],
     form_variables: Mapping[str, FormVariable],
     form_step_slugs: Collection[str],

--- a/src/openforms/forms/constants.py
+++ b/src/openforms/forms/constants.py
@@ -43,6 +43,12 @@ LOGIC_ACTION_TYPES_REQUIRING_FORM_STEP_SLUG = (
     LOGIC_ACTION_TYPES_REQUIRING_FORM_STEP_UUID
 )
 
+SINGLE_STEP_FORM_ACTION_TYPES: set[str] = {
+    LogicActionTypes.variable.value,
+    LogicActionTypes.evaluate_dmn.value,
+    LogicActionTypes.set_registration_backend.value,
+}
+
 
 class PropertyTypes(models.TextChoices):
     bool = "bool", _("Boolean")

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -570,6 +570,114 @@ class FormEndpointTests(APITestCase):
         # logic rules
         self.assertEqual(form.formlogic_set.count(), 1)
 
+    def test_create_single_step_form_with_registrations_and_confirmation_template(self):
+        form_definition_uuid = str(uuid4())
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "internalName": "Create form internal",
+            "registrationBackends": [
+                {
+                    "name": "Email registration",
+                    "key": "email-fu",
+                    "backend": "email",
+                    "options": {
+                        "to_emails": ["foo@example.com"],
+                    },
+                }
+            ],
+            "slug": "create-form",
+            "type": FormTypeChoices.single_step,
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "isReusable": True,
+                        "loginRequired": False,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "label": "component1",
+                                    "hidden": False,
+                                    "clearOnHide": True,
+                                },
+                            ],
+                        },
+                    },
+                }
+            ],
+            "confirmationEmailTemplate": {
+                "translations": {
+                    "en": {
+                        "subject": "Submission received",
+                        "content": "{% confirmation_summary %} {% appointment_information %} {% payment_information %}",
+                        "cosign_subject": "Cosign submission received",
+                        "cosign_content": "{% confirmation_summary %} {% appointment_information %} {% payment_information %} {% cosign_information %}",
+                    },
+                    "nl": {
+                        "subject": "Inzending ontvangen",
+                        "content": "{% confirmation_summary %} {% appointment_information %} {% payment_information %}",
+                        "cosign_subject": "Cosign inzending ontvangen",
+                        "cosign_content": "{% confirmation_summary %} {% appointment_information %} {% payment_information %} {% cosign_information %}",
+                    },
+                }
+            },
+            "sendConfirmationEmail": True,
+        }
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(Form.objects.count(), 1)
+        form = Form.objects.get()
+
+        # registration backends
+        registration_backend = FormRegistrationBackend.objects.get()
+        self.assertEqual(form.registration_backends.get(), registration_backend)
+        self.assertEqual(registration_backend.name, "Email registration")
+        self.assertEqual(registration_backend.key, "email-fu")
+        self.assertEqual(registration_backend.backend, "email")
+        self.assertEqual(
+            registration_backend.options,
+            {
+                "to_emails": ["foo@example.com"],
+                "attach_files_to_email": None,
+            },
+        )
+
+        # confirmation email
+        confirmation_email_template = form.confirmation_email_template
+        assert confirmation_email_template, "No confirmation email coupled to form"
+        self.assertEqual(confirmation_email_template.subject_en, "Submission received")
+        self.assertEqual(
+            confirmation_email_template.content_en,
+            "{% confirmation_summary %} {% appointment_information %} {% payment_information %}",
+        )
+        self.assertEqual(
+            confirmation_email_template.cosign_subject_en, "Cosign submission received"
+        )
+        self.assertEqual(
+            confirmation_email_template.cosign_content_en,
+            "{% confirmation_summary %} {% appointment_information %} {% payment_information %} {% cosign_information %}",
+        )
+        self.assertEqual(confirmation_email_template.subject_nl, "Inzending ontvangen")
+        self.assertEqual(
+            confirmation_email_template.content_nl,
+            "{% confirmation_summary %} {% appointment_information %} {% payment_information %}",
+        )
+        self.assertEqual(
+            confirmation_email_template.cosign_subject_nl, "Cosign inzending ontvangen"
+        )
+        self.assertEqual(
+            confirmation_email_template.cosign_content_nl,
+            "{% confirmation_summary %} {% appointment_information %} {% payment_information %} {% cosign_information %}",
+        )
+
     def test_create_reuse_existing_definition(self):
         form_definition = FormDefinitionFactory.create(
             name="Form definition",
@@ -663,6 +771,95 @@ class FormEndpointTests(APITestCase):
             },
         )
         self.assertEqual(FormDefinition.objects.count(), 1)
+
+    def test_login_not_allowed_in_single_step_form(self):
+        form_definition_uuid = str(uuid4())
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "internalName": "Create form internal",
+            "slug": "create-form",
+            "type": FormTypeChoices.single_step,
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "isReusable": True,
+                        "loginRequired": True,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "label": "component1",
+                                },
+                            ],
+                        },
+                    },
+                }
+            ],
+            "active": True,
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(response_data["invalidParams"]), 1)
+        self.assertEqual(response_data["code"], "invalid")
+        self.assertEqual(response_data["invalidParams"][0]["name"], "nonFieldErrors")
+        self.assertEqual(
+            response_data["invalidParams"][0]["reason"],
+            _("Single step forms do not support authentication."),
+        )
+
+    def test_submission_not_allowed_by_default_fails_in_single_step_form(self):
+        form_definition_uuid = str(uuid4())
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "internalName": "Create form internal",
+            "slug": "create-form",
+            "type": FormTypeChoices.single_step,
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "isReusable": True,
+                        "loginRequired": False,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "label": "component1",
+                                },
+                            ],
+                        },
+                    },
+                }
+            ],
+            "active": True,
+            "submissionAllowed": SubmissionAllowedChoices.no_without_overview,
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(response_data["invalidParams"]), 1)
+        self.assertEqual(response_data["code"], "invalid")
+        self.assertEqual(response_data["invalidParams"][0]["name"], "nonFieldErrors")
+        self.assertEqual(
+            response_data["invalidParams"][0]["reason"],
+            _("Submission is always allowed in single step forms."),
+        )
 
     def test_update_clears_existing_registration_backends(self):
         form = FormFactory.create(
@@ -4072,7 +4269,7 @@ class FormEndpointLogicRulesTests(APITestCase):
             {
                 "name": "logicRules.0.actions.0.component",
                 "code": "invalid",
-                "reason": "You cannot used the 'disabled' property on layout components'.",
+                "reason": "You cannot use the 'disabled' property on layout components'.",
             },
         )
 
@@ -4201,6 +4398,125 @@ class FormEndpointLogicRulesTests(APITestCase):
                 "name": "logicRules.0.actions.0.formStepSlug",
                 "code": "invalid",
                 "reason": "Could not find a step with the slug 'wrong'.",
+            },
+        )
+
+    def test_valid_action_in_single_step_form(self):
+        form = FormFactory.create()
+        form_step = FormStepFactory.create(form=form, slug="step-1")
+        form_definition = form_step.form_definition
+        FormLogicFactory.create(form=form)
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "type": FormTypeChoices.single_step,
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition.uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "textfield",
+                                    "label": "Textfield",
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            "logic_rules": [
+                {
+                    "order": 0,
+                    "jsonLogicTrigger": True,
+                    "is_advanced": True,
+                    "actions": [
+                        {
+                            "variable": "textfield",
+                            "action": {
+                                "type": "variable",
+                                "value": "foo",
+                                "property": {"type": "", "value": ""},
+                                "state": "",
+                            },
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_invalid_action_in_single_step_form(self):
+        form = FormFactory.create()
+        form_step = FormStepFactory.create(form=form, slug="step-1")
+        form_definition = form_step.form_definition
+        FormLogicFactory.create(form=form)
+
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": form.uuid},
+        )
+        data = {
+            "name": "Update form",
+            "slug": "update-form",
+            "type": FormTypeChoices.single_step,
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition.uuid,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "textfield",
+                                    "label": "Textfield",
+                                },
+                            ],
+                        },
+                    },
+                },
+            ],
+            "logic_rules": [
+                {
+                    "order": 0,
+                    "jsonLogicTrigger": True,
+                    "is_advanced": True,
+                    "actions": [
+                        {
+                            "component": "textfield",
+                            "action": {
+                                "type": "property",
+                                "property": {"type": "bool", "value": "hidden"},
+                                "value": "",
+                                "state": True,
+                            },
+                            "formStepUuid": "fc52a48d-f289-48b1-b02b-805edeb422c0",
+                        }
+                    ],
+                },
+            ],
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response_data["code"], "invalid")
+        self.assertEqual(
+            response_data["invalidParams"][0],
+            {
+                "name": "logicRules.0.actions.0.type",
+                "code": "invalid",
+                "reason": "Logic action property is not allowed in single step forms.",
             },
         )
 

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -772,7 +772,7 @@ class FormEndpointTests(APITestCase):
         )
         self.assertEqual(FormDefinition.objects.count(), 1)
 
-    def test_login_not_allowed_in_single_step_form(self):
+    def test_login_not_allowed_in_single_step_form_step(self):
         form_definition_uuid = str(uuid4())
         url = reverse(
             "api:v3:form-detail",
@@ -803,6 +803,56 @@ class FormEndpointTests(APITestCase):
                 }
             ],
             "active": True,
+        }
+        response = self.client.put(url, data=data)
+        response_data = response.json()
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(len(response_data["invalidParams"]), 1)
+        self.assertEqual(response_data["code"], "invalid")
+        self.assertEqual(response_data["invalidParams"][0]["name"], "nonFieldErrors")
+        self.assertEqual(
+            response_data["invalidParams"][0]["reason"],
+            _("Single step forms do not support authentication."),
+        )
+
+    def test_auth_backends_not_allowed_in_single_step_form(self):
+        form_definition_uuid = str(uuid4())
+        url = reverse(
+            "api:v3:form-detail",
+            kwargs={"uuid": "559812e7-9bff-4142-ab41-0cc8cf4e5e32"},
+        )
+        data = {
+            "name": "Create form",
+            "internalName": "Create form internal",
+            "slug": "create-form",
+            "type": FormTypeChoices.single_step,
+            "steps": [
+                {
+                    "slug": "step-1",
+                    "formDefinition": {
+                        "uuid": form_definition_uuid,
+                        "isReusable": True,
+                        "loginRequired": False,
+                        "configuration": {
+                            "components": [
+                                {
+                                    "type": "textfield",
+                                    "key": "component1",
+                                    "label": "component1",
+                                },
+                            ],
+                        },
+                    },
+                }
+            ],
+            "active": True,
+            "authBackends": [
+                {
+                    "backend": "digid",
+                    "options": {"loa": DigiDAssuranceLevels.substantial},
+                }
+            ],
         }
         response = self.client.put(url, data=data)
         response_data = response.json()

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -591,6 +591,7 @@ class FormEndpointTests(APITestCase):
             ],
             "slug": "create-form",
             "type": FormTypeChoices.single_step,
+            "submission_allowed": SubmissionAllowedChoices.yes,
             "steps": [
                 {
                     "slug": "step-1",
@@ -827,6 +828,7 @@ class FormEndpointTests(APITestCase):
             "internalName": "Create form internal",
             "slug": "create-form",
             "type": FormTypeChoices.single_step,
+            "submission_allowed": SubmissionAllowedChoices.yes,
             "steps": [
                 {
                     "slug": "step-1",
@@ -908,7 +910,7 @@ class FormEndpointTests(APITestCase):
         self.assertEqual(response_data["invalidParams"][0]["name"], "nonFieldErrors")
         self.assertEqual(
             response_data["invalidParams"][0]["reason"],
-            _("Submission is always allowed in single step forms."),
+            _("Submission must always be allowed in single step forms."),
         )
 
     def test_update_clears_existing_registration_backends(self):
@@ -4465,6 +4467,7 @@ class FormEndpointLogicRulesTests(APITestCase):
             "name": "Update form",
             "slug": "update-form",
             "type": FormTypeChoices.single_step,
+            "submission_allowed": SubmissionAllowedChoices.yes,
             "steps": [
                 {
                     "slug": "step-1",
@@ -4519,6 +4522,7 @@ class FormEndpointLogicRulesTests(APITestCase):
             "name": "Update form",
             "slug": "update-form",
             "type": FormTypeChoices.single_step,
+            "submission_allowed": SubmissionAllowedChoices.yes,
             "steps": [
                 {
                     "slug": "step-1",

--- a/src/openforms/registrations/tests/test_update_registration_with_confirmation_email.py
+++ b/src/openforms/registrations/tests/test_update_registration_with_confirmation_email.py
@@ -4,6 +4,7 @@ from django.test import TestCase
 
 from rest_framework import serializers
 
+from openforms.forms.constants import FormTypeChoices
 from openforms.forms.models import FormRegistrationBackend
 from openforms.logging.models import TimelineLogProxy
 from openforms.submissions.constants import RegistrationStatuses
@@ -23,6 +24,42 @@ class UpdateRegistrationWithConfirmationEmailTests(TestCase):
     def test_happy_flow(self):
         submission = SubmissionFactory.create(
             completed=True,
+            form__registration_backend="plugin",
+            form__registration_backend_options={"string": "foo"},
+            registration_result={"result": "bar"},
+            registration_status=RegistrationStatuses.success,
+        )
+
+        register = Registry()
+
+        @register("plugin")
+        class Plugin(BasePlugin):
+            verbose_name = "Cool plugin"
+            configuration_options = OptionsSerializer
+
+            def register_submission(self, submission, options):
+                return {}
+
+            def update_registration_with_confirmation_email(self, submission, options):
+                return {"result": "bar"}
+
+        model_field = FormRegistrationBackend._meta.get_field("backend")
+        with patch_registry(model_field, register):
+            update_registration_with_confirmation_email(submission.pk)
+
+        submission.refresh_from_db()
+        self.assertEqual(submission.registration_result, {"result": "bar"})
+
+        # Check log
+        log = TimelineLogProxy.objects.last()
+        self.assertEqual(
+            log.event, "registration_update_with_confirmation_email_success"
+        )
+
+    def test_happy_flow_for_single_step_forms(self):
+        submission = SubmissionFactory.create(
+            completed=True,
+            form__type=FormTypeChoices.single_step,
             form__registration_backend="plugin",
             form__registration_backend_options={"string": "foo"},
             registration_result={"result": "bar"},


### PR DESCRIPTION
Closes #6210

**Changes**

Added missing validations for single step forms.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
