### PR TITLE
Fixed some documentation links

### DIFF
--- a/docs/developers/ui-components.rst
+++ b/docs/developers/ui-components.rst
@@ -84,7 +84,8 @@ when writing HTML.
 Block-Element-Modifier (BEM)
 ----------------------------
 
-`BEM <https://getbem.com/>`_ is a methodology for reusable components.
+`BEM <https://github.com/getbem/getbem.github.io/blob/master/src/pages/introduction.mdx/>`_
+is a methodology for reusable components.
 
 **Blocks**
 

--- a/docs/introduction/open-source/index.rst
+++ b/docs/introduction/open-source/index.rst
@@ -5,7 +5,7 @@ Open-source
 
 The Open Forms project is open-source and available under the `EUPL license`_.
 
-In addition, this project makes use of various open-source `Python libraries`_ 
+In addition, this project makes use of various open-source `Python libraries`_
 and `npm packages`_ and `npm packages for the SDK` under the hood.
 
 Sustainable Management
@@ -24,5 +24,5 @@ Read more about the management organization, contributions, and responsibilities
 .. _`Python libraries`: https://github.com/open-formulieren/open-forms/blob/main/requirements/base.txt
 .. _`npm packages`: https://github.com/open-formulieren/open-forms/blob/main/package.json
 .. _`npm packages for the SDK`: https://github.com/open-formulieren/open-forms-sdk/blob/main/package.json
-.. _`Stakeholders`: https://github.com/open-formulieren/open-forms-sdk/blob/main/STAKEHOLDERS.md
-.. _`PROJECT_GOVERNANCE.md`: https://github.com/open-formulieren/open-forms-sdk/blob/main/PROJECT_GOVERNANCE.md
+.. _`Stakeholders`: https://github.com/open-formulieren/open-forms/blob/main/STAKEHOLDERS.md
+.. _`PROJECT_GOVERNANCE.md`: https://github.com/open-formulieren/open-forms/blob/main/PROJECT_GOVERNANCE.md


### PR DESCRIPTION
Closes #6611

**Changes**

A couple documentation links pointed to non-existing sources, or sources that are no-longer available. These failing links have been fixed.

getbem.com is not reachable, so i've updated that developers documentation link to the getbem github repo.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
