### PR TITLE
Test setup cleanups and general code prettifying

### DIFF
--- a/src/openforms/appointments/contrib/qmatic/tests/test_api_endpoints.py
+++ b/src/openforms/appointments/contrib/qmatic/tests/test_api_endpoints.py
@@ -295,7 +295,12 @@ class CancelAppointmentTests(MockConfigMixin, SubmissionsMixin, APITestCase):
     def test_cancel_appointment_deletes_the_appointment(self, m):
         submission = SubmissionFactory.from_components(
             components_list=[
-                {"key": "email", "label": "Email", "confirmationRecipient": True}
+                {
+                    "type": "email",
+                    "key": "email",
+                    "label": "Email",
+                    "confirmationRecipient": True,
+                }
             ],
             submitted_data={"email": "maykin@media.nl"},
         )
@@ -342,7 +347,12 @@ class CancelAppointmentTests(MockConfigMixin, SubmissionsMixin, APITestCase):
         identifier = "123456789"
         submission = SubmissionFactory.from_components(
             components_list=[
-                {"key": "email", "label": "Email", "confirmationRecipient": True}
+                {
+                    "type": "email",
+                    "key": "email",
+                    "label": "Email",
+                    "confirmationRecipient": True,
+                }
             ],
             submitted_data={"email": "maykin@media.nl"},
         )

--- a/src/openforms/contrib/customer_interactions/transform.py
+++ b/src/openforms/contrib/customer_interactions/transform.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from itertools import groupby
 
 import structlog
@@ -17,8 +17,8 @@ logger = structlog.stdlib.get_logger(__name__)
 
 def transform_digital_addresses(
     digital_addresses: Iterable[DigitaalAdres],
-    configured_address_types: list[SupportedChannels],
-) -> list[CommunicationChannel]:
+    configured_address_types: Sequence[SupportedChannels],
+) -> Sequence[CommunicationChannel]:
     """
     Filter and group digital addresses.
 

--- a/src/openforms/emails/tests/test_confirmation_email.py
+++ b/src/openforms/emails/tests/test_confirmation_email.py
@@ -655,9 +655,9 @@ class ConfirmationEmailRenderingIntegrationTest(HTMLAssertMixin, TestCase):
             subject="My Subject",
             content="{% confirmation_summary %}",
         )
-        first_step_name = submission.submissionstep_set.all()[  # pyright: ignore[reportAttributeAccessIssue]
-            0
-        ].form_step.form_definition.name
+        first_step = submission.submissionstep_set.all()[0].form_step
+        assert first_step is not None
+        first_step_name = first_step.form_definition.name
 
         send_confirmation_email(submission)
 

--- a/src/openforms/formio/formatters/tests/files/all_components.json
+++ b/src/openforms/formio/formatters/tests/files/all_components.json
@@ -1688,9 +1688,7 @@
             "type": "licenseplate",
             "input": true,
             "label": "License plate",
-            "errors": {
-                "pattern": "Invalid Dutch license plate"
-            },
+            "errors": {},
             "hidden": false,
             "prefix": "",
             "suffix": "",

--- a/src/openforms/formio/formatters/tests/files/kitchensink_components.json
+++ b/src/openforms/formio/formatters/tests/files/kitchensink_components.json
@@ -7029,9 +7029,7 @@
             "type": "licenseplate",
             "input": true,
             "label": "License plate",
-            "errors": {
-                "pattern": "Invalid Dutch license plate"
-            },
+            "errors": {},
             "hidden": false,
             "prefix": "",
             "suffix": "",
@@ -7112,9 +7110,7 @@
             "type": "licenseplate",
             "input": true,
             "label": "License plate Empty",
-            "errors": {
-                "pattern": "Invalid Dutch license plate"
-            },
+            "errors": {},
             "hidden": false,
             "prefix": "",
             "suffix": "",
@@ -7195,9 +7191,7 @@
             "type": "licenseplate",
             "input": true,
             "label": "License plate Hidden",
-            "errors": {
-                "pattern": "Invalid Dutch license plate"
-            },
+            "errors": {},
             "hidden": true,
             "prefix": "",
             "suffix": "",
@@ -7278,9 +7272,7 @@
             "type": "licenseplate",
             "input": true,
             "label": "License plate Multi",
-            "errors": {
-                "pattern": "Invalid Dutch license plate"
-            },
+            "errors": {},
             "hidden": false,
             "prefix": "",
             "suffix": "",
@@ -7361,9 +7353,7 @@
             "type": "licenseplate",
             "input": true,
             "label": "License plate Multi Empty",
-            "errors": {
-                "pattern": "Invalid Dutch license plate"
-            },
+            "errors": {},
             "hidden": false,
             "prefix": "",
             "suffix": "",

--- a/src/openforms/formio/formatters/tests/test_default_formatters.py
+++ b/src/openforms/formio/formatters/tests/test_default_formatters.py
@@ -24,7 +24,9 @@ class DefaultFormatterTestCase(SimpleTestCase):
     def test_formatters(self):
         # TODO ditch all_components*.json stuff after #1301 is fixed
         all_components = load_json("all_components.json")["components"]
+        assert isinstance(all_components, list)
         data = load_json("all_components_data.json")
+        assert isinstance(data, dict)
 
         # Submission data should be native Python objects
         data["date"] = date.fromisoformat(data["date"])
@@ -84,6 +86,7 @@ class DefaultFormatterTestCase(SimpleTestCase):
     def test_formatter_multiple(self):
         # TODO simplify without reference to all_components.json
         all_components = load_json("all_components.json")["components"]
+        assert isinstance(all_components, list)
         time_component = next(
             component for component in all_components if component["key"] == "time"
         )
@@ -101,6 +104,7 @@ class DefaultFormatterTestCase(SimpleTestCase):
     def test_formatter_empty_value(self):
         # TODO simplify without reference to all_components.json
         all_components = load_json("all_components.json")["components"]
+        assert isinstance(all_components, list)
         component = all_components[0]
 
         formatted = format_value(component, "")
@@ -135,7 +139,7 @@ class DefaultFormatterTestCase(SimpleTestCase):
             "key": "checkbox",
             "label": "checkbox",
         }
-        yes, no, maybe = _("yes,no,maybe").split(",")
+        yes, no, _maybe = _("yes,no,maybe").split(",")
         expected = [
             ("", ""),
             (None, ""),

--- a/src/openforms/formio/formatters/tests/test_kitchensink.py
+++ b/src/openforms/formio/formatters/tests/test_kitchensink.py
@@ -50,8 +50,11 @@ class KitchensinkFormatterTestCase(BaseFormatterTestCase):
 
     def run_kitchensink_test(self, name_data, name_printable):
         configuration = load_json("kitchensink_components.json")
+        assert isinstance(configuration, dict)
         data = load_json(f"{name_data}.json")
+        assert isinstance(data, dict)
         text_printed = load_json(f"{name_printable}.json")
+        assert isinstance(text_printed, dict)
 
         # for sanity
         self.assertFlatConfiguration(configuration)
@@ -71,12 +74,12 @@ class KitchensinkFormatterTestCase(BaseFormatterTestCase):
         assert "Signature" in text_printed
         text_printed["Signature"] = _("signature added")
 
-        expected_labels = set(
+        expected_labels = {
             c["label"] for c in filter_printable(iter_components(configuration))
-        )
-        expected_keys = set(
+        }
+        expected_keys = {
             c["key"] for c in filter_printable(iter_components(configuration))
-        )
+        }
 
         expected_keys.remove("numberEmpty")
         expected_keys.remove("currencyEmpty")
@@ -85,9 +88,11 @@ class KitchensinkFormatterTestCase(BaseFormatterTestCase):
         # self.assertEqual(set(data.keys()), expected_keys)
 
         submission = SubmissionFactory.from_components(
-            configuration["components"], submitted_data=data, completed=True
+            configuration["components"],  # pyright: ignore[reportArgumentType]
+            submitted_data=data,
+            completed=True,
         )
-        submission_step = submission.submissionstep_set.get()  # pyright: ignore[reportAttributeAccessIssue]
+        submission_step = submission.submissionstep_set.get()
 
         # these must match the components
         self.assertComponentKeyExists(configuration, "file")
@@ -114,7 +119,7 @@ class KitchensinkFormatterTestCase(BaseFormatterTestCase):
         printable_data = _get_printable_data(submission)
 
         # check if we have something for all components
-        self.assertEqual(set(d[0] for d in printable_data), expected_labels)
+        self.assertEqual({d[0] for d in printable_data}, expected_labels)
 
         text_values = dict(printable_data)
 

--- a/src/openforms/formio/formatters/tests/utils.py
+++ b/src/openforms/formio/formatters/tests/utils.py
@@ -1,10 +1,11 @@
 import json
 from pathlib import Path
-from typing import Any
+
+from openforms.typing import JSONValue
 
 FILES_DIR = Path(__file__).parent / "files"
 
 
-def load_json(filename: str) -> dict[str, Any]:
+def load_json(filename: str) -> JSONValue:
     with open(FILES_DIR / filename) as infile:
         return json.load(infile)

--- a/src/openforms/formio/tests/assertions.py
+++ b/src/openforms/formio/tests/assertions.py
@@ -35,3 +35,8 @@ class FormioMixin:
                 except GlomError:
                     self.fail(f"Could not find property with path '{key}' in component")
                 self.assertEqual(value, expected_value)
+
+    def assertComponentProperties(self, result, expected):
+        for key, expected_value in expected.items():
+            with self.subTest(key=key):
+                self.assertEqual(result[key], expected_value)

--- a/src/openforms/formio/tests/test_simple_conditionals_converter.py
+++ b/src/openforms/formio/tests/test_simple_conditionals_converter.py
@@ -15,6 +15,7 @@ class RegressionTests(SimpleTestCase):
                     "type": "editgrid",
                     "key": "ingeschrevenOnderneming",
                     "label": "Gegevens onderneming",
+                    "groupLabel": "Item",
                     "components": [
                         {
                             "type": "radio",
@@ -71,6 +72,7 @@ class RegressionTests(SimpleTestCase):
             "type": "editgrid",
             "key": "medebewonerHGroep",
             "label": "Broken editgrid",
+            "groupLabel": "Item",
             "components": [
                 {
                     "type": "textfield",

--- a/src/openforms/forms/models/form.py
+++ b/src/openforms/forms/models/form.py
@@ -58,6 +58,7 @@ if TYPE_CHECKING:
         FormRegistrationBackend,
         FormStep,
         FormVariable,
+        FormVersion,
     )
 
 
@@ -455,6 +456,7 @@ class Form(models.Model):
     auth_backends: Manager[FormAuthenticationBackend]
     registration_backends: Manager[FormRegistrationBackend]
     formlogic_set: Manager[FormLogic]
+    formversion_set: Manager[FormVersion]
 
     get_begin_text = literal_getter("begin_text", "form_begin_text")
     get_previous_text = literal_getter("previous_text", "form_previous_text")

--- a/src/openforms/forms/tests/test_api_formdefinition.py
+++ b/src/openforms/forms/tests/test_api_formdefinition.py
@@ -519,6 +519,7 @@ class FormDefinitionsAPITests(APITestCase):
                             "key": "repeatingGroup",
                             "label": "Repeating Group",
                             "type": "editgrid",
+                            "groupLabel": "Item",
                             "components": [
                                 {
                                     "key": "duplicate",

--- a/src/openforms/forms/tests/test_migration_operations.py
+++ b/src/openforms/forms/tests/test_migration_operations.py
@@ -70,9 +70,9 @@ class ConvertComponentsOperationTests(TestCase):
                         "label": "Text",
                     },
                     {
-                        "type": "nottextfield",
-                        "key": "textfield",
-                        "label": "Text",
+                        "type": "email",
+                        "key": "email",
+                        "label": "Email",
                     },
                 ]
             }

--- a/src/openforms/forms/tests/test_models.py
+++ b/src/openforms/forms/tests/test_models.py
@@ -119,7 +119,7 @@ class FormTestCase(TestCase):
                 "components": [
                     {
                         "key": "aaa",
-                        "type": "textfield",
+                        "type": "email",
                         "label": "AAA",
                         "confirmationRecipient": True,
                     },
@@ -132,7 +132,7 @@ class FormTestCase(TestCase):
                 "components": [
                     {
                         "key": "bbb",
-                        "type": "textfield",
+                        "type": "email",
                         "label": "BBB",
                         "confirmationRecipient": True,
                         "multiple": True,
@@ -434,9 +434,24 @@ class FormDefinitionTestCase(TestCase):
             configuration={
                 "display": "form",
                 "components": [
-                    {"key": "aaa", "label": "AAA", "confirmationRecipient": True},
-                    {"key": "bbb", "label": "BBB", "confirmationRecipient": False},
-                    {"key": "ccc", "label": "CCC", "confirmationRecipient": True},
+                    {
+                        "type": "email",
+                        "key": "aaa",
+                        "label": "AAA",
+                        "confirmationRecipient": True,
+                    },
+                    {
+                        "type": "email",
+                        "key": "bbb",
+                        "label": "BBB",
+                        "confirmationRecipient": False,
+                    },
+                    {
+                        "type": "email",
+                        "key": "ccc",
+                        "label": "CCC",
+                        "confirmationRecipient": True,
+                    },
                 ],
             }
         )
@@ -482,10 +497,12 @@ class FormDefinitionTestCase(TestCase):
                     {
                         "type": "fieldset",
                         "key": "fieldset",
+                        "label": "fieldset",
                         "components": [
                             {
                                 "type": "textfield",
                                 "key": "textfield",
+                                "label": "textfield",
                             }
                         ],
                     }
@@ -587,7 +604,10 @@ class FormStepBackendLogicEvaluationRequiredTests(SimpleTestCase):
                         "type": "radio",
                         "key": "radio",
                         "label": "Radio",
-                        "openForms": {"dataSrc": "variable"},
+                        "openForms": {
+                            "dataSrc": "variable",
+                            "itemsExpression": {"var": "foo"},
+                        },
                         "values": [{"value": "", "label": ""}],
                     }
                 ]
@@ -658,6 +678,7 @@ class FormStepBackendLogicEvaluationRequiredTests(SimpleTestCase):
                         "type": "textfield",
                         "key": "textfield",
                         "label": "Textfield",
+                        "multiple": True,
                         "defaultValue": ["{{ foo }}", "{{ bar }}"],
                     }
                 ]

--- a/src/openforms/forms/tests/v3/test_endpoints.py
+++ b/src/openforms/forms/tests/v3/test_endpoints.py
@@ -684,7 +684,15 @@ class FormEndpointTests(APITestCase):
             name="Form definition",
             slug="form-definition",
             is_reusable=True,
-            configuration={"components": [{"key": "textfield", "type": "textfield"}]},
+            configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "textfield",
+                        "label": "textfield",
+                    }
+                ]
+            },
         )
 
         url = reverse(
@@ -3518,7 +3526,7 @@ class FormEndpointVariableTests(APITestCase):
                                 {
                                     "type": "textfield",
                                     "key": "textfield",
-                                    "name": "Text field",
+                                    "label": "Text field",
                                 },
                             ],
                         },
@@ -4283,6 +4291,7 @@ class FormEndpointLogicRulesTests(APITestCase):
                                     "type": "fieldset",
                                     "key": "fieldset",
                                     "label": "Fieldset",
+                                    "components": [],
                                 },
                             ],
                         },
@@ -4349,6 +4358,7 @@ class FormEndpointLogicRulesTests(APITestCase):
                                     "type": "fieldset",
                                     "key": "fieldset",
                                     "label": "Fieldset",
+                                    "components": [],
                                 },
                             ],
                         },
@@ -4413,6 +4423,7 @@ class FormEndpointLogicRulesTests(APITestCase):
                                     "type": "fieldset",
                                     "key": "fieldset",
                                     "label": "Fieldset",
+                                    "components": [],
                                 },
                             ],
                         },
@@ -4728,6 +4739,7 @@ class FormEndpointLogicRulesTests(APITestCase):
                                     "type": "fieldset",
                                     "key": "fieldset",
                                     "label": "Fieldset",
+                                    "components": [],
                                 },
                             ],
                         },
@@ -4997,7 +5009,15 @@ class FormEndpointConcurrentTests(APITransactionTestCase):
         concurrently, is not possible.
         """
         form_definition = FormDefinitionFactory(
-            configuration={"components": [{"key": "textfield", "type": "textfield"}]},
+            configuration={
+                "components": [
+                    {
+                        "type": "textfield",
+                        "key": "textfield",
+                        "label": "textfield",
+                    }
+                ]
+            },
             is_reusable=True,
             uuid=uuid4(),
         )

--- a/src/openforms/prefill/tests/test_prefill_variables.py
+++ b/src/openforms/prefill/tests/test_prefill_variables.py
@@ -683,7 +683,7 @@ class PrefillVariablesTransactionTests(OFVCRMixin, TransactionTestCase):
 
         prefill_variables(submission=submission_step.submission)
 
-        logs = TimelineLogProxy.objects.filter(object_id=submission_step.submission.id)
+        logs = TimelineLogProxy.objects.filter(object_id=submission_step.submission.pk)
 
         for log in logs:
             self.assertNotEqual(log.event, "prefill_retrieve_success")

--- a/src/openforms/registrations/contrib/email/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/email/tests/test_backend.py
@@ -149,9 +149,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
             },
             language_code="nl",
         )
-        step = (
-            submission.submissionstep_set.get()  # pyright: ignore[reportAttributeAccessIssue]
-        )
+        step = submission.submissionstep_set.get()
         submission_file_attachment_1 = SubmissionFileAttachmentFactory.create(
             submission_variable__key="file1",
             submission_step=step,
@@ -772,9 +770,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
             form__name="MyName",
             form__internal_name="MyInternalName",
         )
-        submission_step = (
-            submission.submissionstep_set.get()  # pyright: ignore[reportAttributeAccessIssue]
-        )
+        submission_step = submission.submissionstep_set.get()
         SubmissionFileAttachmentFactory.create(
             submission_step=submission_step,
             file_name="my-foo.bin",
@@ -869,9 +865,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
             completed=True,
             with_report=True,
         )
-        submission_step = (
-            submission.submissionstep_set.get()  # pyright: ignore[reportAttributeAccessIssue]
-        )
+        submission_step = submission.submissionstep_set.get()
         SubmissionFileAttachmentFactory.create(
             submission_step=submission_step,
             file_name="my-foo.bin",
@@ -907,6 +901,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
             completed=True,
             components_list=[
                 {
+                    "type": "select",
                     "data": {
                         "values": [
                             {"label": "Hallo", "value": "hallo"},
@@ -923,18 +918,18 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
                     "showInEmail": True,
                 },
                 {
+                    "type": "textfield",
                     "key": "favorieteComponenten",
                     "label": "Favoriete componenten?",
                     "multiple": True,
                     "defaultValue": [],
                     "showInEmail": True,
-                    "type": "textfield",
                 },
                 {
+                    "type": "time",
                     "key": "tijdstip",
                     "label": "Tijdstip",
                     "showInEmail": False,
-                    "type": "time",
                 },
                 {
                     "components": [
@@ -1046,6 +1041,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
                     "key": "dev2",
                     "label": "Ontwikkelaargegevens",
                     "legend": "Ontwikkelaargegevens",
+                    "type": "fieldset",
                 },
             ],
             submitted_data={
@@ -1130,9 +1126,7 @@ class EmailBackendTests(HTMLAssertMixin, TestCase):
             form__internal_name="MyInternalName",
             form__registration_backend="email",
         )
-        step = (
-            submission.submissionstep_set.get()  # pyright: ignore[reportAttributeAccessIssue]
-        )
+        step = submission.submissionstep_set.get()
         SubmissionFileAttachmentFactory.create(
             submission_variable__key="file1",
             submission_step=step,

--- a/src/openforms/registrations/contrib/generic_json/tests/test_backend.py
+++ b/src/openforms/registrations/contrib/generic_json/tests/test_backend.py
@@ -2155,7 +2155,11 @@ class GenericJSONBackendTests(OFVCRMixin, TestCase):
                     "label": "Extrachilddetails",
                     "groupLabel": "child",
                     "components": [
-                        {"type": "bsn", "key": "bsn", "label": "BSN"},
+                        {
+                            "type": "bsn",
+                            "key": "bsn",
+                            "label": "BSN",
+                        },
                         {
                             "type": "textfield",
                             "key": "childName",

--- a/src/openforms/registrations/tasks.py
+++ b/src/openforms/registrations/tasks.py
@@ -491,7 +491,7 @@ def execute_component_pre_registration_group(task, submission_id: int) -> None:
 def process_component_pre_registration(submission_id: int) -> None:
     submission: Submission = Submission.objects.get(id=submission_id)
 
-    if submission.submissionvaluevariable_set.filter(  # pyright: ignore[reportAttributeAccessIssue]
+    if submission.submissionvaluevariable_set.filter(
         pre_registration_status=ComponentPreRegistrationStatuses.failed
     ).exists():
         submission.needs_on_completion_retry = True

--- a/src/openforms/submissions/api/viewsets.py
+++ b/src/openforms/submissions/api/viewsets.py
@@ -123,7 +123,7 @@ class SubmissionViewSet(
     PermissionFilterMixin,
     SubmissionCompletionMixin,
     mixins.CreateModelMixin,
-    viewsets.ReadOnlyModelViewSet,
+    viewsets.ReadOnlyModelViewSet[Submission],
 ):
     queryset = Submission.objects.select_related("form", "form__product").order_by(
         "created_on"
@@ -143,7 +143,7 @@ class SubmissionViewSet(
             return "pause"
         return None
 
-    def get_object(self):
+    def get_object(self) -> Submission:
         if not hasattr(self, "_get_object_cache"):
             submission = super().get_object()
 
@@ -708,6 +708,7 @@ class SubmissionStepViewSet(
 
         data = form_data_serializer.validated_data["data"]
         new_configuration = evaluate_form_logic(submission, submission_step, data)
+        assert submission_step.form_step is not None
         submission_step.form_step.form_definition.configuration = new_configuration
 
         submission_state_logic_serializer = SubmissionStateLogicSerializer(

--- a/src/openforms/submissions/exports.py
+++ b/src/openforms/submissions/exports.py
@@ -48,6 +48,9 @@ def create_submission_export(queryset: models.QuerySet[Submission]) -> tablib.Da
 
     .. note:: the queryset of submissions must all be of the same form!
     """
+    from openforms.formio.rendering.nodes import ComponentNode
+    from openforms.variables.rendering.nodes import SubmissionValueVariableNode
+
     # queryset *could* be empty
     if not queryset:
         return tablib.Dataset()
@@ -59,10 +62,13 @@ def create_submission_export(queryset: models.QuerySet[Submission]) -> tablib.Da
         headers.append("Taalcode")
 
     for data_node in iter_submission_data_nodes(first_submission):
-        if hasattr(data_node, "component"):
-            headers.append(data_node.component["key"])
-        elif hasattr(data_node, "variable"):
-            headers.append(data_node.variable.key)
+        match data_node:
+            case ComponentNode():
+                headers.append(data_node.component["key"])
+            case SubmissionValueVariableNode():
+                headers.append(data_node.variable.key)
+            case _:  # pragma: no cover
+                pass
 
     data = tablib.Dataset(headers=headers)
 

--- a/src/openforms/submissions/mapping.py
+++ b/src/openforms/submissions/mapping.py
@@ -89,7 +89,7 @@ def apply_data_mapping[T: MutableMapping[str, Any]](
         target_dict = dict()
 
     # build a lookup, also implicitly de-duplicates assigned attributes
-    attr_key_lookup = dict()
+    attr_key_lookup = {}
 
     for component in submission.form.iter_components(recursive=True):
         key = component.get("key")

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -24,7 +24,7 @@ from opentelemetry import trace
 from openforms.appointments.models import AppointmentInfo
 from openforms.config.models import GlobalConfiguration
 from openforms.formio.service import FormioConfigurationWrapper
-from openforms.forms.models import FormRegistrationBackend, FormStep
+from openforms.forms.models import Form, FormRegistrationBackend, FormStep
 from openforms.logging import audit_logger
 from openforms.payments.constants import PaymentStatus
 from openforms.template import openforms_backend, render_from_string
@@ -51,7 +51,10 @@ if TYPE_CHECKING:
         SubmissionFileAttachmentQuerySet,
     )
     from .submission_report import SubmissionReport
-    from .submission_value_variable import SubmissionValueVariablesState
+    from .submission_value_variable import (
+        SubmissionValueVariable,
+        SubmissionValueVariablesState,
+    )
 
 logger = structlog.stdlib.get_logger(__name__)
 tracer = trace.get_tracer("openforms.submissions.models.submission")
@@ -132,7 +135,7 @@ class Submission(models.Model):
     """
 
     uuid = models.UUIDField(_("UUID"), unique=True, default=uuid.uuid4)
-    form = models.ForeignKey("forms.Form", on_delete=models.PROTECT)
+    form = models.ForeignKey[Form]("forms.Form", on_delete=models.PROTECT)
 
     # meta information
     form_url = models.URLField(
@@ -352,6 +355,8 @@ class Submission(models.Model):
     """
     May raise ``RelatedObjectDoesNotExist`` if no record exists in the database.
     """
+    submissionstep_set: models.Manager[SubmissionStep]
+    submissionvaluevariable_set: models.Manager[SubmissionValueVariable]
 
     class Meta:
         verbose_name = _("submission")
@@ -709,6 +714,7 @@ class Submission(models.Model):
             if isinstance(node, SubmissionStepNode):
                 if current_step != {}:
                     summary_data.append(current_step)
+                assert node.step.form_step is not None
                 current_step = {
                     "slug": node.step.form_step.slug,
                     "name": node.render(),

--- a/src/openforms/submissions/models/submission_step.py
+++ b/src/openforms/submissions/models/submission_step.py
@@ -15,9 +15,8 @@ from openforms.formio.service import FormioData
 from openforms.forms.models import FormDefinition, FormStep
 
 if TYPE_CHECKING:
-    from openforms.submissions.models.submission_files import (
-        SubmissionFileAttachmentManager,
-    )
+    from .submission import Submission  # noqa: F401
+    from .submission_files import SubmissionFileAttachmentManager
 
 
 def _make_frozen(obj):
@@ -100,8 +99,10 @@ class SubmissionStep(models.Model):  # noqa: DJ008
     """
 
     uuid = models.UUIDField(_("UUID"), unique=True, default=uuid.uuid4)
-    submission = models.ForeignKey("submissions.Submission", on_delete=models.CASCADE)
-    form_step = models.ForeignKey(
+    submission = models.ForeignKey["Submission"](
+        "submissions.Submission", on_delete=models.CASCADE
+    )
+    form_step = models.ForeignKey[FormStep](
         "forms.FormStep",
         on_delete=RECORD_HISTORICAL_FORM_STEP,
         null=True,

--- a/src/openforms/submissions/rendering/nodes.py
+++ b/src/openforms/submissions/rendering/nodes.py
@@ -71,6 +71,7 @@ class SubmissionStepNode(Node):
     def render(self) -> str:
         if self.mode == RenderModes.export:
             return ""
+        assert self.step.form_step is not None
         form_definition = self.step.form_step.form_definition
         return form_definition.name
 

--- a/src/openforms/submissions/rendering/renderer.py
+++ b/src/openforms/submissions/rendering/renderer.py
@@ -62,7 +62,7 @@ class Renderer:
         else:
             return True
 
-    def get_children(self) -> Iterator[SubmissionStepNode | VariablesNode]:
+    def get_children(self) -> Iterator[Node]:
         """
         Produce only the direct child nodes.
         """
@@ -75,6 +75,7 @@ class Renderer:
                 # update the configuration for introspection - note that we are mutating
                 # an instance here without persisting it to the backend on purpose!
                 # this replicates the run-time behaviour while filling out the form
+                assert step.form_step is not None
                 step.form_step.form_definition.configuration = new_configuration
 
             submission_step_node = SubmissionStepNode(renderer=self, step=step)

--- a/src/openforms/submissions/tests/test_submission_completion.py
+++ b/src/openforms/submissions/tests/test_submission_completion.py
@@ -223,6 +223,9 @@ class SubmissionCompletionTests(SubmissionsMixin, APITestCase):
         """
         Test that non-applicable form steps are not processed during validation of
         submission completion.
+
+        FIXME: this test violates the invariant that forms must have unique component
+        IDs...
         """
         form = FormFactory.create()
         step_1 = FormStepFactory.create(

--- a/src/openforms/submissions/tests/test_tasks_confirmation_emails.py
+++ b/src/openforms/submissions/tests/test_tasks_confirmation_emails.py
@@ -346,7 +346,9 @@ class ConfirmationEmailTests(HTMLAssertMixin, TestCase):
             completed=True,
             components_list=[
                 {
+                    "type": "email",
                     "key": "email",
+                    "label": "Email",
                     "confirmationRecipient": True,
                 },
             ],
@@ -373,7 +375,9 @@ class ConfirmationEmailTests(HTMLAssertMixin, TestCase):
             completed=True,
             components_list=[
                 {
+                    "type": "email",
                     "key": "email",
+                    "label": "Email",
                     "confirmationRecipient": True,
                 },
             ],
@@ -402,7 +406,9 @@ class ConfirmationEmailTests(HTMLAssertMixin, TestCase):
             completed=True,
             components_list=[
                 {
+                    "type": "email",
                     "key": "email",
+                    "label": "Email",
                     "confirmationRecipient": True,
                 },
             ],
@@ -433,7 +439,9 @@ class ConfirmationEmailTests(HTMLAssertMixin, TestCase):
             completed=True,
             components_list=[
                 {
+                    "type": "email",
                     "key": "email",
+                    "label": "Email",
                     "confirmationRecipient": True,
                 },
             ],
@@ -468,7 +476,9 @@ class ConfirmationEmailTests(HTMLAssertMixin, TestCase):
             completed=True,
             components_list=[
                 {
+                    "type": "email",
                     "key": "email",
+                    "label": "Email",
                     "confirmationRecipient": True,
                 },
             ],
@@ -500,7 +510,9 @@ class ConfirmationEmailTests(HTMLAssertMixin, TestCase):
             completed=True,
             components_list=[
                 {
+                    "type": "email",
                     "key": "email",
+                    "label": "Email",
                     "confirmationRecipient": True,
                 },
             ],
@@ -524,7 +536,9 @@ class ConfirmationEmailTests(HTMLAssertMixin, TestCase):
             completed=True,
             components_list=[
                 {
+                    "type": "email",
                     "key": "email",
+                    "label": "Email",
                     "confirmationRecipient": True,
                 },
             ],
@@ -714,7 +728,9 @@ class ConfirmationEmailTests(HTMLAssertMixin, TestCase):
             completed=True,
             components_list=[
                 {
+                    "type": "email",
                     "key": "email",
+                    "label": "Email",
                     "confirmationRecipient": True,
                 },
             ],


### PR DESCRIPTION
Taken from the (strict) msgspec experiment branch.

* Ensure that (most) formio component definitions comply with the (TS) type definitions
* Address some Ruff (new version) linter warnings
* Improve type annotations left and right

[skip: e2e]

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
