### PR TITLE
Sticky components list position

### DIFF
--- a/src/openforms/scss/components/builder/_builder.scss
+++ b/src/openforms/scss/components/builder/_builder.scss
@@ -63,6 +63,10 @@ body:has(.offb-modal) {
   }
 }
 
+.offb-components-list {
+  top: 100px;
+}
+
 .offb-dnd-sortable-item {
   label {
     cursor: move;


### PR DESCRIPTION
Partly closes open-formulieren/formio-builder#337

**Changes**

The `position: sticky;` of the offb-components-list component will place the components list behind the admin navbar. With `top: 100px;` we can make sure the components list will be presented below the navbar.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
