### PR TITLE
Upgrade monaco-json-editor

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@open-formulieren/design-tokens": "^1.2.0",
         "@open-formulieren/formio-builder": "^1.5.0",
         "@open-formulieren/formio-renderer": "^2.0.2",
-        "@open-formulieren/monaco-json-editor": "^0.2.0",
+        "@open-formulieren/monaco-json-editor": "^0.3.0",
         "@tinymce/tinymce-react": "^4.3.2",
         "@trivago/prettier-plugin-sort-imports": "^4.0.0",
         "babel-jest": "^29.3.1",
@@ -5246,27 +5246,26 @@
       }
     },
     "node_modules/@monaco-editor/loader": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
-      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
       "dependencies": {
         "state-local": "^1.0.6"
-      },
-      "peerDependencies": {
-        "monaco-editor": ">= 0.21.0 < 1"
       }
     },
     "node_modules/@monaco-editor/react": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
-      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
       "dependencies": {
-        "@monaco-editor/loader": "^1.4.0"
+        "@monaco-editor/loader": "^1.5.0"
       },
       "peerDependencies": {
         "monaco-editor": ">= 0.25.0 < 1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@mswjs/interceptors": {
@@ -5377,6 +5376,18 @@
         "leaflet-gesture-handling": "^1.2.2",
         "react": "^18.0.0",
         "react-tabs": "^6.1.1"
+      }
+    },
+    "node_modules/@open-formulieren/formio-builder/node_modules/@open-formulieren/monaco-json-editor": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/monaco-json-editor/-/monaco-json-editor-0.2.0.tgz",
+      "integrity": "sha512-XFc8O9g4nlswMm4HlDc4xFr0u2rN9wBKsIOwb5dsjMWHuaNkYiDotcB8g+Z1OqYN+e1QyC0z9gnBWW9cFUUQag==",
+      "license": "MIT",
+      "dependencies": {
+        "@monaco-editor/react": "^4.6.0"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0"
       }
     },
     "node_modules/@open-formulieren/formio-builder/node_modules/clsx": {
@@ -5501,14 +5512,16 @@
       }
     },
     "node_modules/@open-formulieren/monaco-json-editor": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/monaco-json-editor/-/monaco-json-editor-0.2.0.tgz",
-      "integrity": "sha512-XFc8O9g4nlswMm4HlDc4xFr0u2rN9wBKsIOwb5dsjMWHuaNkYiDotcB8g+Z1OqYN+e1QyC0z9gnBWW9cFUUQag==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/monaco-json-editor/-/monaco-json-editor-0.3.0.tgz",
+      "integrity": "sha512-HDW6aU/MIxLO9BJrZnBdV1wwaLjJvOp9VevU5tdM+ilPHqqW946nR+LlUen9U8Ni3xiyLsEmBFo6y8IBeIKi4g==",
+      "license": "MIT",
       "dependencies": {
-        "@monaco-editor/react": "^4.6.0"
+        "@monaco-editor/react": "^4.7.0",
+        "monaco-editor": "^0.56.0"
       },
       "peerDependencies": {
-        "react": "^18.0.0"
+        "react": "^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@open-formulieren/types": {
@@ -16821,7 +16834,6 @@
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
       "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -17818,7 +17830,6 @@
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
       "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "dompurify": "3.4.8",
         "marked": "14.0.0"
@@ -17829,7 +17840,6 @@
       "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
       "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
       "license": "(MPL-2.0 OR Apache-2.0)",
-      "peer": true,
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
       }
@@ -20807,7 +20817,8 @@
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
-      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/state-pool": {
       "version": "0.7.1",
@@ -26697,19 +26708,19 @@
       }
     },
     "@monaco-editor/loader": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
-      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
       "requires": {
         "state-local": "^1.0.6"
       }
     },
     "@monaco-editor/react": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
-      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
       "requires": {
-        "@monaco-editor/loader": "^1.4.0"
+        "@monaco-editor/loader": "^1.5.0"
       }
     },
     "@mswjs/interceptors": {
@@ -26801,6 +26812,14 @@
         "zod-formik-adapter": "^1.2.0"
       },
       "dependencies": {
+        "@open-formulieren/monaco-json-editor": {
+          "version": "0.2.0",
+          "resolved": "https://registry.npmjs.org/@open-formulieren/monaco-json-editor/-/monaco-json-editor-0.2.0.tgz",
+          "integrity": "sha512-XFc8O9g4nlswMm4HlDc4xFr0u2rN9wBKsIOwb5dsjMWHuaNkYiDotcB8g+Z1OqYN+e1QyC0z9gnBWW9cFUUQag==",
+          "requires": {
+            "@monaco-editor/react": "^4.6.0"
+          }
+        },
         "clsx": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
@@ -26859,11 +26878,12 @@
       }
     },
     "@open-formulieren/monaco-json-editor": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@open-formulieren/monaco-json-editor/-/monaco-json-editor-0.2.0.tgz",
-      "integrity": "sha512-XFc8O9g4nlswMm4HlDc4xFr0u2rN9wBKsIOwb5dsjMWHuaNkYiDotcB8g+Z1OqYN+e1QyC0z9gnBWW9cFUUQag==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@open-formulieren/monaco-json-editor/-/monaco-json-editor-0.3.0.tgz",
+      "integrity": "sha512-HDW6aU/MIxLO9BJrZnBdV1wwaLjJvOp9VevU5tdM+ilPHqqW946nR+LlUen9U8Ni3xiyLsEmBFo6y8IBeIKi4g==",
       "requires": {
-        "@monaco-editor/react": "^4.6.0"
+        "@monaco-editor/react": "^4.7.0",
+        "monaco-editor": "^0.56.0"
       }
     },
     "@open-formulieren/types": {
@@ -34798,8 +34818,7 @@
     "marked": {
       "version": "14.0.0",
       "resolved": "https://registry.npmjs.org/marked/-/marked-14.0.0.tgz",
-      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==",
-      "peer": true
+      "integrity": "sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ=="
     },
     "math-intrinsics": {
       "version": "1.1.0",
@@ -35397,7 +35416,6 @@
       "version": "0.56.0",
       "resolved": "https://registry.npmjs.org/monaco-editor/-/monaco-editor-0.56.0.tgz",
       "integrity": "sha512-sXboRm3BeBeLm938eaiyLMe0OxzfXIlZvbv4ir/jVgQy1zDhWjgmny0WoN45fuDKhCCQsYMbBJrv/A6jd8aCUg==",
-      "peer": true,
       "requires": {
         "dompurify": "3.4.8",
         "marked": "14.0.0"
@@ -35407,7 +35425,6 @@
           "version": "3.4.8",
           "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.8.tgz",
           "integrity": "sha512-yb1cEmaOum7wFvOCSQxyfgVlv5D47Rc30iZWoMpbDIWTnJ6grDDQyu2KFJzB2k7u0pMuJcQ1zphH//fFnw2tjQ==",
-          "peer": true,
           "requires": {
             "@types/trusted-types": "^2.0.7"
           }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@open-formulieren/design-tokens": "^1.2.0",
     "@open-formulieren/formio-builder": "^1.5.0",
     "@open-formulieren/formio-renderer": "^2.0.2",
-    "@open-formulieren/monaco-json-editor": "^0.2.0",
+    "@open-formulieren/monaco-json-editor": "^0.3.0",
     "@tinymce/tinymce-react": "^4.3.2",
     "@trivago/prettier-plugin-sort-imports": "^4.0.0",
     "babel-jest": "^29.3.1",

--- a/src/openforms/js/components/JSONEditor.js
+++ b/src/openforms/js/components/JSONEditor.js
@@ -1,0 +1,14 @@
+import {Suspense, lazy} from 'react';
+
+const LazyJSONEditor = lazy(async () => {
+  const monacoJsonEditor = await import('@open-formulieren/monaco-json-editor');
+  return {default: monacoJsonEditor.JSONEditor};
+});
+
+const JSONEditor = props => (
+  <Suspense fallback="Loading editor...">
+    <LazyJSONEditor {...props} />
+  </Suspense>
+);
+
+export default JSONEditor;

--- a/src/openforms/js/components/admin/form_design/logic/DataPreview.js
+++ b/src/openforms/js/components/admin/form_design/logic/DataPreview.js
@@ -1,8 +1,8 @@
-import {JSONEditor} from '@open-formulieren/monaco-json-editor';
 import PropTypes from 'prop-types';
-import React, {useState} from 'react';
+import {useState} from 'react';
 import {useGlobalState} from 'state-pool';
 
+import JSONEditor from 'components/JSONEditor';
 import {currentTheme} from 'utils/theme';
 
 const DataPreview = ({data, maxRows = 20}) => {

--- a/src/openforms/js/components/admin/forms/JsonWidget.js
+++ b/src/openforms/js/components/admin/forms/JsonWidget.js
@@ -1,4 +1,3 @@
-import {JSONEditor} from '@open-formulieren/monaco-json-editor';
 import classNames from 'classnames';
 import jsonLogic from 'json-logic-js';
 import {isEqual} from 'lodash';
@@ -7,6 +6,7 @@ import {useEffect, useRef, useState} from 'react';
 import {useIntl} from 'react-intl';
 import {useGlobalState} from 'state-pool';
 
+import JSONEditor from 'components/JSONEditor';
 import jsonPropTypeValidator from 'utils/JsonPropTypeValidator';
 import {currentTheme} from 'utils/theme';
 

--- a/src/openforms/js/components/admin/forms/ModalJsonSchemaGeneration.js
+++ b/src/openforms/js/components/admin/forms/ModalJsonSchemaGeneration.js
@@ -1,9 +1,9 @@
-import {JSONEditor} from '@open-formulieren/monaco-json-editor';
 import PropTypes from 'prop-types';
-import {React, useContext, useState} from 'react';
+import {useContext, useState} from 'react';
 import {FormattedMessage} from 'react-intl';
 import {useGlobalState} from 'state-pool';
 
+import JSONEditor from 'components/JSONEditor';
 import {FormContext} from 'components/admin/form_design/Context';
 import {FORM_ENDPOINT} from 'components/admin/form_design/constants';
 import Modal from 'components/admin/modals/Modal';

--- a/src/openforms/scss/_vendor.scss
+++ b/src/openforms/scss/_vendor.scss
@@ -1,3 +1,6 @@
+// TODO: modular CSS (only loading leaflet, monaco... styles when relevant) would reduce
+// CSS bundle size
+
 @use 'leaflet/dist/leaflet';
 @use 'ckeditor5/ckeditor5';
 @use 'flatpickr/dist/flatpickr';
@@ -7,3 +10,5 @@
 @use './vendor/django-two-factor-auth';
 @use './vendor/design-token-editor';
 @use './vendor/react-select';
+
+@import '@open-formulieren/monaco-json-editor/style.css';


### PR DESCRIPTION
**Changes**

* Upgraded to our monaco-json-editor 0.3.0, which bundles monaco-editor directly and removes our dependency on a CDN
* Added lazy loading/bundle splitting, as it's quite a hefty chunk of code to load while it's not immediately needed
* Prepares for React 19 compatibility

**Checklist**

Check off the items that are completed or not relevant.

- Impact on features

  - [x] Checked copying a form
  - [x] Checked import/export of a form
  - [x] Config checks in the configuration overview admin page
  - [x] Checked new model fields are usable in the admin
  - [x] Problem detection in the admin email digest is handled

- Dockerfile/scripts

  - [x] Updated the Dockerfile with the necessary scripts from the `./bin` folder

- Commit hygiene

  - [x] Commit messages refer to the relevant Github issue
  - [x] Commit messages explain the "why" of change, not the how

- Documentation

  - [x] Added documentation which describes the changes
