### PR TITLE
[#6622] apply email verification validation to customerProfile component

### DIFF
--- a/src/openforms/formio/components/custom.py
+++ b/src/openforms/formio/components/custom.py
@@ -33,6 +33,7 @@ from openforms.contrib.customer_interactions.update import (
     update_customer_interaction_data,
 )
 from openforms.formio.typing.map import Overlay
+from openforms.formio.validators import EmailVerificationValidator
 from openforms.forms.models import FormVariable
 from openforms.prefill.contrib.family_members.plugin import (
     PLUGIN_IDENTIFIER as FM_PLUGIN_IDENTIFIER,
@@ -1304,6 +1305,9 @@ class CustomerProfile(BasePlugin[CustomerProfileComponent]):
             digital_address_types=component["digitalAddressTypes"],
             required=required,
             allow_null=not required,
+            validators=[
+                EmailVerificationValidator(component["key"], "customerProfile")
+            ],
         )
 
     @staticmethod

--- a/src/openforms/formio/components/vanilla.py
+++ b/src/openforms/formio/components/vanilla.py
@@ -30,9 +30,9 @@ from rest_framework.utils.formatting import lazy_format
 from csp_post_processor import post_process_html
 from openforms.config.constants import UploadFileType
 from openforms.config.models import GlobalConfiguration
+from openforms.formio.validators import EmailVerificationValidator
 from openforms.submissions.attachments import temporary_upload_from_url
 from openforms.submissions.form_logic import process_visibility
-from openforms.submissions.models import EmailVerification
 from openforms.typing import JSONObject, JSONValue
 from openforms.utils.json_schema import to_multiple
 from openforms.utils.urls import build_absolute_uri
@@ -167,27 +167,6 @@ class TextField(BasePlugin[TextFieldComponent]):
         return to_multiple(base) if multiple else base
 
 
-class EmailVerificationValidator:
-    message = _("The email address {value} has not been verified yet.")
-    requires_context = True
-
-    def __init__(self, component_key: str):
-        self.component_key = component_key
-
-    def __call__(self, value: str, field: serializers.Field) -> None:
-        submission: Submission = field.context["submission"]
-        has_verification = EmailVerification.objects.filter(
-            submission=submission,
-            component_key=self.component_key,
-            email=value,
-            verified_on__isnull=False,
-        ).exists()
-        if not has_verification:
-            raise serializers.ValidationError(
-                self.message.format(value=value), code="unverified"
-            )
-
-
 @register("email")
 class Email(BasePlugin):
     formatter = EmailFormatter
@@ -213,7 +192,7 @@ class Email(BasePlugin):
             validators.append(PluginValidator(plugin_ids))
 
         if verification_required:
-            validators.append(EmailVerificationValidator(component["key"]))
+            validators.append(EmailVerificationValidator(component["key"], "email"))
 
         if validators:
             extra["validators"] = validators

--- a/src/openforms/formio/tests/validation/test_profile.py
+++ b/src/openforms/formio/tests/validation/test_profile.py
@@ -1,7 +1,10 @@
 from django.test import TestCase, tag
 from django.utils.translation import gettext_lazy as _
 
-from openforms.submissions.tests.factories import SubmissionFactory
+from openforms.submissions.tests.factories import (
+    EmailVerificationFactory,
+    SubmissionFactory,
+)
 
 from ...typing.custom import CustomerProfileComponent
 from .helpers import extract_error, validate_formio_data
@@ -24,6 +27,12 @@ class ProfileValidationTests(TestCase):
         submission = SubmissionFactory.create(
             form__generate_minimal_setup=True,
             form__formstep__form_definition__configuration={"components": [component]},
+        )
+        EmailVerificationFactory.create(
+            submission=submission,
+            component_key="profile",
+            email="john@smith.org",
+            verified=True,
         )
         valid_values = {
             "profile": [
@@ -54,6 +63,9 @@ class ProfileValidationTests(TestCase):
         submission = SubmissionFactory.create(
             form__generate_minimal_setup=True,
             form__formstep__form_definition__configuration={"components": [component]},
+        )
+        EmailVerificationFactory.create(
+            submission=submission, component_key="profile", email="", verified=True
         )
         valid_values = {
             "profile": [
@@ -141,6 +153,12 @@ class ProfileValidationTests(TestCase):
                 ]
             },
         )
+        EmailVerificationFactory.create(
+            submission=submission,
+            component_key="profile",
+            email="some-incorrect-email",
+            verified=True,
+        )
         values = {
             "profile": [
                 {
@@ -203,6 +221,18 @@ class ProfileValidationTests(TestCase):
                     component,
                 ]
             },
+        )
+        EmailVerificationFactory.create(
+            submission=submission,
+            component_key="profile",
+            email="john@smith.org",
+            verified=True,
+        )
+        EmailVerificationFactory.create(
+            submission=submission,
+            component_key="profile",
+            email="another@email.org",
+            verified=True,
         )
         values = {
             "profile": [

--- a/src/openforms/formio/validators.py
+++ b/src/openforms/formio/validators.py
@@ -3,6 +3,11 @@ from django.core.validators import RegexValidator
 from django.utils.regex_helper import _lazy_re_compile
 from django.utils.translation import gettext_lazy as _
 
+from rest_framework import serializers
+
+from openforms.formio.typing.custom import DigitalAddress
+from openforms.submissions.typing import EmailVerificationComponentType
+
 # Regex and message adapted from
 # https://github.com/formio/formio.js/blob/4.13.x/src/components/_classes/component/editForm/Component.edit.api.js#L10
 variable_key_validator = RegexValidator(
@@ -41,3 +46,44 @@ def validate_formio_js_schema(value: dict):
             _("The 'components' value must be a list of components."),
             code="invalid",
         )
+
+
+class EmailVerificationValidator:
+    message = _("The email address {value} has not been verified yet.")
+    requires_context = True
+
+    component_key: str
+    component_type: EmailVerificationComponentType
+
+    def __init__(
+        self, component_key: str, component_type: EmailVerificationComponentType
+    ) -> None:
+        self.component_key = component_key
+        self.component_type = component_type
+
+    def __call__(self, value: str | DigitalAddress, field: serializers.Field) -> None:
+        from openforms.submissions.models import EmailVerification, Submission
+
+        address: str
+        error_format: str | dict[str, list[str]]
+        if self.component_type == "customerProfile":
+            assert isinstance(value, dict)
+            if value.get("type", "") == "phoneNumber":
+                return
+            address = value.get("address") or ""
+            error_format = {"address": [self.message.format(value=address)]}
+        else:
+            assert isinstance(value, str)
+            address = value
+            error_format = self.message.format(value=address)
+
+        submission: Submission = field.context["submission"]
+        has_verification = EmailVerification.objects.filter(
+            submission=submission,
+            component_key=self.component_key,
+            email=address,
+            verified_on__isnull=False,
+        ).exists()
+
+        if not has_verification:
+            raise serializers.ValidationError(error_format, code="unverified")

--- a/src/openforms/submissions/models/submission.py
+++ b/src/openforms/submissions/models/submission.py
@@ -40,8 +40,8 @@ from ..cosigning import CosignData, CosignState
 from ..pricing import get_submission_price
 from ..query import SubmissionQuerySet, SubmissionsManagerType
 from ..serializers import CoSignDataSerializer
+from ..typing import SubmissionCosignData
 from .submission_step import SubmissionStep
-from .typing import SubmissionCosignData
 
 if TYPE_CHECKING:
     from openforms.authentication.models import AuthInfo, RegistratorInfo

--- a/src/openforms/submissions/tests/factories.py
+++ b/src/openforms/submissions/tests/factories.py
@@ -464,7 +464,6 @@ class PostCompletionMetadataFactory(factory.django.DjangoModelFactory):
 
 class EmailVerificationFactory(factory.django.DjangoModelFactory):
     submission = factory.SubFactory(SubmissionFactory)
-    component_key = "email"
     email = factory.Faker("email")
 
     class Meta:

--- a/src/openforms/submissions/typing.py
+++ b/src/openforms/submissions/typing.py
@@ -14,3 +14,6 @@ class SubmissionCosignData(TypedDict):
     attribute: AuthAttribute
     value: str
     cosign_date: datetime
+
+
+type EmailVerificationComponentType = Literal["email", "customerProfile"]


### PR DESCRIPTION
Is required for the back-end part of https://github.com/open-formulieren/open-forms/issues/6622

**Changes**

Adds back-end validation for email verification for the customer profile component.

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [ ] Checked copying a form
  - [ ] Checked import/export of a form
  - [ ] Config checks in the configuration overview admin page
  - [ ] Checked new model fields are usable in the admin
  - [ ] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [ ] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [ ] Commit messages refer to the relevant Github issue
  - [ ] Commit messages explain the "why" of change, not the how

- Documentation

  - [ ] Added documentation which describes the changes
