### PR TITLE
Fix upgrade checks trying to load fields that do not exist yet

### DIFF
--- a/bin/report_invalid_form_logic.py
+++ b/bin/report_invalid_form_logic.py
@@ -10,6 +10,12 @@ from tabulate import tabulate
 
 SRC_DIR = Path(__file__).parent.parent / "src"
 sys.path.insert(0, str(SRC_DIR.resolve()))
+FIELDS_TO_DEFER = (
+    "type",
+    "help_callout_page_display",
+    "help_dialog_content",
+    "help_dialog_image",
+)
 
 type Row = tuple[int, str]
 
@@ -27,10 +33,14 @@ def report_invalid_forms() -> bool:
     invalid_rules_detected = False
 
     # check invalid existing forms that are perhaps migrated on the shell
-    forms = Form.objects.filter(
-        new_logic_evaluation_enabled=True,
-        formlogic__trigger_from_step__isnull=False,
-    ).distinct()
+    forms = (
+        Form.objects.filter(
+            new_logic_evaluation_enabled=True,
+            formlogic__trigger_from_step__isnull=False,
+        )
+        .defer(*FIELDS_TO_DEFER)
+        .distinct()
+    )
     if forms.exists():
         invalid_rules_detected = True
         print(
@@ -45,11 +55,15 @@ def report_invalid_forms() -> bool:
         )
 
     # check if any forms still have new logic evaluation disabled
-    forms_to_check = Form.objects.filter(
-        _is_deleted=False,
-        new_logic_evaluation_enabled=False,
-        formlogic__isnull=False,
-    ).distinct()
+    forms_to_check = (
+        Form.objects.filter(
+            _is_deleted=False,
+            new_logic_evaluation_enabled=False,
+            formlogic__isnull=False,
+        )
+        .defer(*FIELDS_TO_DEFER)
+        .distinct()
+    )
 
     non_converted_forms_detected = False
     if forms_to_check.exists():

--- a/src/openforms/zgw_urls_migrator.py
+++ b/src/openforms/zgw_urls_migrator.py
@@ -20,6 +20,13 @@ from openforms.contrib.objects_api.models import ObjectsAPIGroupConfig
 from openforms.formio.typing import FileComponent
 from openforms.forms.models import Form, FormDefinition, FormRegistrationBackend
 
+FIELDS_TO_DEFER = (
+    "type",
+    "help_callout_page_display",
+    "help_dialog_content",
+    "help_dialog_image",
+)
+
 
 @dataclass
 class ComponentProblem:
@@ -157,7 +164,7 @@ class FormioConfigurationMigrator:
 
     def __init__(self, outfile: TextIOBase):
         self.outfile = outfile
-        self.forms_queryset = Form.objects.all()
+        self.forms_queryset = Form.objects.defer(*FIELDS_TO_DEFER).all()
 
     def _iter_form_defs(self, form: Form) -> Iterator[tuple[FormDefinition, str]]:
         for form_definition in FormDefinition.objects.filter(formstep__form=form):
@@ -266,6 +273,7 @@ class RegistrationBackendMigrator:
                     ),
                 )
             )
+            .defer(*FIELDS_TO_DEFER)
             .distinct()
         )
         self.objects_api_groups_queryset = ObjectsAPIGroupConfig.objects.exclude(


### PR DESCRIPTION
Discovered during the test upgrade. These fields only exist in 4.0 after running the migrations. The upgrade checks are executed before it, though, so we need to be make sure to not try to load them from the database.

Note: merges into stable 4.0.x

**Changes**

Added a `defer` with relevant fields to the upgrade checks

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
