### PR TITLE
[#6626] Pin Open Klant Client to v0.8.0

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -379,7 +379,7 @@ oauthlib==3.3.1
     # via requests-oauthlib
 onlinepayments-sdk-python3==7.1.0
     # via -r requirements/base.in
-open-klant-client==0.4.0
+open-klant-client==0.8.0
     # via -r requirements/base.in
 openpyxl==3.1.5
     # via tablib

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -660,7 +660,7 @@ onlinepayments-sdk-python3==7.1.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt
-open-klant-client==0.4.0
+open-klant-client==0.8.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -721,7 +721,7 @@ onlinepayments-sdk-python3==7.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-open-klant-client==0.4.0
+open-klant-client==0.8.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt

--- a/requirements/extensions.txt
+++ b/requirements/extensions.txt
@@ -622,7 +622,7 @@ open-forms-ext-haalcentraal-hr==0.3.1
     # via -r requirements/extensions.in
 open-forms-ext-token-exchange==0.5.0
     # via -r requirements/extensions.in
-open-klant-client==0.4.0
+open-klant-client==0.8.0
     # via
     #   -c requirements/base.txt
     #   -r requirements/base.txt

--- a/requirements/type-checking.txt
+++ b/requirements/type-checking.txt
@@ -707,7 +707,7 @@ onlinepayments-sdk-python3==7.1.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt
-open-klant-client==0.4.0
+open-klant-client==0.8.0
     # via
     #   -c requirements/ci.txt
     #   -r requirements/ci.txt


### PR DESCRIPTION
Closes #6626 partly

**Changes**

- Upgrade Open Klant Client to v0.8.0 (support for `verificatieDatum`).

Single PR for this upgrade since we are going to gradually/smoothly backport everything needed.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
