### PR TITLE
Update for reworked monaco-json-editor package structure

### DIFF
--- a/src/openforms/js/components/JSONEditor.js
+++ b/src/openforms/js/components/JSONEditor.js
@@ -1,0 +1,11 @@
+import {Suspense, lazy} from 'react';
+
+const LazyJSONEditor = lazy(() => import('./LazyJSONEditor'));
+
+const JSONEditor = props => (
+  <Suspense fallback="Loading editor...">
+    <LazyJSONEditor {...props} />
+  </Suspense>
+);
+
+export default JSONEditor;

--- a/src/openforms/js/components/LazyJSONEditor.js
+++ b/src/openforms/js/components/LazyJSONEditor.js
@@ -1,0 +1,7 @@
+// just a wrapper for React.lazy which requires a default export
+//
+// DO NOT IMPORT THIS MODULE DIRECTLY
+//
+import {JSONEditor} from '@open-formulieren/monaco-json-editor';
+
+export default JSONEditor;

--- a/src/openforms/js/components/admin/form_design/logic/DataPreview.js
+++ b/src/openforms/js/components/admin/form_design/logic/DataPreview.js
@@ -1,8 +1,8 @@
-import {JSONEditor} from '@open-formulieren/monaco-json-editor';
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import {useState} from 'react';
 import {useGlobalState} from 'state-pool';
 
+import JSONEditor from 'components/JSONEditor';
 import {currentTheme} from 'utils/theme';
 
 const DataPreview = ({data, maxRows = 20}) => {

--- a/src/openforms/js/components/admin/forms/JsonWidget.js
+++ b/src/openforms/js/components/admin/forms/JsonWidget.js
@@ -1,4 +1,3 @@
-import {JSONEditor} from '@open-formulieren/monaco-json-editor';
 import classNames from 'classnames';
 import jsonLogic from 'json-logic-js';
 import {isEqual} from 'lodash';
@@ -7,6 +6,7 @@ import {useEffect, useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {useGlobalState} from 'state-pool';
 
+import JSONEditor from 'components/JSONEditor';
 import jsonPropTypeValidator from 'utils/JsonPropTypeValidator';
 import {currentTheme} from 'utils/theme';
 

--- a/src/openforms/js/components/admin/forms/ModalJsonSchemaGeneration.js
+++ b/src/openforms/js/components/admin/forms/ModalJsonSchemaGeneration.js
@@ -1,9 +1,9 @@
-import {JSONEditor} from '@open-formulieren/monaco-json-editor';
 import PropTypes from 'prop-types';
-import {React, useContext, useState} from 'react';
+import {useContext, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useGlobalState} from 'state-pool';
 
+import JSONEditor from 'components/JSONEditor';
 import {FormContext} from 'components/admin/form_design/Context';
 import {FORM_ENDPOINT} from 'components/admin/form_design/constants';
 import Modal from 'components/admin/modals/Modal';

--- a/src/openforms/scss/_vendor.scss
+++ b/src/openforms/scss/_vendor.scss
@@ -1,3 +1,6 @@
+// TODO: modular CSS (only loading leaflet, monaco... styles when relevant) would reduce
+// CSS bundle size
+
 @use 'leaflet/dist/leaflet';
 @use 'ckeditor5/ckeditor5';
 @use 'flatpickr/dist/flatpickr';
@@ -7,3 +10,5 @@
 @use './vendor/django-two-factor-auth';
 @use './vendor/design-token-editor';
 @use './vendor/react-select';
+
+@import '@open-formulieren/monaco-json-editor/style.css';


### PR DESCRIPTION
It now bundles the editor entirely rather than loading everything from a CDN, which gives more control but also shifts some responsabilities in terms of CSS inclusion and lazy loading.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Checked new model fields are usable in the admin
  - [ ] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [ ] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how

- Documentation

  - [ ] Added documentation which describes the changes
